### PR TITLE
Round robin keypool for kaggle

### DIFF
--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -246,7 +246,7 @@ class KeyPool:
         for i, slot in enumerate(self.slots):
             marker = "►" if i == self._index else " "
             parts.append(
-                f"  {marker} slot {i} [...{slot.api_key[-6:]}] "
+                f"  {marker} slot {i} "
                 f"{slot.status} | jobs: {slot.jobs_processed}"
             )
         return "\n".join(parts)

--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -45,6 +45,14 @@ from typing import Optional
 
 logger = logging.getLogger("kaggle_worker")
 
+# ── Module constants ──────────────────────────────────────────────────────────
+# Centralized list of YouTube API key environment variable names for round-robin
+YOUTUBE_API_KEY_NAMES = [
+    "YOUTUBE_API_KEY",
+    "YOUTUBE_API_KEY_2",
+    "YOUTUBE_API_KEY_3",
+]
+
 # ── Step 1: fetch secrets once, before any worker import ─────────────────────
 # This MUST happen before importing creator_worker, because that module reads
 # os.environ at import time for YOUTUBE_DAILY_QUOTA and other constants.
@@ -53,7 +61,7 @@ logger = logging.getLogger("kaggle_worker")
 def _bootstrap_kaggle_secrets() -> None:
     """
     Pull secrets from Kaggle UserSecretsClient into os.environ once.
-    Loads YOUTUBE_API_KEY, YOUTUBE_API_KEY_2, YOUTUBE_API_KEY_3 (if present)
+    Loads all YouTube API keys from YOUTUBE_API_KEY_NAMES
     so KeyPool can populate itself with all available keys.
     """
     try:
@@ -71,10 +79,10 @@ def _bootstrap_kaggle_secrets() -> None:
     optional = {
         "YOUTUBE_DAILY_QUOTA": "10000",
         "NEXT_PUBLIC_SUPABASE_ANON_KEY": None,
-        # Extra API keys for round-robin rotation — add as many as you have
-        "YOUTUBE_API_KEY_2": None,
-        "YOUTUBE_API_KEY_3": None,
     }
+    # Add extra API key names as optional secrets
+    for key_name in YOUTUBE_API_KEY_NAMES[1:]:  # Skip first one, it's already required
+        optional[key_name] = None
 
     missing = []
     for key in required + list(optional):
@@ -94,17 +102,13 @@ def _bootstrap_kaggle_secrets() -> None:
                 os.environ[key] = optional[key]
 
     if missing:
