### PR TITLE
Limit engagement ranking chart to top 12 entries and enhance color 

### DIFF
--- a/charts.py
+++ b/charts.py
@@ -83,7 +83,7 @@ def _apply_point_colors(data: list[dict]) -> tuple[list[dict], list[str]]:
     palette = _distributed_palette(len(data))
     for i, d in enumerate(data):
         # ApexCharts reads 'color' per point
-        d["color"] = palette[i % len(palette)]
+        d["fillColor"] = palette[i % len(palette)]
     return data, palette
 
 
@@ -1453,11 +1453,15 @@ def chart_views_vs_likes(
                 "text": "🎯 Views vs Likes (bubble size = comments)",
                 "align": "left",
             },
+            tooltip={
+                "theme": "light",
+                "y": {"formatter": "function(val){ return val.toFixed(2) + '%'; }"},
+            },
             plotOptions={
                 "bubble": {
                     "minBubbleRadius": 4,
                     "maxBubbleRadius": 25,
-                    "colorByPoint": True,
+                    # "colorByPoint": True,
                 }
             },
             colors=palette,


### PR DESCRIPTION
…ding for better visualization

## Summary by Sourcery

Limit the engagement leaderboard chart to the top-ranked entries and update its visual styling.

New Features:
- Highlight the top three videos in the engagement leaderboard with rank-based bar colors while using a consistent color for the remaining entries.

Enhancements:
- Restrict the engagement ranking chart to display only the top 12 videos by engagement rate for clearer comparison.
- Compute and pass engagement rate values more explicitly for each data point in the engagement ranking chart.
- Disable distributed bar coloring and hide the legend to simplify the chart’s visual presentation.