### PR TITLE
fix cov directory

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -43,8 +43,8 @@ jobs:
       # ✅ Use existing coverage.xml instead of regenerating
       - name: Copy coverage files
         run: |
-          cp coverage-data/coverage.xml ./coverage.xml
-          cp -r coverage-data/htmlcov ./htmlcov || echo "HTML coverage not in artifact"
+          cp coverage-data//coverage-report/coverage.xml ./coverage.xml
+          cp -r coverage-data//coverage-report/htmlcov ./htmlcov || echo "HTML coverage not in artifact"
 
 
       - name: Generate coverage badge


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Adjust coverage-badge workflow paths to use the coverage-report subdirectory within the coverage-data artifact.