### PR TITLE
Decode the base64 at runtime

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -7,14 +7,16 @@ services:
     buildCommand: |
       pip install --upgrade pip
       pip install --no-cache-dir -r requirements-backend.txt
+    startCommand: |
       # decode cookies into /tmp
       echo $YOUTUBE_COOKIES | base64 -d > /tmp/cookies.txt
-    startCommand: |
       python -m worker.worker
     envVars:
       - key: SUPABASE_URL
         sync: false
       - key: SUPABASE_KEY
+        sync: false
+      - key: YOUTUBE_COOKIES
         sync: false
       - key: WORKER_POLL_INTERVAL
         value: 10


### PR DESCRIPTION
@sourcery-ai

## Summary by Sourcery

Update render.yaml to decode base64-encoded YouTube cookies at service startup and expose them via an environment variable

Enhancements:
- Merge startCommand to decode YOUTUBE_COOKIES into /tmp/cookies.txt before launching the worker
- Add YOUTUBE_COOKIES as a non-synced environment variable in render.yaml