-        raise EnvironmentError(
+        raise ValueError(
             f"Required Kaggle secrets not found: {missing}\n"
             "Add them under Add-ons → Secrets in your notebook."
         )
 
     # Log which API keys were found
-    keys_found = [
-        k
-        for k in ["YOUTUBE_API_KEY", "YOUTUBE_API_KEY_2", "YOUTUBE_API_KEY_3"]
-        if os.environ.get(k)
-    ]
+    keys_found = [k for k in YOUTUBE_API_KEY_NAMES if os.environ.get(k)]
     logger.info("✅ Secrets loaded. YouTube API keys available: %d", len(keys_found))
 
 
@@ -186,19 +190,22 @@ class KeyPool:
     @classmethod
     def from_env(cls) -> "KeyPool":
         """
-        Build pool from YOUTUBE_API_KEY, YOUTUBE_API_KEY_2, YOUTUBE_API_KEY_3.
+        Build pool from all YOUTUBE_API_KEY_* environment variables.
         Any key not present in env is silently skipped.
+
+        Raises:
+            ValueError: If no API keys are found in the environment.
         """
         keys = []
-        for name in ["YOUTUBE_API_KEY", "YOUTUBE_API_KEY_2", "YOUTUBE_API_KEY_3"]:
+        for name in YOUTUBE_API_KEY_NAMES:
             k = os.environ.get(name, "").strip()
             if k:
                 keys.append(k)
         if not keys:
-            raise ValueError("No YOUTUBE_API_KEY found in environment")
-        return cls(keys)
-        if not keys:
-            raise EnvironmentError("No YOUTUBE_API_KEY found in environment")
+            raise ValueError(
+                f"No YouTube API keys found in environment. "
+                f"Expected at least one of: {', '.join(YOUTUBE_API_KEY_NAMES)}"
+            )
         return cls(keys)
 
     @property
@@ -244,10 +251,7 @@ class KeyPool:
         parts = []
         for i, slot in enumerate(self.slots):
             marker = "►" if i == self._index else " "
-            parts.append(
-                f"  {marker} slot {i} "
-                f"{slot.status} | jobs: {slot.jobs_processed}"
-            )
+            parts.append(f"  {marker} slot {i} " f"{slot.status} | jobs: {slot.jobs_processed}")
         return "\n".join(parts)
 
 
@@ -358,6 +362,9 @@ async def run(
 
         except asyncio.TimeoutError:
             jobs_processed += 1
+            # Note: Timeouts are not recorded against the current key's job count,
+            # as the timeout represents a network/processing failure, not a successful
+            # API call. This avoids penalizing the key pool's rotation logic.
             logger.warning("⏱  Job %d timed out after 90s — continuing", jobs_processed)
 
         except Exception as e:
@@ -366,8 +373,9 @@ async def run(
             if isinstance(e, QuotaExceededException):
                 logger.warning(
                     "⏸  Quota exhausted on key slot %d (...%s) — attempting rotation",
-                    "⏸  Quota exhausted on key slot %d — attempting rotation",
+                    key_pool._index,
                     key_pool.current_slot.api_key[-6:],
+                )
                 rotated = key_pool.mark_exhausted_and_rotate()
                 if rotated:
                     # Swap resolver to new key

--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -227,9 +227,8 @@ class KeyPool:
             if self.slots[candidate].is_active:
                 self._index = candidate
                 logger.info(
-                    "  🔄 Rotated to key slot %d (...%s)",
+                    "  🔄 Rotated to key slot %d",
                     self._index,
-                    self.slots[self._index].api_key[-6:],
                 )
                 return True
 

--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -38,6 +38,9 @@ import logging
 import os
 import time
 import gc
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
 
 logger = logging.getLogger("kaggle_worker")
 
@@ -49,7 +52,8 @@ logger = logging.getLogger("kaggle_worker")
 def _bootstrap_kaggle_secrets() -> None:
     """
     Pull secrets from Kaggle UserSecretsClient into os.environ once.
-    Skips any key already present — safe to call multiple times.
+    Loads YOUTUBE_API_KEY, YOUTUBE_API_KEY_2, YOUTUBE_API_KEY_3 (if present)
+    so KeyPool can populate itself with all available keys.
     """
     try:
         from kaggle_secrets import UserSecretsClient  # type: ignore[import]
@@ -58,20 +62,23 @@ def _bootstrap_kaggle_secrets() -> None:
         return
 
     client = UserSecretsClient()
-    required = {
-        "NEXT_PUBLIC_SUPABASE_URL": None,
-        "SUPABASE_SERVICE_KEY": None,
-        "YOUTUBE_API_KEY": None,
-    }
+    required = [
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "SUPABASE_SERVICE_KEY",
+        "YOUTUBE_API_KEY",
+    ]
     optional = {
         "YOUTUBE_DAILY_QUOTA": "10000",
         "NEXT_PUBLIC_SUPABASE_ANON_KEY": None,
+        # Extra API keys for round-robin rotation — add as many as you have
+        "YOUTUBE_API_KEY_2": None,
+        "YOUTUBE_API_KEY_3": None,
     }
 
     missing = []
-    for key in {**required, **optional}:
+    for key in required + list(optional):
         if key in os.environ:
-            continue  # already set — don't touch Kaggle API
+            continue
         try:
             val = client.get_secret(key)
             if val:
@@ -91,7 +98,13 @@ def _bootstrap_kaggle_secrets() -> None:
             "Add them under Add-ons → Secrets in your notebook."
         )
 
-    logger.info("✅ Secrets bootstrapped into os.environ (Kaggle API called once)")
+    # Log which API keys were found
+    keys_found = [
+        k
+        for k in ["YOUTUBE_API_KEY", "YOUTUBE_API_KEY_2", "YOUTUBE_API_KEY_3"]
+        if os.environ.get(k)
+    ]
+    logger.info("✅ Secrets loaded. YouTube API keys available: %d", len(keys_found))
 
 
 # Run immediately at import — before worker module is imported below
@@ -114,6 +127,126 @@ from worker.creator_worker import (  # noqa: E402
 from services.youtube_config import get_creator_worker_api_key  # noqa: E402
 from services.channel_utils import YouTubeResolver  # noqa: E402
 
+
+# =============================================================================
+# KeyPool — round-robin YouTube API key rotation
+# =============================================================================
+
+
+@dataclass
+class ApiKeySlot:
+    """Single API key with usage tracking."""
+
+    api_key: str
+    status: str = "active"  # "active" | "exhausted"
+    exhausted_at: Optional[datetime] = None
+    jobs_processed: int = 0
+
+    def exhaust(self) -> None:
+        self.status = "exhausted"
+        self.exhausted_at = datetime.now(timezone.utc)
+        logger.warning(
+            "  🔑 Key ...%s exhausted after %d jobs",
+            self.api_key[-6:],
+            self.jobs_processed,
+        )
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == "active"
+
+
+class KeyPool:
+    """
+    Round-robin pool of YouTube API keys.
+
+    On QuotaExceededException:
+      1. Mark current slot exhausted
+      2. Advance to next active slot
+      3. Swap the YouTubeResolver to the new key
+      4. If no active slots remain → set all_exhausted_event
+
+    Usage:
+        pool = KeyPool.from_env()
+        resolver = pool.current_resolver()
+        ...
+        pool.mark_exhausted_and_rotate()   # on QuotaExceededException
+    """
+
+    def __init__(self, api_keys: list[str]) -> None:
+        if not api_keys:
+            raise ValueError("KeyPool requires at least one API key")
+        self.slots: list[ApiKeySlot] = [ApiKeySlot(k) for k in api_keys]
+        self._index: int = 0
+        self.all_exhausted_event: asyncio.Event = asyncio.Event()
+        logger.info("KeyPool initialised with %d key(s)", len(self.slots))
+
+    @classmethod
+    def from_env(cls) -> "KeyPool":
+        """
+        Build pool from YOUTUBE_API_KEY, YOUTUBE_API_KEY_2, YOUTUBE_API_KEY_3.
+        Any key not present in env is silently skipped.
+        """
+        keys = []
+        for name in ["YOUTUBE_API_KEY", "YOUTUBE_API_KEY_2", "YOUTUBE_API_KEY_3"]:
+            k = os.environ.get(name, "").strip()
+            if k:
+                keys.append(k)
+        if not keys:
+            raise EnvironmentError("No YOUTUBE_API_KEY found in environment")
+        return cls(keys)
+
+    @property
+    def current_slot(self) -> ApiKeySlot:
+        return self.slots[self._index]
+
+    def current_resolver(self) -> "YouTubeResolver":
+        return YouTubeResolver(api_key=self.current_slot.api_key)
+
+    def record_job(self) -> None:
+        self.current_slot.jobs_processed += 1
+
+    def mark_exhausted_and_rotate(self) -> bool:
+        """
+        Exhaust the current slot and advance to the next active one.
+
+        Returns:
+            True  — rotated successfully, caller should swap resolver and retry
+            False — all slots exhausted, caller should stop
+        """
+        self.current_slot.exhaust()
+
+        # Find next active slot (wrapping around)
+        for offset in range(1, len(self.slots)):
+            candidate = (self._index + offset) % len(self.slots)
+            if self.slots[candidate].is_active:
+                self._index = candidate
+                logger.info(
+                    "  🔄 Rotated to key slot %d (...%s)",
+                    self._index,
+                    self.slots[self._index].api_key[-6:],
+                )
+                return True
+
+        # No active slots remain
+        logger.error(
+            "  ❌ All %d API key(s) exhausted. " "Quota resets at midnight Pacific (08:00 UTC).",
+            len(self.slots),
+        )
+        self.all_exhausted_event.set()
+        return False
+
+    def summary(self) -> str:
+        parts = []
+        for i, slot in enumerate(self.slots):
+            marker = "►" if i == self._index else " "
+            parts.append(
+                f"  {marker} slot {i} [...{slot.api_key[-6:]}] "
+                f"{slot.status} | jobs: {slot.jobs_processed}"
+            )
+        return "\n".join(parts)
+
+
 # ── Kaggle-specific loop config ───────────────────────────────────────────────
 _DEFAULT_MAX_JOBS = 5000
 # Stop after 5 consecutive empty polls instead of 3 — prevents premature exit
@@ -134,45 +267,49 @@ async def run(
     """
     Run the creator worker loop in-process for Kaggle.
 
-    Unlike the production worker, this does NOT exit after each job.
-    Instead it resets the YouTubeResolver every _RESOLVER_RESET_INTERVAL jobs
-    to reclaim httplib2 memory, which is the only reason production uses
-    subprocess isolation.
+    Uses KeyPool for round-robin API key rotation on quota exhaustion.
+    Resets YouTubeResolver every _RESOLVER_RESET_INTERVAL jobs for
+    httplib2 memory management.
 
     Args:
-        max_jobs:        Stop after processing this many jobs (default 500).
+        max_jobs:        Stop after processing this many jobs.
         max_empty_polls: Stop after this many consecutive empty queue polls.
     """
+    import worker.creator_worker as _cw
+
+    # ── Build key pool from env ───────────────────────────────────────────────
+    key_pool = KeyPool.from_env()
     logger.info("🚀 Kaggle Creator Worker starting")
     logger.info(
-        "   max_jobs=%d  max_empty_polls=%d  resolver_reset=%d",
+        "   max_jobs=%d  max_empty_polls=%d  resolver_reset=%d  keys=%d",
         max_jobs,
         max_empty_polls,
         _RESOLVER_RESET_INTERVAL,
+        len(key_pool.slots),
     )
 
-    # Initialise Supabase + YouTube resolver (same as production init())
+    # ── Initialise Supabase + resolver ────────────────────────────────────────
     await init()
+    _cw.youtube_resolver = key_pool.current_resolver()
 
     jobs_processed = 0
     empty_polls = 0
     start_time = time.time()
 
-    while not stop_event.is_set() and jobs_processed < max_jobs:
+    while (
+        not stop_event.is_set()
+        and not key_pool.all_exhausted_event.is_set()
+        and jobs_processed < max_jobs
+    ):
 
         # ── Periodic resolver reset (httplib2 memory management) ─────────────
         if jobs_processed > 0 and jobs_processed % _RESOLVER_RESET_INTERVAL == 0:
             logger.info(
-                "🔄 Resetting YouTubeResolver after %d jobs (httplib2 flush)",
-                jobs_processed,
+                "🔄 Resetting YouTubeResolver after %d jobs (httplib2 flush)", jobs_processed
             )
-            import worker.creator_worker as _cw
-
-            _cw.youtube_resolver = None  # Drop reference to allow GC to reclaim memory
-            gc.collect()  # Force garbage collection to free memory immediately
-
-            # Re-instantiate YouTubeResolver with fresh state
-            _cw.youtube_resolver = YouTubeResolver(api_key=get_creator_worker_api_key())
+            _cw.youtube_resolver = None
+            gc.collect()
+            _cw.youtube_resolver = key_pool.current_resolver()
             logger.info("✅ Memory flushed and Resolver re-initialized")
 
         # ── Fetch next job ────────────────────────────────────────────────────
@@ -181,18 +318,10 @@ async def run(
         if not jobs:
             empty_polls += 1
             if empty_polls >= max_empty_polls:
-                logger.info(
-                    "✅ Queue empty for %d consecutive polls — stopping",
-                    empty_polls,
-                )
+                logger.info("✅ Queue empty for %d consecutive polls — stopping", empty_polls)
                 break
             backoff = min(30 * (2 ** (empty_polls - 1)), 300)
-            logger.info(
-                "Queue empty (%d/%d) — sleeping %ds",
-                empty_polls,
-                max_empty_polls,
-                backoff,
-            )
+            logger.info("Queue empty (%d/%d) — sleeping %ds", empty_polls, max_empty_polls, backoff)
             await asyncio.sleep(backoff)
             continue
 
@@ -207,25 +336,55 @@ async def run(
                     job_number=jobs_processed + 1,
                     retry_count=job.get("retry_count", 0),
                 ),
-                timeout=90,  # generous timeout — no bash loop to recover us
+                timeout=90,
             )
             jobs_processed += 1
+            key_pool.record_job()
             status = "✅" if result else "⚠️"
             logger.info(
-                "%s Job %d done | processed=%d quota=%d/%d (%.1f%%)",
+                "%s Job %d done | key_slot=%d jobs_on_key=%d quota=%d/%d (%.1f%%)",
                 status,
                 jobs_processed,
-                jobs_processed,
+                key_pool._index,
+                key_pool.current_slot.jobs_processed,
                 metrics.youtube_credits_used,
                 YOUTUBE_DAILY_QUOTA,
                 metrics.quota_percentage(),
             )
+
         except asyncio.TimeoutError:
             jobs_processed += 1
             logger.warning("⏱  Job %d timed out after 90s — continuing", jobs_processed)
+
         except Exception as e:
-            jobs_processed += 1
-            logger.exception("❌ Job %d raised: %s", jobs_processed, e)
+            from services.youtube_errors import QuotaExceededException
+
+            if isinstance(e, QuotaExceededException):
+                logger.warning(
+                    "⏸  Quota exhausted on key slot %d (...%s) — attempting rotation",
+                    key_pool._index,
+                    key_pool.current_slot.api_key[-6:],
+                )
+                rotated = key_pool.mark_exhausted_and_rotate()
+                if rotated:
+                    # Swap resolver to new key
+                    _cw.youtube_resolver = None
+                    gc.collect()
+                    _cw.youtube_resolver = key_pool.current_resolver()
+                    logger.info(
+                        "  ↩️  Re-queuing job %s for retry on new key",
+                        job["id"],
+                    )
+                    # Don't increment jobs_processed — re-fetch same job next iteration
+                    # (it was marked failed with retry_at, bootstrap will re-queue it,
+                    #  or we can re-fetch immediately by continuing without incrementing)
+                    continue
+                else:
+                    logger.error("  🛑 All keys exhausted — stopping worker")
+                    break
+            else:
+                jobs_processed += 1
+                logger.exception("❌ Job %d raised: %s", jobs_processed, e)
 
     # ── Final summary ─────────────────────────────────────────────────────────
     elapsed = time.time() - start_time
@@ -242,6 +401,7 @@ async def run(
         YOUTUBE_DAILY_QUOTA,
         metrics.quota_percentage(),
     )
+    logger.info("Key pool summary:\n%s", key_pool.summary())
     logger.info("=" * 60)
 
 

--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -195,6 +195,9 @@ class KeyPool:
             if k:
                 keys.append(k)
         if not keys:
+            raise ValueError("No YOUTUBE_API_KEY found in environment")
+        return cls(keys)
+        if not keys:
             raise EnvironmentError("No YOUTUBE_API_KEY found in environment")
         return cls(keys)
 

--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -38,6 +38,7 @@ import logging
 import os
 import time
 import gc
+import hashlib
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
@@ -145,9 +146,10 @@ class ApiKeySlot:
     def exhaust(self) -> None:
         self.status = "exhausted"
         self.exhausted_at = datetime.now(timezone.utc)
+        key_id = hashlib.sha256(self.api_key.encode("utf-8")).hexdigest()[:12]
         logger.warning(
-            "  🔑 Key ...%s exhausted after %d jobs",
-            self.api_key[-6:],
+            "  🔑 Key id=%s exhausted after %d jobs",
+            key_id,
             self.jobs_processed,
         )
 

--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -366,9 +366,8 @@ async def run(
             if isinstance(e, QuotaExceededException):
                 logger.warning(
                     "⏸  Quota exhausted on key slot %d (...%s) — attempting rotation",
-                    key_pool._index,
+                    "⏸  Quota exhausted on key slot %d — attempting rotation",
                     key_pool.current_slot.api_key[-6:],
-                )
                 rotated = key_pool.mark_exhausted_and_rotate()
                 if rotated:
                     # Swap resolver to new key

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -1137,16 +1137,17 @@ async def handle_sync_job(
         # ── Quota exhausted: transient — stop processing, do NOT purge ─────────
         # The daily quota resets at midnight Pacific. Mark the job failed so it
         # re-enters the queue tomorrow; do not touch the creator row.
+        # Re-raise to let kaggle_worker.py handle key rotation.
         if isinstance(e, QuotaExceededException):
             logger.error(
-                f"{job_tag} ⏸️  YouTube quota exhausted — job {job_id} marked failed "
+                f"{job_tag} ⏸️  YouTube quota exhausted — marking job {job_id} failed "
                 "for retry. Creator record preserved."
             )
             try:
                 mark_creator_sync_failed(job_id, "YouTube quota exceeded — will retry")
             except Exception as mark_err:
                 logger.warning(f"{job_tag} Could not mark job failed: {mark_err}")
-            return False
+            raise
 
         # ── Permanent failure: channel does not exist on YouTube ──────────────
         # Do NOT retry — the channel is gone. Hard-delete from creators table


### PR DESCRIPTION
## Summary by Sourcery

Introduce a round-robin YouTube API key pool for the Kaggle creator worker and wire it into the worker loop with improved quota and key usage logging.

Enhancements:
- Load multiple YouTube API keys from Kaggle secrets and environment variables, including optional secondary keys.
- Add a KeyPool abstraction with round-robin rotation and per-key usage tracking, and integrate it into the Kaggle worker processing loop, including resolver resets and key exhaustion handling.
- Refine worker loop termination conditions to also stop when all API keys are exhausted and log a final key pool usage summary.
- Tighten and simplify logging around queue polling, job execution, and resolver resets to include key slot and per-key job counts.