### PR TITLE
enable creator seeding from playlist jobs

### DIFF
--- a/services/youtube_backend_api.py
+++ b/services/youtube_backend_api.py
@@ -247,11 +247,11 @@ class YouTubeBackendAPI(YouTubeBackendBase):
             stats["backend"] = "youtubeapi"
             stats["analyzed_videos"] = len(videos)
             # Add channel metadata for creator tracking
-            stats["channel_id"] = playlist_metadata.get("channel_id", "")
+            stats["channel_id"] = playlist_metadata.get("channel_id") or None
             stats["channel_url"] = (
-                f"https://www.youtube.com/channel/{playlist_metadata.get('channel_id', '')}"
+                f"https://www.youtube.com/channel/{playlist_metadata.get('channel_id')}"
                 if playlist_metadata.get("channel_id")
-                else ""
+                else None
             )
 
             # Add enhanced metadata if videos were processed

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -587,12 +587,15 @@ async def handle_job(job: Dict[str, Any], is_retry: bool = False):
                         )
                 else:
                     logger.debug(
-                        f"[Job {job_id}] No channel_id available for creator seeding"
+                        f"[Job {job_id}] Skipping creator seeding - missing required data "
+                        f"(channel_id={'present' if channel_id else 'missing'}, "
+                        f"channel_name={'present' if channel_name else 'missing'})"
                     )
             except Exception as e:
                 # Don't fail the job if creator seeding fails
                 logger.warning(
-                    f"[Job {job_id}] Creator seeding failed (non-critical): {e}"
+                    f"[Job {job_id}] Creator seeding failed (non-critical): {e}",
+                    exc_info=True,
                 )
 
             await mark_job_status(


### PR DESCRIPTION
## Summary by Sourcery

Enable automatic creator seeding when processing YouTube playlist jobs using playlist metadata.

New Features:
- Seed creator records during playlist jobs based on channel metadata returned from the YouTube backend API.

Enhancements:
- Propagate channel identifier and URL from YouTube playlist metadata into summary statistics for downstream creator tracking.