### PR TITLE
fix snyx issues

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write  # Required for uploading SARIF results to Code Scanning
 
 jobs:
   scan:
@@ -28,6 +29,6 @@ jobs:
 
       - name: Upload Snyk results to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: always() && hashFiles('snyk.sarif') != ''  # Only upload if SARIF file exists
         with:
           sarif_file: snyk.sarif


### PR DESCRIPTION
## Summary by Sourcery

Adjust Snyk GitHub Actions workflow to only upload SARIF scan results when present and grant required permissions for code scanning.

CI:
- Grant GitHub Actions workflow permission to write security events for uploading Snyk SARIF results to code scanning.
- Guard the Snyk SARIF upload step so it runs only when a SARIF file has been generated.