### PR TITLE
feat(creators): add creator by handle or channel ID via worker queue

### DIFF
--- a/db.py
+++ b/db.py
@@ -900,7 +900,198 @@ def queue_creator_sync_bulk(
 
 
 # ============================================================================
-# 💳 Stripe / Subscription helpers
+# � Creator add-by-handle/ID request queue  (migration 018)
+# ============================================================================
+
+# Regex patterns for input validation — compiled once at module load
+import re as _re
+
+_UC_ID_RE = _re.compile(r"^UC[a-zA-Z0-9_-]{22}$")
+_HANDLE_RE = _re.compile(r"^@[a-zA-Z0-9._-]{1,100}$")
+
+# Per-user rate limit: max requests per window
+_ADD_REQUEST_LIMIT = int(os.getenv("CREATOR_ADD_REQUEST_LIMIT", "5"))
+_ADD_REQUEST_WINDOW_HOURS = int(os.getenv("CREATOR_ADD_REQUEST_WINDOW_HOURS", "1"))
+
+
+def _validate_creator_input(q: str) -> tuple[bool, str]:
+    """
+    Validate a raw user input string as a YouTube channel identifier.
+
+    Accepts:
+        - Canonical channel ID: UC followed by exactly 22 base64url chars
+        - @handle: starting with @ followed by 1–100 alphanumeric/._- chars
+
+    Returns:
+        (is_valid, normalised_input)  — normalised lowercases handles, leaves UC IDs as-is.
+    """
+    q = q.strip()
+    if _UC_ID_RE.match(q):
+        return True, q
+    handle = q if q.startswith("@") else f"@{q}"
+    if _HANDLE_RE.match(handle):
+        return True, handle.lower()
+    return False, q
+
+
+def queue_creator_add_request(
+    input_query: str,
+    user_id: str,
+) -> tuple[bool, str]:
+    """
+    Submit a user request to add a creator by @handle or channel ID.
+
+    This writes a ``job_type='resolve_and_add'`` row to ``creator_sync_jobs``
+    with ``creator_id=NULL``.  The worker resolves the input to a real channel,
+    upserts the creator row, then converts the job to ``job_type='sync_stats'``
+    so the normal pipeline takes over.
+
+    Validations performed (all enforced before any DB write):
+        1. Input matches UC ID or @handle format.
+        2. Creator not already in ``creators`` table (by channel_id or custom_url).
+        3. No pending ``resolve_and_add`` job for the same ``input_query`` exists
+           (enforced by partial unique index; also checked explicitly for a clear
+           error message).
+        4. Per-user rate limit: max ``CREATOR_ADD_REQUEST_LIMIT`` requests per
+           ``CREATOR_ADD_REQUEST_WINDOW_HOURS`` hours.
+
+    Args:
+        input_query: Raw user input — "@MrBeast" or "UCX6OQ3DkcsbYNE6H8uQQuVA".
+        user_id:     Authenticated user UUID (from session).
+
+    Returns:
+        ``(True, "queued")`` on success.
+        ``(False, reason_string)`` on any validation or DB failure.
+    """
+    if not supabase_client:
+        return False, "Database unavailable"
+
+    # ── 1. Validate format ────────────────────────────────────────────────────
+    is_valid, normalised = _validate_creator_input(input_query)
+    if not is_valid:
+        return False, (
+            "Invalid input — please enter a YouTube @handle (e.g. @MrBeast) "
+            "or a channel ID starting with UC."
+        )
+
+    try:
+        # ── 2. Already in DB? ─────────────────────────────────────────────────
+        if normalised.startswith("UC"):
+            existing = (
+                supabase_client.table(CREATOR_TABLE)
+                .select("id")
+                .eq("channel_id", normalised)
+                .limit(1)
+                .execute()
+            )
+        else:
+            handle_slug = normalised.lstrip("@")
+            existing = (
+                supabase_client.table(CREATOR_TABLE)
+                .select("id")
+                .ilike("custom_url", handle_slug)
+                .limit(1)
+                .execute()
+            )
+
+        if existing.data:
+            creator_id = existing.data[0]["id"]
+            return False, f"already_tracked:{creator_id}"
+
+        # ── 3. Duplicate pending resolve_and_add? ────────────────────────────
+        dup = (
+            supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
+            .select("id")
+            .eq("input_query", normalised)
+            .eq("job_type", "resolve_and_add")
+            .eq("status", "pending")
+            .limit(1)
+            .execute()
+        )
+        if dup.data:
+            return False, "A request for this creator is already pending — please check back soon."
+
+        # ── 4. Rate limit ─────────────────────────────────────────────────────
+        window_start = (
+            datetime.now(timezone.utc) - timedelta(hours=_ADD_REQUEST_WINDOW_HOURS)
+        ).isoformat()
+
+        recent = (
+            supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
+            .select("id", count="exact")
+            .eq("requested_by", user_id)
+            .eq("job_type", "resolve_and_add")
+            .gte("created_at", window_start)
+            .execute()
+        )
+        recent_count = recent.count or 0
+        if recent_count >= _ADD_REQUEST_LIMIT:
+            return False, (
+                f"You can submit up to {_ADD_REQUEST_LIMIT} creator requests per "
+                f"{_ADD_REQUEST_WINDOW_HOURS}h. Please try again later."
+            )
+
+        # ── 5. Insert the job ─────────────────────────────────────────────────
+        payload = {
+            "job_type": "resolve_and_add",
+            "status": "pending",
+            "source": "user_add",
+            "input_query": normalised,
+            "requested_by": user_id,
+            # creator_id intentionally NULL — filled in by the worker
+        }
+        resp = supabase_client.table(CREATOR_SYNC_JOBS_TABLE).insert(payload).execute()
+
+        if resp.data:
+            logger.info(
+                "Creator add request queued: input=%s user=%s job_id=%s",
+                normalised,
+                user_id,
+                resp.data[0].get("id"),
+            )
+            return True, "queued"
+
+        logger.error("Insert returned no data for creator add request: %s", normalised)
+        return False, "Failed to queue request — please try again."
+
+    except Exception as e:
+        logger.exception("Error queuing creator add request for %s: %s", normalised, e)
+        return False, "An unexpected error occurred — please try again."
+
+
+def get_creator_add_request_status(input_query: str) -> Optional[Dict[str, Any]]:
+    """
+    Return the most recent resolve_and_add job for the given input.
+
+    Used by the optional status-polling endpoint so the UI can show a
+    "still processing…" or "ready — view profile" state.
+
+    Returns:
+        Dict with keys ``status``, ``creator_id``, ``error_message``; or None.
+    """
+    if not supabase_client:
+        return None
+    is_valid, normalised = _validate_creator_input(input_query)
+    if not is_valid:
+        return None
+    try:
+        resp = (
+            supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
+            .select("status,creator_id,error_message")
+            .eq("input_query", normalised)
+            .eq("job_type", "resolve_and_add")
+            .order("created_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        return resp.data[0] if resp.data else None
+    except Exception as e:
+        logger.exception("Error fetching add request status for %s: %s", normalised, e)
+        return None
+
+
+# ============================================================================
+# �💳 Stripe / Subscription helpers
 # ============================================================================
 
 SUBSCRIPTIONS_TABLE = "subscriptions"

--- a/db.py
+++ b/db.py
@@ -1062,45 +1062,14 @@ def queue_creator_add_request(
                 user_id,
                 resp.data[0].get("id"),
             )
-            return True, "queued"
+            return True, "queued", None
 
         logger.error("Insert returned no data for creator add request: %s", normalised)
-        return False, "Failed to queue request — please try again."
+        return False, "Failed to queue request — please try again.", None
 
     except Exception as e:
         logger.exception("Error queuing creator add request for %s: %s", normalised, e)
-        return False, "An unexpected error occurred — please try again."
-
-
-def get_creator_add_request_status(input_query: str) -> Optional[Dict[str, Any]]:
-    """
-    Return the most recent resolve_and_add job for the given input.
-
-    Used by the optional status-polling endpoint so the UI can show a
-    "still processing…" or "ready — view profile" state.
-
-    Returns:
-        Dict with keys ``status``, ``creator_id``, ``error_message``; or None.
-    """
-    if not supabase_client:
-        return None
-    is_valid, normalised = _validate_creator_input(input_query)
-    if not is_valid:
-        return None
-    try:
-        resp = (
-            supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
-            .select("status,creator_id,error_message")
-            .eq("input_query", normalised)
-            .eq("job_type", "resolve_and_add")
-            .order("created_at", desc=True)
-            .limit(1)
-            .execute()
-        )
-        return resp.data[0] if resp.data else None
-    except Exception as e:
-        logger.exception("Error fetching add request status for %s: %s", normalised, e)
-        return None
+        return False, "An unexpected error occurred — please try again.", None
 
 
 # ============================================================================

--- a/db.py
+++ b/db.py
@@ -937,7 +937,7 @@ def _validate_creator_input(q: str) -> tuple[bool, str]:
 def queue_creator_add_request(
     input_query: str,
     user_id: str,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, Optional[str]]:
     """
     Submit a user request to add a creator by @handle or channel ID.
 
@@ -960,18 +960,23 @@ def queue_creator_add_request(
         user_id:     Authenticated user UUID (from session).
 
     Returns:
-        ``(True, "queued")`` on success.
-        ``(False, reason_string)`` on any validation or DB failure.
+        ``(True, "queued", None)`` on success.
+        ``(False, message, None)`` on validation or DB failure.
+        ``(False, message, creator_id)`` when the creator already exists in the DB.
     """
     if not supabase_client:
-        return False, "Database unavailable"
+        return False, "Database unavailable", None
 
     # ── 1. Validate format ────────────────────────────────────────────────────
     is_valid, normalised = _validate_creator_input(input_query)
     if not is_valid:
-        return False, (
-            "Invalid input — please enter a YouTube @handle (e.g. @MrBeast) "
-            "or a channel ID starting with UC."
+        return (
+            False,
+            (
+                "Invalid input — please enter a YouTube @handle (e.g. @MrBeast) "
+                "or a channel ID starting with UC."
+            ),
+            None,
         )
 
     try:
@@ -996,7 +1001,7 @@ def queue_creator_add_request(
 
         if existing.data:
             creator_id = existing.data[0]["id"]
-            return False, f"already_tracked:{creator_id}"
+            return False, "This creator is already in the database.", creator_id
 
         # ── 3. Duplicate pending resolve_and_add? ────────────────────────────
         dup = (
@@ -1009,7 +1014,11 @@ def queue_creator_add_request(
             .execute()
         )
         if dup.data:
-            return False, "A request for this creator is already pending — please check back soon."
+            return (
+                False,
+                "A request for this creator is already pending — please check back soon.",
+                None,
+            )
 
         # ── 4. Rate limit ─────────────────────────────────────────────────────
         window_start = (
@@ -1026,9 +1035,13 @@ def queue_creator_add_request(
         )
         recent_count = recent.count or 0
         if recent_count >= _ADD_REQUEST_LIMIT:
-            return False, (
-                f"You can submit up to {_ADD_REQUEST_LIMIT} creator requests per "
-                f"{_ADD_REQUEST_WINDOW_HOURS}h. Please try again later."
+            return (
+                False,
+                (
+                    f"You can submit up to {_ADD_REQUEST_LIMIT} creator requests per "
+                    f"{_ADD_REQUEST_WINDOW_HOURS}h. Please try again later."
+                ),
+                None,
             )
 
         # ── 5. Insert the job ─────────────────────────────────────────────────

--- a/db/migrations/018_creator_add_requests.sql
+++ b/db/migrations/018_creator_add_requests.sql
@@ -1,0 +1,43 @@
+-- Migration 018: Creator add-by-handle/ID request queue
+--
+-- Adds two columns to creator_sync_jobs so that the web frontend can submit
+-- a raw @handle or UCxxxxxxxx channel ID without calling the YouTube API.
+-- The worker resolves the input, upserts the creator, then converts the job
+-- to a normal sync_stats job.
+--
+-- New job_type: 'resolve_and_add'
+--   - creator_id  : NULL until the worker resolves the input
+--   - input_query : raw user input — "@MrBeast" or "UCxxxxxxxxxxxxxxxxxx"
+--   - requested_by: users.id of the user who submitted the request
+--
+-- Run once in the Supabase SQL editor.
+
+-- 1. Add input_query column — stores "@handle" or "UCxxxxxxxx"
+ALTER TABLE public.creator_sync_jobs
+    ADD COLUMN IF NOT EXISTS input_query   text;
+
+-- 2. Add requested_by column — FK to users; nullable for system-queued jobs
+ALTER TABLE public.creator_sync_jobs
+    ADD COLUMN IF NOT EXISTS requested_by  uuid REFERENCES public.users(id) ON DELETE SET NULL;
+
+-- 3. Allow creator_id to be NULL so resolve_and_add jobs can be inserted
+--    before the creator row exists.
+--    (creator_id was NOT NULL if enforced at DB level — check and drop if so)
+ALTER TABLE public.creator_sync_jobs
+    ALTER COLUMN creator_id DROP NOT NULL;
+
+-- 4. Partial unique index: one pending resolve_and_add per input_query.
+--    Prevents the same handle being submitted twice while a job is running.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_creator_sync_jobs_pending_resolve
+    ON public.creator_sync_jobs (input_query)
+    WHERE status = 'pending' AND job_type = 'resolve_and_add';
+
+-- 5. Index to let the worker efficiently poll for resolve_and_add jobs
+CREATE INDEX IF NOT EXISTS idx_creator_sync_jobs_resolve_and_add
+    ON public.creator_sync_jobs (status, job_type, created_at)
+    WHERE job_type = 'resolve_and_add';
+
+-- 6. Index for looking up requests by the submitting user (rate-limit check)
+CREATE INDEX IF NOT EXISTS idx_creator_sync_jobs_requested_by
+    ON public.creator_sync_jobs (requested_by, created_at)
+    WHERE requested_by IS NOT NULL;

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ from views.dashboard import render_full_dashboard
 from views.my_dashboards import render_my_dashboards_page
 from views.table import DISPLAY_HEADERS, get_sort_col, render_playlist_table
 from routes.analysis import analysis_page_content
-from routes.creators import creator_profile_route, creators_route
+from routes.creators import creator_profile_route, creator_request_route, creators_route
 from routes.legal import privacy_page_content, terms_page_content
 from routes.pricing import pricing_page_content
 from routes.stripe_webhooks import stripe_webhook
@@ -1112,7 +1112,7 @@ def creators(req, sess):
     """Creators discovery page - PUBLIC route with filtering and sorting"""
 
     # Call the route handler
-    page_content = creators_route(req)
+    page_content = creators_route(req, is_authenticated=bool(sess.get("auth")))
 
     # Render with navigation
     return Titled(

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -332,7 +332,7 @@ def creator_request_route(request, sess):
             message="Please enter a @handle or channel ID.",
         )
 
-    ok, reason = queue_creator_add_request(q, user_id)
+    ok, message, creator_id = queue_creator_add_request(q, user_id)
 
     if ok:
         return render_add_creator_result(
@@ -343,13 +343,4 @@ def creator_request_route(request, sess):
             ),
         )
 
-    # Structured "already tracked" response — extract creator_id and link to profile
-    if reason.startswith("already_tracked:"):
-        creator_id = reason.split(":", 1)[1]
-        return render_add_creator_result(
-            success=False,
-            message=reason,
-            creator_id=creator_id,
-        )
-
-    return render_add_creator_result(success=False, message=reason)
+    return render_add_creator_result(success=False, message=message, creator_id=creator_id or "")

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -18,6 +18,7 @@ from db import (
     get_creator_rank,
     get_creator_stats,
     get_creators,
+    queue_creator_add_request,
 )
 from db_lists import (
     get_lists_meta,
@@ -28,6 +29,7 @@ from db_lists import (
 
 # from services.youtube_backend_api import YouTubeBackendAPI
 from views.creators import (
+    render_add_creator_result,
     render_creator_preview,
     render_creator_profile_page,
     render_creators_page,
@@ -36,7 +38,7 @@ from views.creators import (
 logger = logging.getLogger(__name__)
 
 
-def creators_route(request):
+def creators_route(request, is_authenticated: bool = False):
     """GET /creators - Creators discovery page."""
 
     # Get query parameters
@@ -211,6 +213,7 @@ def creators_route(request):
         per_page=per_page,
         total_count=total_count,
         total_pages=total_pages,
+        is_authenticated=is_authenticated,
     )
 
 
@@ -300,3 +303,53 @@ def creator_profile_route(request, creator_id: str):
         context_ranks=context_ranks,
         category_stats=category_stats,
     )
+
+
+def creator_request_route(request, sess):
+    """
+    POST /creators/request
+    HTMX endpoint — queues a creator add request submitted by the user.
+    Accepts form field ``q`` (@handle or UC channel ID).
+    Returns an inline HTMX partial (no full page reload).
+    """
+    user_id = sess.get("user_id") if sess else None
+    if not user_id or not sess.get("auth"):
+        return render_add_creator_result(
+            success=False,
+            message="You must be logged in to submit a creator.",
+        )
+
+    # Read form body
+    try:
+        form = request.form()
+        q = form.get("q", "").strip()
+    except Exception:
+        q = ""
+
+    if not q:
+        return render_add_creator_result(
+            success=False,
+            message="Please enter a @handle or channel ID.",
+        )
+
+    ok, reason = queue_creator_add_request(q, user_id)
+
+    if ok:
+        return render_add_creator_result(
+            success=True,
+            message=(
+                "We'll add them within a few minutes. "
+                "Refresh the page shortly to find them in the list."
+            ),
+        )
+
+    # Structured "already tracked" response — extract creator_id and link to profile
+    if reason.startswith("already_tracked:"):
+        creator_id = reason.split(":", 1)[1]
+        return render_add_creator_result(
+            success=False,
+            message=reason,
+            creator_id=creator_id,
+        )
+
+    return render_add_creator_result(success=False, message=reason)

--- a/views/creators.py
+++ b/views/creators.py
@@ -441,6 +441,114 @@ def _build_filter_url(
 
 
 # ============================================================================
+# ADD CREATOR SECTION
+# ============================================================================
+
+
+def render_add_creator_section() -> Div:
+    """
+    HTMX form that lets authenticated users submit a creator by @handle or
+    channel ID.  No YouTube API is called on the Vercel frontend — the input
+    is passed directly to the backend worker queue via ``POST /creators/request``.
+    """
+    return Div(
+        Div(
+            Div(
+                UkIcon("plus-circle", cls="size-5 text-primary shrink-0 mt-0.5"),
+                Div(
+                    H3("Submit a Creator", cls="text-base font-semibold text-foreground"),
+                    P(
+                        "Know a channel that's not listed? Submit their @handle or "
+                        "channel ID and our system will add them automatically.",
+                        cls="text-sm text-muted-foreground mt-0.5",
+                    ),
+                    cls="flex-1 min-w-0",
+                ),
+                cls="flex items-start gap-3",
+            ),
+            # Input + submit (HTMX inline form)
+            Form(
+                Div(
+                    Input(
+                        type="text",
+                        name="q",
+                        id="creator-add-input",
+                        placeholder="@MrBeast or UCX6OQ3DkcsbYNE6H8uQQuVA",
+                        autocomplete="off",
+                        cls="flex-1 px-3 py-2 text-sm rounded-lg border border-border "
+                        "bg-background focus:outline-none focus:ring-2 focus:ring-primary/40",
+                    ),
+                    Button(
+                        UkIcon("send", cls="size-4 mr-1.5"),
+                        "Submit",
+                        type="submit",
+                        cls="flex items-center px-4 py-2 text-sm font-medium rounded-lg "
+                        "bg-primary text-primary-foreground hover:bg-primary/90 "
+                        "transition-colors shrink-0",
+                    ),
+                    cls="flex gap-2 mt-3",
+                ),
+                # Response target injected below the form
+                Div(id="creator-add-result", cls="mt-3"),
+                hx_post="/creators/request",
+                hx_target="#creator-add-result",
+                hx_swap="innerHTML",
+            ),
+            cls="p-4 rounded-xl border border-border bg-background",
+        ),
+        cls="mt-6 mb-2",
+    )
+
+
+def render_add_creator_result(success: bool, message: str, creator_id: str = "") -> Div:
+    """
+    HTMX partial returned by POST /creators/request.
+    Renders a success or error notice inline below the submit form.
+    """
+    if success:
+        return Div(
+            UkIcon("check-circle", cls="size-4 text-green-600 shrink-0"),
+            Div(
+                P(
+                    "Request queued!",
+                    cls="text-sm font-semibold text-green-700 dark:text-green-400",
+                ),
+                P(message, cls="text-xs text-muted-foreground mt-0.5"),
+                cls="flex-1",
+            ),
+            cls="flex items-start gap-2 p-3 rounded-lg bg-green-50 dark:bg-green-950/30 "
+            "border border-green-200 dark:border-green-800",
+        )
+
+    # "already_tracked" is a structured code — link directly to the profile
+    if message.startswith("already_tracked:") and creator_id:
+        return Div(
+            UkIcon("info", cls="size-4 text-blue-600 shrink-0"),
+            Div(
+                P(
+                    "Already in the database",
+                    cls="text-sm font-semibold text-blue-700 dark:text-blue-400",
+                ),
+                A(
+                    "View their profile →",
+                    href=f"/creator/{creator_id}",
+                    cls="text-xs text-primary hover:underline",
+                ),
+                cls="flex-1",
+            ),
+            cls="flex items-start gap-2 p-3 rounded-lg bg-blue-50 dark:bg-blue-950/30 "
+            "border border-blue-200 dark:border-blue-800",
+        )
+
+    return Div(
+        UkIcon("alert-circle", cls="size-4 text-red-600 shrink-0"),
+        P(message, cls="text-sm text-red-700 dark:text-red-400 flex-1"),
+        cls="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/30 "
+        "border border-red-200 dark:border-red-800",
+    )
+
+
+# ============================================================================
 # MAIN PAGE FUNCTION
 # ============================================================================
 
@@ -460,6 +568,7 @@ def render_creators_page(
     per_page: int = 50,
     total_count: int = 0,
     total_pages: int = 1,
+    is_authenticated: bool = False,
 ) -> Div:
     """
     Analytics-first creator discovery dashboard.
@@ -513,6 +622,8 @@ def render_creators_page(
             filtered_count=total_count,
             has_filters=has_active_filters,
         ),
+        # Add creator section — only visible to authenticated users
+        (render_add_creator_section() if is_authenticated else None),
         # Filter controls (sticky bar)
         _render_filter_bar(
             search=search,

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -448,7 +448,7 @@ def _fetch_pending_jobs(batch_size: int) -> List[Dict]:
         # Jobs with no retry_at scheduled (fresh or first attempt)
         fresh_resp = (
             supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
-            .select("id,creator_id,source,retry_count")
+            .select("id,creator_id,source,retry_count,job_type,input_query")
             .eq("status", JobStatus.PENDING.value)
             .is_("retry_at", "null")
             .order("created_at", desc=False)
@@ -462,7 +462,7 @@ def _fetch_pending_jobs(batch_size: int) -> List[Dict]:
         if len(fresh_jobs) < batch_size:
             retry_resp = (
                 supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
-                .select("id,creator_id,source,retry_count")
+                .select("id,creator_id,source,retry_count,job_type,input_query")
                 .eq("status", JobStatus.PENDING.value)
                 .not_.is_("retry_at", "null")
                 .lte("retry_at", now_iso)
@@ -752,6 +752,148 @@ def _compute_quality_grade(engagement: float, subscribers: int) -> str:
         return "B"
     else:
         return "C"
+
+
+# =============================================================================
+# resolve_and_add job handler
+# =============================================================================
+
+
+async def handle_resolve_and_add_job(
+    job_id: int,
+    input_query: str,
+    job_number: int = 0,
+) -> bool:
+    """
+    Handle a ``job_type='resolve_and_add'`` job submitted by the web frontend.
+
+    This is the first stage of creator addition when the Vercel frontend cannot
+    call the YouTube API directly (bundle-size constraint).  The steps are:
+
+    1. Validate input format (UC channel ID or @handle).
+    2. If @handle, resolve it to a canonical channel ID via YouTube API
+       (uses ``forUsername`` then ``search.list`` fallback — same as seed path,
+       costs 1 quota unit for handles, 0 for UC IDs).
+    3. Check if the creator already exists in the DB (idempotent).
+    4. Upsert a minimal creator stub row.
+    5. Convert this job to ``job_type='sync_stats'`` so the normal
+       ``handle_sync_job`` pipeline picks it up next.
+
+    On permanent failure (channel not found, invalid ID), the job is marked
+    ``failed`` with a user-readable ``error_message`` — no retry scheduled.
+
+    Args:
+        job_id:       ``creator_sync_jobs.id``
+        input_query:  Raw input as stored — "@handle" or "UCxxxxxxxx".
+        job_number:   For logging only.
+
+    Returns:
+        True on success, False on failure.
+    """
+    job_tag = f"[ResolveJob {job_number}:{job_id}]"
+    logger.info("%s ─── Starting resolve_and_add | input=%s", job_tag, input_query)
+
+    if not supabase_client:
+        raise RuntimeError("Supabase client not initialized")
+
+    # STAGE 1: Mark as processing
+    mark_creator_sync_processing(job_id)
+
+    try:
+        # STAGE 2: Determine channel_id
+        if input_query.startswith("UC"):
+            channel_id = input_query
+            logger.info("%s Input is a UC channel ID — skipping handle resolution", job_tag)
+        else:
+            # Strip leading @ for the resolver (it normalises internally)
+            handle_raw = input_query.lstrip("@")
+            logger.info("%s Resolving @%s to channel ID via YouTube API…", job_tag, handle_raw)
+
+            resolved = await asyncio.wait_for(
+                resolver.resolve_handle_to_channel_id(handle_raw),
+                timeout=SYNC_TIMEOUT,
+            )
+            if not resolved:
+                raise ChannelNotFoundException(
+                    f"YouTube could not find a channel for handle '{input_query}'."
+                )
+            channel_id = resolved
+            logger.info("%s Resolved %s → %s", job_tag, input_query, channel_id)
+
+        # STAGE 3: Check if already in DB (race: another worker or the user re-submitted)
+        existing_resp = (
+            supabase_client.table(CREATOR_TABLE)
+            .select("id")
+            .eq("channel_id", channel_id)
+            .limit(1)
+            .execute()
+        )
+        if existing_resp.data:
+            creator_id = existing_resp.data[0]["id"]
+            logger.info(
+                "%s Creator %s already in DB (id=%s) — converting job to sync_stats",
+                job_tag,
+                channel_id,
+                creator_id,
+            )
+        else:
+            # STAGE 4: Insert minimal stub — worker will fill full stats next
+            stub = {
+                "channel_id": channel_id,
+                "channel_name": "Pending sync…",
+                "channel_url": f"https://www.youtube.com/channel/{channel_id}",
+                "current_subscribers": 0,
+                "current_view_count": 0,
+                "current_video_count": 0,
+            }
+            insert_resp = supabase_client.table(CREATOR_TABLE).insert(stub).execute()
+            if not insert_resp.data:
+                raise RuntimeError(f"Failed to insert creator stub for {channel_id}")
+            creator_id = insert_resp.data[0]["id"]
+            logger.info("%s Inserted creator stub id=%s for %s", job_tag, creator_id, channel_id)
+
+        # STAGE 5: Convert this job to sync_stats so the normal pipeline runs it
+        supabase_client.table(CREATOR_SYNC_JOBS_TABLE).update(
+            {
+                "job_type": "sync_stats",
+                "creator_id": creator_id,
+                "status": "pending",
+                "retry_count": 0,
+                "retry_at": None,
+                "error_message": None,
+                "started_at": None,
+            }
+        ).eq("id", job_id).execute()
+
+        logger.info(
+            "%s ✅ Converted job %s to sync_stats for creator %s",
+            job_tag,
+            job_id,
+            creator_id,
+        )
+        return True
+
+    except ChannelNotFoundException as exc:
+        err = str(exc)
+        logger.warning("%s ❌ Channel not found: %s", job_tag, err)
+        mark_creator_sync_failed(job_id, error=err)
+        return False
+
+    except asyncio.TimeoutError:
+        err = f"YouTube API timeout after {SYNC_TIMEOUT}s during handle resolution"
+        logger.warning("%s ❌ %s", job_tag, err)
+        mark_creator_sync_failed(job_id, error=err)
+        return False
+
+    except QuotaExceededException:
+        # Let the outer loop catch this and halt processing
+        raise
+
+    except Exception as exc:
+        err = f"Unexpected error during resolve_and_add: {exc}"
+        logger.exception("%s ❌ %s", job_tag, err)
+        mark_creator_sync_failed(job_id, error=err)
+        return False
 
 
 # =============================================================================
@@ -1518,13 +1660,22 @@ async def process_creator_syncs():
             results = []
             for i, job in enumerate(jobs, 1):
                 try:
-                    result = await asyncio.wait_for(
-                        handle_sync_job(
+                    job_type = job.get("job_type", "sync_stats")
+                    if job_type == "resolve_and_add":
+                        coro = handle_resolve_and_add_job(
+                            job_id=job["id"],
+                            input_query=job.get("input_query", ""),
+                            job_number=i,
+                        )
+                    else:
+                        coro = handle_sync_job(
                             job_id=job["id"],
                             creator_id=job["creator_id"],
                             job_number=i,
                             retry_count=job.get("retry_count", 0),
-                        ),
+                        )
+                    result = await asyncio.wait_for(
+                        coro,
                         timeout=SYNC_TIMEOUT + 30,  # Extra buffer for DB ops
                     )
                     results.append(result)


### PR DESCRIPTION
Implements a fully queue-based creator submission flow that keeps the YouTube API out of the Vercel frontend (bundle-size constraint):

db/migrations/018_creator_add_requests.sql
- Add input_query and requested_by columns to creator_sync_jobs
- Allow creator_id to be NULL for pre-resolution jobs
- Partial unique index: one pending resolve_and_add per input_query
- Index for worker polling and per-user rate-limit lookups

db.py
- queue_creator_add_request(): validates @handle / UC ID format, checks for existing creator, deduplicates pending jobs, enforces per-user rate limit (5/hr), inserts job_type='resolve_and_add'
- get_creator_add_request_status(): status polling helper

worker/creator_worker.py
- handle_resolve_and_add_job(): resolves @handle → channel_id via YouTubeResolver, upserts creator stub, converts job to sync_stats so the normal pipeline takes over; permanent failures marked failed, quota exhaustion propagated to halt worker
- _fetch_pending_jobs(): include job_type and input_query in SELECT
- Dispatch loop: route resolve_and_add jobs to new handler

views/creators.py
- render_add_creator_section(): HTMX form, auth-gated
- render_add_creator_result(): inline success/error/already-tracked card
- render_creators_page(): new is_authenticated param, embeds add section

routes/creators.py
- creator_request_route(): POST /creators/request, reads form q field, calls queue_creator_add_request, returns HTMX partial

main.py
- Register POST /creators/request route
- Pass is_authenticated=bool(sess["auth"]) to creators_route

## Summary by Sourcery

Introduce a queue-based flow for user-submitted creator additions, resolved by a backend worker instead of the frontend calling the YouTube API directly.

New Features:
- Allow authenticated users to submit new creators by YouTube handle or channel ID via an HTMX form on the creators page, gated behind login.
- Add a backend endpoint and DB-backed queue workflow to accept creator add requests, validate input, enforce per-user rate limits, and track request status.
- Extend the worker to process resolve_and_add jobs that resolve handles to channel IDs, upsert creator stubs, and convert jobs into normal sync_stats syncs.

Enhancements:
- Extend creator_sync_jobs schema and indexes to support resolve_and_add jobs, per-user attribution, and efficient worker polling.
- Update creators page routing to pass authentication state so the UI can conditionally render the creator submission section.