### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -11,6 +11,8 @@ concurrency:
 
 jobs:
   run-worker:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 330  # 5.5 hours (safety buffer)
     env:


### PR DESCRIPTION
Potential fix for [https://github.com/navneeth/viralvibes/security/code-scanning/2](https://github.com/navneeth/viralvibes/security/code-scanning/2)

In general, the problem is fixed by adding a `permissions` section either at the workflow root (applies to all jobs) or directly under the job definition to limit the `GITHUB_TOKEN` to the least privileges required (often just `contents: read` for workflows that only need to fetch code).

For this workflow, the `run-worker` job only checks out the repository, sets up Python, installs dependencies, and runs a script. None of these steps require write access to the repository or other GitHub resources. The simplest and safest fix is to add a `permissions` block with `contents: read`. To keep the change tightly scoped to the flagged job, we’ll add the block under `jobs: run-worker:` (line 13–14 region). Concretely, in `.github/workflows/worker.yml`, insert:

```yaml
    permissions:
      contents: read
```

indented to align with `runs-on`, `timeout-minutes`, etc. No imports or additional definitions are needed, since this is GitHub Actions workflow YAML only. Existing functionality remains unchanged; only the default token privileges are reduced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Limit the GITHUB_TOKEN permissions for the run-worker job to contents: read in the worker workflow to address code scanning security concerns.