### PR TITLE
progress callback

### DIFF
--- a/services/youtube_service.py
+++ b/services/youtube_service.py
@@ -931,14 +931,16 @@ class YouTubeBackendAPI(YouTubeBackendBase):
     async def _fetch_video_details(
         self,
         video_ids: List[str],
-        progress_callback: Optional[callable],
+        progress_callback: Optional[callable] = None,
     ) -> List[Dict[str, Any]]:
-        """Fetch detailed video information in batches (robust; returns partial results)."""
+        """Fetch detailed video information in batches."""
         videos = []
 
         try:
-            # iterate in batches (max 50 per YouTube API)
-            for i in range(0, len(video_ids), self.YOUTUBE_API_MAX_RESULTS):
+            total_videos = len(video_ids)
+
+            # iterate in batches
+            for i in range(0, total_videos, self.YOUTUBE_API_MAX_RESULTS):
                 batch = video_ids[i : i + self.YOUTUBE_API_MAX_RESULTS]
                 batch_num = i // self.YOUTUBE_API_MAX_RESULTS + 1
 
@@ -990,7 +992,7 @@ class YouTubeBackendAPI(YouTubeBackendBase):
 
         except Exception as e:
             logger.exception(f"[YouTubeAPI] Failed to fetch video details: {e}")
-            return videos  # return whatever partial results we have
+            return videos  # return partial results
 
     async def _fetch_playlist_metadata(
         self, playlist_id: str


### PR DESCRIPTION
## Summary by Sourcery

Convert progress updates to async callbacks and streamline playlist fetching logic

Enhancements:
- Convert update_progress to an async function with early exit on zero total
- Add _make_progress_callback helper to generate async progress callbacks
- Refactor handle_job to use the new progress callback instead of inline lambda
- Clean up YouTube service by defaulting progress_callback to None and simplifying batch iteration

Chores:
- Remove deprecated functions: check_bot_challenge_cooldown, handle_job_failure, and _result_to_mapping