### PR TITLE
youtube api key

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -19,6 +19,8 @@ services:
         sync: false
       - key: YOUTUBE_COOKIES
         sync: false
+      - key: YOUTUBE_API_KEY
+        sync: false
       - key: WORKER_POLL_INTERVAL
         value: "60"
       - key: WORKER_BATCH_SIZE


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Configure the Render service to include a YOUTUBE_API_KEY environment variable without syncing its value.