### PR TITLE
chore: optimize worker throughput for Fly.io and Kaggle

### DIFF
--- a/deploy/fly/fly.toml
+++ b/deploy/fly/fly.toml
@@ -4,11 +4,20 @@ primary_region = "nrt"   # Tokyo, since you’re in Japan
 [build]
   dockerfile = "Dockerfile"
 
+# CREATOR_WORKER_MAX_RUNTIME is in seconds (matches worker.py env var name).
+# CREATOR_WORKER_SKIP_DIAGNOSIS=true skips the 4-query DB diagnosis on every
+# process start — set to false only for the very first cold boot.
 [env]
   WORKER_POLL_INTERVAL = "10"
-  WORKER_BATCH_SIZE = "3"
-  WORKER_MAX_RUNTIME = "300"  # minutes
+  WORKER_BATCH_SIZE = "5"
+  MIN_REQUEST_DELAY = "0.5"
+  MAX_REQUEST_DELAY = "2.0"
+  CREATOR_WORKER_MAX_RUNTIME = "3600"
+  CREATOR_WORKER_SKIP_DIAGNOSIS = "true"
+  BOT_CHALLENGE_BACKOFF = "120"
 
-[[services]]
-  internal_port = 8080
-  processes = ["app"]
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"
+
+# 🚫 NO services block — background worker, no HTTP port needed

--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,24 @@ primary_region = "ams"
 [deploy]
   strategy = "immediate"
 
-# 🚫 NO services block
+# Tune worker throughput — all values are env-configurable at runtime.
+# WORKER_BATCH_SIZE: jobs claimed per poll cycle.
+# MIN/MAX_REQUEST_DELAY: anti-bot jitter before each job (seconds).
+# CREATOR_WORKER_MAX_RUNTIME: hard wall before the process exits (seconds).
+[env]
+  WORKER_POLL_INTERVAL = "10"
+  WORKER_BATCH_SIZE = "5"
+  MIN_REQUEST_DELAY = "0.5"
+  MAX_REQUEST_DELAY = "2.0"
+  CREATOR_WORKER_MAX_RUNTIME = "3600"
+  BOT_CHALLENGE_BACKOFF = "120"
+
+# shared-cpu-1x @ 256 MB is the cheapest Fly machine.
+# The worker is pure I/O (YouTube API + Supabase), never CPU-bound.
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"
+
+# 🚫 NO services block — background worker, no HTTP
 # 🚫 NO http checks
 # 🚫 NO ports

--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -116,9 +116,13 @@ from services.channel_utils import YouTubeResolver  # noqa: E402
 
 # ── Kaggle-specific loop config ───────────────────────────────────────────────
 _DEFAULT_MAX_JOBS = 5000
-_DEFAULT_MAX_EMPTY_POLLS = 3
-_RESOLVER_RESET_INTERVAL = 50  # reset YouTubeResolver every N jobs to flush
-# httplib2 state — replaces process isolation
+# Stop after 5 consecutive empty polls instead of 3 — prevents premature exit
+# during burst gaps where the queue drains briefly between job submissions.
+_DEFAULT_MAX_EMPTY_POLLS = 5
+# Reset YouTubeResolver every 100 jobs instead of 50.
+# GC + resolver re-init is ~1-2s of dead time; httplib2 only fragments under
+# sustained load and is safe well past 50 iterations.
+_RESOLVER_RESET_INTERVAL = 100
 
 # ── Main entry point ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
fly.toml (root):
- Add [env] block: BATCH_SIZE=5, POLL_INTERVAL=10s, MIN_REQUEST_DELAY=0.5s, MAX_REQUEST_DELAY=2.0s, BOT_CHALLENGE_BACKOFF=120s, MAX_RUNTIME=3600s
- Add explicit [[vm]] size=shared-cpu-1x / memory=256mb

deploy/fly/fly.toml (Tokyo):
- Fix bug: WORKER_MAX_RUNTIME → CREATOR_WORKER_MAX_RUNTIME (wrong env var name meant max runtime was silently ignored, defaulting to 3600s)
- Remove spurious [[services]] block (background worker has no HTTP server)
- Add CREATOR_WORKER_SKIP_DIAGNOSIS=true to avoid ~4 wasted DB round trips on every process restart under EXIT_AFTER_JOB=True bash loop

kaggle_worker.py:
- _RESOLVER_RESET_INTERVAL: 50 → 100 (saves ~1-2s GC pause per 50 jobs)
- _DEFAULT_MAX_EMPTY_POLLS: 3 → 5 (prevents premature exit during burst gaps)

## Summary by Sourcery

Tune worker configuration and loop behavior to improve throughput and reliability for Fly.io and Kaggle deployments.

Enhancements:
- Configure Fly.io workers with explicit polling, batching, delay, and runtime environment variables plus a minimal shared CPU VM profile.
- Align Tokyo Fly deployment worker env vars with the main config, including batch size, jitter, max runtime, and diagnosis skipping for faster restarts.
- Adjust Kaggle worker loop thresholds to tolerate more empty polls and reduce resolver reset frequency to minimize unnecessary pauses.