### PR TITLE
no cache write on disk

### DIFF
--- a/youtube_service.py
+++ b/youtube_service.py
@@ -38,10 +38,17 @@ class YoutubePlaylistService:
         """
         default_opts = {
             "quiet": True,
+            "nocheckcertificate": True,
             # "extract_flat": True,
-            "extract_flat":
-            "in_playlist",  # allows lightweight fetch with URLs
+            # allows lightweight fetch with URLs
+            "extract_flat": "in_playlist",
+            # 🚀 prevent yt-dlp from writing to ~/.cache
+            "cachedir": False,
             #"force_generic_extractor": True
+            "skip_download": True,
+            "ignoreerrors": True,
+            "dump_single_json": True,
+            "no_warnings": True,
         }
         self.ydl_opts = ydl_opts or default_opts
         self.ydl = yt_dlp.YoutubeDL(self.ydl_opts)


### PR DESCRIPTION
@sourcery-ai

## Summary by Sourcery

Update default YoutubeDL options to disable disk caching and optimize lightweight metadata extraction

Enhancements:
- Disable disk cache by setting 'cachedir' to False
- Add 'nocheckcertificate', 'skip_download', 'ignoreerrors', 'dump_single_json', and 'no_warnings' options to the default yt-dlp configuration
- Retain and reformat 'extract_flat' option for lightweight playlist metadata fetching