### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Potential fix for [https://github.com/navneeth/viralvibes/security/code-scanning/9](https://github.com/navneeth/viralvibes/security/code-scanning/9)

In general, the problem is fixed by explicitly adding a `permissions:` block that restricts the `GITHUB_TOKEN` to the least privileges necessary. For this workflow, the job only checks out code, sets up Python, installs dependencies, and runs `pre-commit`; none of these steps require write access to repository contents, issues, or pull requests. Therefore, the minimal appropriate permissions are `contents: read`.

The best fix without changing existing functionality is to add a `permissions:` block scoped to the `pre-commit` job. This makes the job self-contained and clear about its needs. Concretely, within `.github/workflows/pre-commit.yml`, under `jobs: pre-commit:` and at the same indentation level as `runs-on:`, add:

```yaml
permissions:
  contents: read
```

This ensures the `GITHUB_TOKEN` used in this job only has read access to the repository’s contents. No additional methods, imports, or definitions are needed since this is purely a configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Set explicit read-only contents permissions for the pre-commit GitHub Actions workflow job to address security scanning requirements.