### PR TITLE
error fix

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -43,8 +43,8 @@ jobs:
       # ✅ Use existing coverage.xml instead of regenerating
       - name: Copy coverage files
         run: |
-          cp coverage-data//coverage-report/coverage.xml ./coverage.xml
-          cp -r coverage-data//coverage-report/htmlcov ./htmlcov || echo "HTML coverage not in artifact"
+          cp coverage-data/coverage-report/coverage.xml ./coverage.xml
+          cp -r coverage-data/coverage-report/htmlcov ./htmlcov || echo "HTML coverage not in artifact"
 
 
       - name: Generate coverage badge


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Correct the file paths used to copy coverage.xml and HTML coverage reports in the coverage-badge workflow job.