### PR TITLE
remove get method

### DIFF
--- a/db.py
+++ b/db.py
@@ -184,15 +184,12 @@ def get_cached_playlist_stats(
 
 @dataclass
 class UpsertResult:
-    source: str  # "cache" | "fresh" | "error"
-    df_json: Optional[str] = None
-    summary_stats_json: Optional[str] = None
-    inserted_row: Optional[Dict[str, Any]] = None
-    raw_row: Optional[Dict[str, Any]] = None
-    error: Optional[str] = None
+    """Result of upserting playlist stats to the database."""
 
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
+    source: str  # 'cache', 'fresh', 'error'
+    df: Optional[pl.DataFrame] = None
+    summary_stats: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
 
 
 async def upsert_playlist_stats(stats: Dict[str, Any]) -> UpsertResult:

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -386,7 +386,7 @@ async def handle_job(job, is_retry: bool = False):
         logger.debug(f"[Job {job_id}] Upsert payload={safe_payload}")
 
         result = await upsert_playlist_stats(stats_to_cache)
-        logger.info(f"[Job {job_id}] Upsert result source={result.get('source')}")
+        logger.info(f"[Job {job_id}] Upsert result source={result.source}")
 
         # Detailed validation: ensure DB confirms presence of serialized payloads
         # Prefer df (cache case) or df_json (fresh insert confirmation)


### PR DESCRIPTION
## Summary by Sourcery

Simplify the UpsertResult data model to use structured data types and update its consumer to access attributes directly

Enhancements:
- Simplify UpsertResult by replacing JSON string fields and row dicts with structured pl.DataFrame and summary_stats dict
- Add docstring to UpsertResult and remove its to_dict method
- Update job handler to use attribute access for result.source instead of result.get('source')