### PR TITLE
coverage error fix

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Debug coverage artifacts
         run: |
           echo "Contents of coverage-data:"
-          ls -R coverage-data
+          ls -R coverage-data || echo "coverage-data directory not found"
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary by Sourcery

Ensure the coverage badge workflow fails clearly when coverage artifacts are missing and add debugging for artifact contents.

CI:
- Add a debugging step to list the contents of the downloaded coverage-data artifacts in the coverage-badge workflow.
- Tighten the coverage badge generation step to error explicitly if coverage.xml is missing and remove the fallback HTML coverage generation step.