### PR TITLE
bug fix

### DIFF
--- a/youtube_service.py
+++ b/youtube_service.py
@@ -45,7 +45,7 @@ class YoutubePlaylistService:
             # 🚀 prevent yt-dlp from writing to ~/.cache
             "cachedir": False,
             #"force_generic_extractor": True
-            #"skip_download": True,
+            "skip_download": True,
             #"ignoreerrors": True,
             #"dump_single_json": True,
             #"no_warnings": True,

--- a/youtube_service.py
+++ b/youtube_service.py
@@ -45,10 +45,10 @@ class YoutubePlaylistService:
             # 🚀 prevent yt-dlp from writing to ~/.cache
             "cachedir": False,
             #"force_generic_extractor": True
-            "skip_download": True,
-            "ignoreerrors": True,
-            "dump_single_json": True,
-            "no_warnings": True,
+            #"skip_download": True,
+            #"ignoreerrors": True,
+            #"dump_single_json": True,
+            #"no_warnings": True,
         }
         self.ydl_opts = ydl_opts or default_opts
         self.ydl = yt_dlp.YoutubeDL(self.ydl_opts)


### PR DESCRIPTION
## Summary by Sourcery

Disable skip_download, ignoreerrors, dump_single_json, and no_warnings defaults in YoutubeService to restore proper download and error handling behavior

Bug Fixes:
- Remove default skip_download flag to allow actual media downloads
- Disable ignoreerrors, dump_single_json, and no_warnings options to re-enable error reporting and default output