### PR TITLE
fly worker for jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
-# Base image
 FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install ffmpeg and curl (yt-dlp needs ffmpeg)
-RUN apt-get update && apt-get install -y \
-    ffmpeg \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
 
 # Install Python deps
 COPY requirements-backend.txt .
 RUN pip install --no-cache-dir -r requirements-backend.txt
 
-# Copy app source
+# Copy only what worker needs (optional refinement later)
 COPY . .
 
-# Entrypoint
-RUN chmod +x /app/fly-entrypoint.sh
-ENTRYPOINT ["/app/fly-entrypoint.sh"]
+# 🚨 No entrypoint script
+CMD ["python", "-m", "worker.worker"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,16 @@
+app = "viralvibes-worker"
+
+primary_region = "ams"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[processes]
+  worker = "python -m worker.worker"
+
+[deploy]
+  strategy = "immediate"
+
+# 🚫 NO services block
+# 🚫 NO http checks
+# 🚫 NO ports


### PR DESCRIPTION
## Summary by Sourcery

Configure a dedicated Fly.io worker app and container entrypoint for running background jobs separately from the main service.

Build:
- Update Dockerfile to run the worker module directly via CMD instead of using a custom entrypoint script.

Deployment:
- Add Fly.io app configuration for a worker process without HTTP services or ports.