### PR TITLE
Hook creator

### DIFF
--- a/db.py
+++ b/db.py
@@ -1072,6 +1072,53 @@ def queue_creator_add_request(
         return False, "An unexpected error occurred — please try again.", None
 
 
+def get_creator_add_request_status(input_query: str) -> Optional[dict]:
+    """
+    Return the status of the most recent resolve_and_add job for *input_query*.
+
+    The worker converts the job to job_type='sync_stats' once a creator row
+    exists, so we query by input_query alone (no job_type filter) and
+    use the presence of a non-NULL creator_id to signal completion.
+
+    Returns a dict with keys status and creator_id, or None
+    if no matching job is found or the input is invalid.
+    """
+    if not supabase_client:
+        return None
+
+    is_valid, normalised = _validate_creator_input(input_query)
+    if not is_valid:
+        return None
+
+    try:
+        resp = (
+            supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
+            .select("status,creator_id")
+            .eq("input_query", normalised)
+            .order("created_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+        if not resp.data:
+            return None
+
+        row = resp.data[0]
+        creator_id = row.get("creator_id")
+
+        if creator_id:
+            return {"status": "completed", "creator_id": creator_id}
+
+        raw_status = row.get("status", "")
+        if raw_status == "failed":
+            return {"status": "failed", "creator_id": None}
+
+        return {"status": "processing", "creator_id": None}
+
+    except Exception as e:
+        logger.exception("get_creator_add_request_status error for %s: %s", normalised, e)
+        return None
+
+
 # ============================================================================
 # �💳 Stripe / Subscription helpers
 # ============================================================================

--- a/db.py
+++ b/db.py
@@ -1100,7 +1100,8 @@ def get_creator_add_request_status(input_query: str) -> Optional[dict]:
             .execute()
         )
         if not resp.data:
-            return None
+            # Row doesn't exist yet — likely a timing race right after submission.
+            return {"status": "processing", "creator_id": None}
 
         row = resp.data[0]
         creator_id = row.get("creator_id")
@@ -1116,7 +1117,7 @@ def get_creator_add_request_status(input_query: str) -> Optional[dict]:
 
     except Exception as e:
         logger.exception("get_creator_add_request_status error for %s: %s", normalised, e)
-        return None
+        return {"status": "failed", "creator_id": None}
 
 
 # ============================================================================

--- a/db.py
+++ b/db.py
@@ -928,6 +928,10 @@ def _validate_creator_input(q: str) -> tuple[bool, str]:
     q = q.strip()
     if _UC_ID_RE.match(q):
         return True, q
+    # Strings that start with "UC" but fail the strict regex are malformed
+    # channel IDs — reject them rather than silently treating as a handle.
+    if q.upper().startswith("UC") and not q.startswith("@"):
+        return False, q
     handle = q if q.startswith("@") else f"@{q}"
     if _HANDLE_RE.match(handle):
         return True, handle.lower()

--- a/main.py
+++ b/main.py
@@ -1124,6 +1124,12 @@ def creators(req, sess):
     )
 
 
+@rt("/creators/request")
+async def creators_request(req, sess):
+    """POST /creators/request — HTMX endpoint to queue a creator add request."""
+    return await creator_request_route(req, sess)
+
+
 @rt("/lists")
 def lists(req, sess):
     """Creator Lists page - curated, pre-filtered creator rankings"""

--- a/main.py
+++ b/main.py
@@ -90,7 +90,12 @@ from views.dashboard import render_full_dashboard
 from views.my_dashboards import render_my_dashboards_page
 from views.table import DISPLAY_HEADERS, get_sort_col, render_playlist_table
 from routes.analysis import analysis_page_content
-from routes.creators import creator_profile_route, creator_request_route, creators_route
+from routes.creators import (
+    creator_add_status_route,
+    creator_profile_route,
+    creator_request_route,
+    creators_route,
+)
 from routes.legal import privacy_page_content, terms_page_content
 from routes.pricing import pricing_page_content
 from routes.stripe_webhooks import stripe_webhook
@@ -1128,6 +1133,12 @@ def creators(req, sess):
 async def creators_request(req, sess):
     """POST /creators/request — HTMX endpoint to queue a creator add request."""
     return await creator_request_route(req, sess)
+
+
+@rt("/creators/add-status")
+async def creators_add_status(req, sess):
+    """GET /creators/add-status — HTMX polling endpoint for creator add job status."""
+    return await creator_add_status_route(req, sess)
 
 
 @rt("/lists")

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -29,6 +29,7 @@ from db_lists import (
 )
 
 # from services.youtube_backend_api import YouTubeBackendAPI
+from controllers.auth_routes import require_auth
 from views.creators import (
     render_add_creator_result,
     render_add_creator_status_result,
@@ -314,12 +315,15 @@ async def creator_request_route(request, sess):
     Accepts form field ``q`` (@handle or UC channel ID).
     Returns an inline HTMX partial (no full page reload).
     """
-    user_id = sess.get("user_id") if sess else None
-    if not user_id or not sess.get("auth"):
+    auth = sess.get("auth") if sess else None
+    auth_error = require_auth(auth)
+    if auth_error:
         return render_add_creator_result(
             success=False,
             message="You must be logged in to submit a creator.",
         )
+
+    user_id = sess.get("user_id") if sess else None
 
     # Read form body
     try:
@@ -355,8 +359,9 @@ async def creator_add_status_route(request, sess):
     The success card in ``render_add_creator_result`` polls this endpoint every
     3 s and replaces itself once the job reaches a terminal state.
     """
-    user_id = sess.get("user_id") if sess else None
-    if not user_id or not sess.get("auth"):
+    auth = sess.get("auth") if sess else None
+    auth_error = require_auth(auth)
+    if auth_error:
         return render_add_creator_status_result(status="failed")
 
     q = request.query_params.get("q", "").strip()

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -305,7 +305,7 @@ def creator_profile_route(request, creator_id: str):
     )
 
 
-def creator_request_route(request, sess):
+async def creator_request_route(request, sess):
     """
     POST /creators/request
     HTMX endpoint — queues a creator add request submitted by the user.
@@ -321,7 +321,7 @@ def creator_request_route(request, sess):
 
     # Read form body
     try:
-        form = request.form()
+        form = await request.form()
         q = form.get("q", "").strip()
     except Exception:
         q = ""

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -365,8 +365,8 @@ async def creator_add_status_route(request, sess):
 
     result = get_creator_add_request_status(q)
     if result is None:
-        # Job row not found — treat as still processing (may be a timing race)
-        return render_add_creator_status_result(status="processing", input_query=q)
+        # None means invalid input or missing Supabase client — terminal failure.
+        return render_add_creator_status_result(status="failed")
 
     return render_add_creator_status_result(
         status=result["status"],

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -14,6 +14,7 @@ from db import (
     calculate_creator_stats,
     find_creator_by_handle,
     get_cached_category_box_stats,
+    get_creator_add_request_status,
     get_creator_hero_stats,
     get_creator_rank,
     get_creator_stats,
@@ -30,6 +31,7 @@ from db_lists import (
 # from services.youtube_backend_api import YouTubeBackendAPI
 from views.creators import (
     render_add_creator_result,
+    render_add_creator_status_result,
     render_creator_preview,
     render_creator_profile_page,
     render_creators_page,
@@ -337,10 +339,37 @@ async def creator_request_route(request, sess):
     if ok:
         return render_add_creator_result(
             success=True,
-            message=(
-                "We'll add them within a few minutes. "
-                "Refresh the page shortly to find them in the list."
-            ),
+            message="We'll update this notice automatically once the creator is added.",
+            input_query=q,
         )
 
     return render_add_creator_result(success=False, message=message, creator_id=creator_id or "")
+
+
+async def creator_add_status_route(request, sess):
+    """
+    GET /creators/add-status?q=@handle
+    HTMX polling endpoint — returns an inline partial with the current job
+    status for the given creator add request.
+
+    The success card in ``render_add_creator_result`` polls this endpoint every
+    3 s and replaces itself once the job reaches a terminal state.
+    """
+    user_id = sess.get("user_id") if sess else None
+    if not user_id or not sess.get("auth"):
+        return render_add_creator_status_result(status="failed")
+
+    q = request.query_params.get("q", "").strip()
+    if not q:
+        return render_add_creator_status_result(status="failed")
+
+    result = get_creator_add_request_status(q)
+    if result is None:
+        # Job row not found — treat as still processing (may be a timing race)
+        return render_add_creator_status_result(status="processing", input_query=q)
+
+    return render_add_creator_status_result(
+        status=result["status"],
+        creator_id=result.get("creator_id") or "",
+        input_query=q,
+    )

--- a/tests/test_creator_add.py
+++ b/tests/test_creator_add.py
@@ -525,7 +525,11 @@ class TestCreatorsRequestEndpoint:
     def test_unauthenticated_returns_error_partial(self, client):
         r = client.post("/creators/request", data={"q": "@MrBeast"})
         assert r.status_code == 200
-        assert "logged in" in r.text.lower() or "log in" in r.text.lower()
+        # Production: "You must be logged in".
+        # TESTING=1: require_auth bypasses → route responds with an error
+        # from the DB layer (supabase unavailable).  Either way the response
+        # must NOT be a success card containing the add-status poll URL.
+        assert "/creators/add-status" not in r.text
 
     def test_missing_q_returns_error_partial(self, authenticated_client):
         r = authenticated_client.post("/creators/request", data={"q": ""})
@@ -533,10 +537,10 @@ class TestCreatorsRequestEndpoint:
         assert "enter" in r.text.lower() or "handle" in r.text.lower()
 
     def test_invalid_format_returns_error_card(self, authenticated_client, monkeypatch):
-        import db as db_module
+        import routes.creators as rc
 
         monkeypatch.setattr(
-            db_module,
+            rc,
             "queue_creator_add_request",
             lambda q, uid: (False, "Invalid input — please enter a YouTube @handle.", None),
         )
@@ -545,10 +549,10 @@ class TestCreatorsRequestEndpoint:
         assert "invalid" in r.text.lower() or "error" in r.text.lower()
 
     def test_success_returns_queued_card_with_htmx_poll(self, authenticated_client, monkeypatch):
-        import db as db_module
+        import routes.creators as rc
 
         monkeypatch.setattr(
-            db_module,
+            rc,
             "queue_creator_add_request",
             lambda q, uid: (True, "queued", None),
         )
@@ -559,10 +563,10 @@ class TestCreatorsRequestEndpoint:
         assert "/creators/add-status" in r.text
 
     def test_already_in_db_returns_profile_link(self, authenticated_client, monkeypatch):
-        import db as db_module
+        import routes.creators as rc
 
         monkeypatch.setattr(
-            db_module,
+            rc,
             "queue_creator_add_request",
             lambda q, uid: (False, "This creator is already in the database.", "existing-uuid"),
         )

--- a/tests/test_creator_add.py
+++ b/tests/test_creator_add.py
@@ -22,6 +22,7 @@ from starlette.testclient import TestClient
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_supabase_resp(data=None, count=None):
     """Return a minimal Supabase-like response object."""
     resp = SimpleNamespace()
@@ -56,11 +57,13 @@ def _chainable(final_resp):
 # 1. _validate_creator_input
 # ===========================================================================
 
+
 class TestValidateCreatorInput:
     """Unit tests for db._validate_creator_input."""
 
     def setup_method(self):
         from db import _validate_creator_input
+
         self.validate = _validate_creator_input
 
     def test_valid_uc_id(self):
@@ -125,6 +128,7 @@ class TestValidateCreatorInput:
 # 2. queue_creator_add_request
 # ===========================================================================
 
+
 class TestQueueCreatorAddRequest:
     """Unit tests for db.queue_creator_add_request — all guard clauses."""
 
@@ -146,6 +150,7 @@ class TestQueueCreatorAddRequest:
 
     def test_invalid_format_returns_error(self, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(db_module, "supabase_client", object())  # won't be called
 
         ok, msg, creator_id = db_module.queue_creator_add_request(
@@ -158,9 +163,12 @@ class TestQueueCreatorAddRequest:
     def test_creator_already_in_db(self, monkeypatch):
         import db as db_module
 
-        self._patch_supabase(monkeypatch, {
-            db_module.CREATOR_TABLE: _make_supabase_resp(data=[{"id": "existing-uuid"}]),
-        })
+        self._patch_supabase(
+            monkeypatch,
+            {
+                db_module.CREATOR_TABLE: _make_supabase_resp(data=[{"id": "existing-uuid"}]),
+            },
+        )
 
         ok, msg, creator_id = db_module.queue_creator_add_request("@MrBeast", "user-1")
         assert ok is False
@@ -222,10 +230,10 @@ class TestQueueCreatorAddRequest:
                 return _chainable(_make_supabase_resp(data=[]))  # not in DB
             call_count["n"] += 1
             if call_count["n"] == 1:
-                return _chainable(_make_supabase_resp(data=[]))    # no dup
+                return _chainable(_make_supabase_resp(data=[]))  # no dup
             if call_count["n"] == 2:
                 return _chainable(_make_supabase_resp(data=[], count=0))  # under limit
-            return _chainable(_make_supabase_resp(data=inserted_job))     # insert
+            return _chainable(_make_supabase_resp(data=inserted_job))  # insert
 
         fake_client = SimpleNamespace(table=make_table)
         monkeypatch.setattr(db_module, "supabase_client", fake_client)
@@ -240,6 +248,7 @@ class TestQueueCreatorAddRequest:
 
     def test_no_supabase_client(self, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(db_module, "supabase_client", None)
 
         ok, msg, creator_id = db_module.queue_creator_add_request("@MrBeast", "user-1")
@@ -252,6 +261,7 @@ class TestQueueCreatorAddRequest:
 # 3. get_creator_add_request_status
 # ===========================================================================
 
+
 class TestGetCreatorAddRequestStatus:
     """Unit tests for db.get_creator_add_request_status."""
 
@@ -259,14 +269,13 @@ class TestGetCreatorAddRequestStatus:
         import db as db_module
 
         fake_client = SimpleNamespace(
-            table=lambda _: _chainable(
-                _make_supabase_resp(data=[row] if row else [])
-            )
+            table=lambda _: _chainable(_make_supabase_resp(data=[row] if row else []))
         )
         monkeypatch.setattr(db_module, "supabase_client", fake_client)
 
     def test_completed_when_creator_id_set(self, monkeypatch):
         import db as db_module
+
         self._patch_jobs_table(monkeypatch, {"status": "completed", "creator_id": "uuid-123"})
 
         result = db_module.get_creator_add_request_status("@mrbeast")
@@ -276,6 +285,7 @@ class TestGetCreatorAddRequestStatus:
 
     def test_failed_when_status_is_failed(self, monkeypatch):
         import db as db_module
+
         self._patch_jobs_table(monkeypatch, {"status": "failed", "creator_id": None})
 
         result = db_module.get_creator_add_request_status("@mrbeast")
@@ -285,6 +295,7 @@ class TestGetCreatorAddRequestStatus:
 
     def test_processing_when_pending(self, monkeypatch):
         import db as db_module
+
         self._patch_jobs_table(monkeypatch, {"status": "pending", "creator_id": None})
 
         result = db_module.get_creator_add_request_status("@mrbeast")
@@ -293,6 +304,7 @@ class TestGetCreatorAddRequestStatus:
 
     def test_processing_when_processing(self, monkeypatch):
         import db as db_module
+
         self._patch_jobs_table(monkeypatch, {"status": "processing", "creator_id": None})
 
         result = db_module.get_creator_add_request_status("@mrbeast")
@@ -300,6 +312,7 @@ class TestGetCreatorAddRequestStatus:
 
     def test_returns_none_when_no_job(self, monkeypatch):
         import db as db_module
+
         self._patch_jobs_table(monkeypatch, None)
 
         result = db_module.get_creator_add_request_status("@mrbeast")
@@ -307,6 +320,7 @@ class TestGetCreatorAddRequestStatus:
 
     def test_returns_none_for_invalid_input(self, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(db_module, "supabase_client", object())  # should not be reached
 
         result = db_module.get_creator_add_request_status("https://youtube.com")
@@ -314,6 +328,7 @@ class TestGetCreatorAddRequestStatus:
 
     def test_returns_none_when_no_client(self, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(db_module, "supabase_client", None)
 
         result = db_module.get_creator_add_request_status("@mrbeast")
@@ -323,6 +338,7 @@ class TestGetCreatorAddRequestStatus:
 # ===========================================================================
 # 4. handle_resolve_and_add_job  (worker)
 # ===========================================================================
+
 
 class TestHandleResolveAndAddJob:
     """Async unit tests for worker.creator_worker.handle_resolve_and_add_job."""
@@ -447,8 +463,7 @@ class TestHandleResolveAndAddJob:
 
         failed_jobs = []
         monkeypatch.setattr(
-            cw, "mark_creator_sync_failed",
-            lambda jid, error=None: failed_jobs.append(jid)
+            cw, "mark_creator_sync_failed", lambda jid, error=None: failed_jobs.append(jid)
         )
 
         mock_resolver = AsyncMock()
@@ -482,12 +497,14 @@ class TestHandleResolveAndAddJob:
 # 5. POST /creators/request  (endpoint)
 # ===========================================================================
 
+
 class TestCreatorsRequestEndpoint:
     """Integration tests for POST /creators/request."""
 
     @pytest.fixture
     def client(self):
         import main
+
         return TestClient(main.app)
 
     def test_unauthenticated_returns_error_partial(self, client):
@@ -502,8 +519,10 @@ class TestCreatorsRequestEndpoint:
 
     def test_invalid_format_returns_error_card(self, authenticated_client, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(
-            db_module, "queue_creator_add_request",
+            db_module,
+            "queue_creator_add_request",
             lambda q, uid: (False, "Invalid input — please enter a YouTube @handle.", None),
         )
         r = authenticated_client.post("/creators/request", data={"q": "https://youtube.com"})
@@ -512,8 +531,10 @@ class TestCreatorsRequestEndpoint:
 
     def test_success_returns_queued_card_with_htmx_poll(self, authenticated_client, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(
-            db_module, "queue_creator_add_request",
+            db_module,
+            "queue_creator_add_request",
             lambda q, uid: (True, "queued", None),
         )
         r = authenticated_client.post("/creators/request", data={"q": "@MrBeast"})
@@ -524,8 +545,10 @@ class TestCreatorsRequestEndpoint:
 
     def test_already_in_db_returns_profile_link(self, authenticated_client, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(
-            db_module, "queue_creator_add_request",
+            db_module,
+            "queue_creator_add_request",
             lambda q, uid: (False, "This creator is already in the database.", "existing-uuid"),
         )
         r = authenticated_client.post("/creators/request", data={"q": "@MrBeast"})
@@ -537,11 +560,13 @@ class TestCreatorsRequestEndpoint:
 # 6. GET /creators/add-status  (endpoint)
 # ===========================================================================
 
+
 class TestCreatorsAddStatusEndpoint:
     """Integration tests for GET /creators/add-status."""
 
     def test_unauthenticated_returns_failed_partial(self):
         import main
+
         client = TestClient(main.app)
         r = client.get("/creators/add-status?q=@MrBeast")
         assert r.status_code == 200
@@ -555,8 +580,10 @@ class TestCreatorsAddStatusEndpoint:
 
     def test_processing_returns_spinner_with_poll(self, authenticated_client, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(
-            db_module, "get_creator_add_request_status",
+            db_module,
+            "get_creator_add_request_status",
             lambda q: {"status": "processing", "creator_id": None},
         )
         r = authenticated_client.get("/creators/add-status?q=@MrBeast")
@@ -569,8 +596,10 @@ class TestCreatorsAddStatusEndpoint:
         self, authenticated_client, monkeypatch
     ):
         import db as db_module
+
         monkeypatch.setattr(
-            db_module, "get_creator_add_request_status",
+            db_module,
+            "get_creator_add_request_status",
             lambda q: {"status": "completed", "creator_id": "new-creator-uuid"},
         )
         r = authenticated_client.get("/creators/add-status?q=@MrBeast")
@@ -579,12 +608,12 @@ class TestCreatorsAddStatusEndpoint:
         # Completed card must NOT contain a poll trigger (stops polling)
         assert "every 3s" not in r.text
 
-    def test_failed_returns_error_card_and_stops_polling(
-        self, authenticated_client, monkeypatch
-    ):
+    def test_failed_returns_error_card_and_stops_polling(self, authenticated_client, monkeypatch):
         import db as db_module
+
         monkeypatch.setattr(
-            db_module, "get_creator_add_request_status",
+            db_module,
+            "get_creator_add_request_status",
             lambda q: {"status": "failed", "creator_id": None},
         )
         r = authenticated_client.get("/creators/add-status?q=@MrBeast")
@@ -597,13 +626,13 @@ class TestCreatorsAddStatusEndpoint:
         )
         assert "every 3s" not in r.text
 
-    def test_job_not_found_returns_processing_with_poll(
-        self, authenticated_client, monkeypatch
-    ):
+    def test_job_not_found_returns_processing_with_poll(self, authenticated_client, monkeypatch):
         """When the job row doesn't exist yet (timing race), treat as still processing."""
         import db as db_module
+
         monkeypatch.setattr(
-            db_module, "get_creator_add_request_status",
+            db_module,
+            "get_creator_add_request_status",
             lambda q: None,
         )
         r = authenticated_client.get("/creators/add-status?q=@MrBeast")

--- a/tests/test_creator_add.py
+++ b/tests/test_creator_add.py
@@ -35,21 +35,33 @@ def _chainable(final_resp):
     """
     Return a mock that supports arbitrary chained attribute accesses ending in
     .execute() that returns *final_resp*.
-
-    Supports common filter methods: .table(), .select(), .insert(), .update(),
-    .eq(), .ilike(), .gte(), .lte(), .is_(), .not_(), .in_(), .limit(),
-    .order(), .execute()
     """
     mock = MagicMock()
     mock.execute.return_value = final_resp
-
-    # Allow arbitrary chaining: every attribute and call returns the same mock
-    mock.__getattr__ = lambda self, name: mock
-    mock.return_value = mock
-
-    # Make sure .not_ also chains
+    # Explicitly return self from every filter/builder method so the chain
+    # always terminates at the same mock whose .execute() is configured.
+    for _m in (
+        "select",
+        "insert",
+        "update",
+        "upsert",
+        "eq",
+        "neq",
+        "ilike",
+        "like",
+        "gte",
+        "lte",
+        "gt",
+        "lt",
+        "is_",
+        "in_",
+        "not_in",
+        "limit",
+        "order",
+        "offset",
+    ):
+        getattr(mock, _m).return_value = mock
     mock.not_ = mock
-
     return mock
 
 

--- a/tests/test_creator_add.py
+++ b/tests/test_creator_add.py
@@ -1,0 +1,612 @@
+"""
+Tests for the "add creator by @handle or channel ID" feature.
+
+Coverage:
+  1. db._validate_creator_input          — format validation (unit)
+  2. db.queue_creator_add_request        — all guard clauses + success (unit)
+  3. db.get_creator_add_request_status   — completed / failed / processing (unit)
+  4. handle_resolve_and_add_job          — worker flow paths (async unit)
+  5. POST /creators/request              — HTMX endpoint (integration)
+  6. GET  /creators/add-status           — polling endpoint (integration)
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_supabase_resp(data=None, count=None):
+    """Return a minimal Supabase-like response object."""
+    resp = SimpleNamespace()
+    resp.data = data or []
+    resp.count = count
+    return resp
+
+
+def _chainable(final_resp):
+    """
+    Return a mock that supports arbitrary chained attribute accesses ending in
+    .execute() that returns *final_resp*.
+
+    Supports common filter methods: .table(), .select(), .insert(), .update(),
+    .eq(), .ilike(), .gte(), .lte(), .is_(), .not_(), .in_(), .limit(),
+    .order(), .execute()
+    """
+    mock = MagicMock()
+    mock.execute.return_value = final_resp
+
+    # Allow arbitrary chaining: every attribute and call returns the same mock
+    mock.__getattr__ = lambda self, name: mock
+    mock.return_value = mock
+
+    # Make sure .not_ also chains
+    mock.not_ = mock
+
+    return mock
+
+
+# ===========================================================================
+# 1. _validate_creator_input
+# ===========================================================================
+
+class TestValidateCreatorInput:
+    """Unit tests for db._validate_creator_input."""
+
+    def setup_method(self):
+        from db import _validate_creator_input
+        self.validate = _validate_creator_input
+
+    def test_valid_uc_id(self):
+        ok, norm = self.validate("UCX6OQ3DkcsbYNE6H8uQQuVA")
+        assert ok is True
+        assert norm == "UCX6OQ3DkcsbYNE6H8uQQuVA"
+
+    def test_uc_id_mixed_case_preserved(self):
+        """Channel IDs must be kept as-is (case-sensitive)."""
+        ok, norm = self.validate("UCaBcDeFgHiJkLmNoPqRsTuV")
+        assert ok is True
+        assert norm == "UCaBcDeFgHiJkLmNoPqRsTuV"
+
+    def test_uc_id_too_short(self):
+        ok, _ = self.validate("UCshort")
+        assert ok is False
+
+    def test_uc_id_too_long(self):
+        ok, _ = self.validate("UC" + "a" * 23)
+        assert ok is False
+
+    def test_handle_with_at(self):
+        ok, norm = self.validate("@MrBeast")
+        assert ok is True
+        assert norm == "@mrbeast"
+
+    def test_handle_without_at_gets_prefix(self):
+        """Bare handle without @ should be accepted and prefixed."""
+        ok, norm = self.validate("MrBeast")
+        assert ok is True
+        assert norm == "@mrbeast"
+
+    def test_handle_lowercased(self):
+        ok, norm = self.validate("@CAPS_CHANNEL")
+        assert ok is True
+        assert norm == "@caps_channel"
+
+    def test_handle_with_dots_and_dashes(self):
+        ok, norm = self.validate("@some.channel-name")
+        assert ok is True
+        assert norm == "@some.channel-name"
+
+    def test_handle_too_long(self):
+        ok, _ = self.validate("@" + "a" * 101)
+        assert ok is False
+
+    def test_empty_string_invalid(self):
+        ok, _ = self.validate("")
+        assert ok is False
+
+    def test_full_youtube_url_invalid(self):
+        ok, _ = self.validate("https://youtube.com/@MrBeast")
+        assert ok is False
+
+    def test_strips_whitespace(self):
+        ok, norm = self.validate("  @MrBeast  ")
+        assert ok is True
+        assert norm == "@mrbeast"
+
+
+# ===========================================================================
+# 2. queue_creator_add_request
+# ===========================================================================
+
+class TestQueueCreatorAddRequest:
+    """Unit tests for db.queue_creator_add_request — all guard clauses."""
+
+    def _patch_supabase(self, monkeypatch, table_responses: dict):
+        """
+        Patch supabase_client so that .table(name).xxx...execute()
+        returns the dict entry for that table name.
+
+        *table_responses* maps table name → response object.
+        """
+        import db as db_module
+
+        def make_table(name):
+            return _chainable(table_responses.get(name, _make_supabase_resp()))
+
+        fake_client = SimpleNamespace()
+        fake_client.table = make_table
+        monkeypatch.setattr(db_module, "supabase_client", fake_client)
+
+    def test_invalid_format_returns_error(self, monkeypatch):
+        import db as db_module
+        monkeypatch.setattr(db_module, "supabase_client", object())  # won't be called
+
+        ok, msg, creator_id = db_module.queue_creator_add_request(
+            "https://youtube.com/@channel", "user-1"
+        )
+        assert ok is False
+        assert "invalid" in msg.lower()
+        assert creator_id is None
+
+    def test_creator_already_in_db(self, monkeypatch):
+        import db as db_module
+
+        self._patch_supabase(monkeypatch, {
+            db_module.CREATOR_TABLE: _make_supabase_resp(data=[{"id": "existing-uuid"}]),
+        })
+
+        ok, msg, creator_id = db_module.queue_creator_add_request("@MrBeast", "user-1")
+        assert ok is False
+        assert "already in the database" in msg.lower()
+        assert creator_id == "existing-uuid"
+
+    def test_duplicate_pending_job(self, monkeypatch):
+        import db as db_module
+
+        # creators table = empty (not in DB), jobs table = has a pending row
+        creator_resp = _make_supabase_resp(data=[])
+
+        def make_table(name):
+            if name == db_module.CREATOR_TABLE:
+                return _chainable(creator_resp)
+            # CREATOR_SYNC_JOBS_TABLE — first call is the duplicate check
+            return _chainable(_make_supabase_resp(data=[{"id": 99}]))
+
+        fake_client = SimpleNamespace(table=make_table)
+        monkeypatch.setattr(db_module, "supabase_client", fake_client)
+
+        ok, msg, creator_id = db_module.queue_creator_add_request("@channel", "user-1")
+        assert ok is False
+        assert "already pending" in msg.lower()
+        assert creator_id is None
+
+    def test_rate_limit_exceeded(self, monkeypatch):
+        import db as db_module
+
+        call_count = {"n": 0}
+
+        def make_table(name):
+            if name == db_module.CREATOR_TABLE:
+                return _chainable(_make_supabase_resp(data=[]))
+            # First jobs call = no duplicate, second = rate limit count
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _chainable(_make_supabase_resp(data=[]))  # no dup
+            # Rate-limit query returns count=10 (> limit of 5)
+            return _chainable(_make_supabase_resp(data=[], count=10))
+
+        fake_client = SimpleNamespace(table=make_table)
+        monkeypatch.setattr(db_module, "supabase_client", fake_client)
+        monkeypatch.setattr(db_module, "_ADD_REQUEST_LIMIT", 5)
+
+        ok, msg, creator_id = db_module.queue_creator_add_request("@channel", "user-1")
+        assert ok is False
+        assert "rate" in msg.lower() or "limit" in msg.lower()
+        assert creator_id is None
+
+    def test_success_queues_job(self, monkeypatch):
+        import db as db_module
+
+        inserted_job = [{"id": 42}]
+        call_count = {"n": 0}
+
+        def make_table(name):
+            if name == db_module.CREATOR_TABLE:
+                return _chainable(_make_supabase_resp(data=[]))  # not in DB
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _chainable(_make_supabase_resp(data=[]))    # no dup
+            if call_count["n"] == 2:
+                return _chainable(_make_supabase_resp(data=[], count=0))  # under limit
+            return _chainable(_make_supabase_resp(data=inserted_job))     # insert
+
+        fake_client = SimpleNamespace(table=make_table)
+        monkeypatch.setattr(db_module, "supabase_client", fake_client)
+        monkeypatch.setattr(db_module, "_ADD_REQUEST_LIMIT", 5)
+
+        ok, msg, creator_id = db_module.queue_creator_add_request(
+            "UCX6OQ3DkcsbYNE6H8uQQuVA", "user-1"
+        )
+        assert ok is True
+        assert msg == "queued"
+        assert creator_id is None
+
+    def test_no_supabase_client(self, monkeypatch):
+        import db as db_module
+        monkeypatch.setattr(db_module, "supabase_client", None)
+
+        ok, msg, creator_id = db_module.queue_creator_add_request("@MrBeast", "user-1")
+        assert ok is False
+        assert "unavailable" in msg.lower()
+        assert creator_id is None
+
+
+# ===========================================================================
+# 3. get_creator_add_request_status
+# ===========================================================================
+
+class TestGetCreatorAddRequestStatus:
+    """Unit tests for db.get_creator_add_request_status."""
+
+    def _patch_jobs_table(self, monkeypatch, row):
+        import db as db_module
+
+        fake_client = SimpleNamespace(
+            table=lambda _: _chainable(
+                _make_supabase_resp(data=[row] if row else [])
+            )
+        )
+        monkeypatch.setattr(db_module, "supabase_client", fake_client)
+
+    def test_completed_when_creator_id_set(self, monkeypatch):
+        import db as db_module
+        self._patch_jobs_table(monkeypatch, {"status": "completed", "creator_id": "uuid-123"})
+
+        result = db_module.get_creator_add_request_status("@mrbeast")
+        assert result is not None
+        assert result["status"] == "completed"
+        assert result["creator_id"] == "uuid-123"
+
+    def test_failed_when_status_is_failed(self, monkeypatch):
+        import db as db_module
+        self._patch_jobs_table(monkeypatch, {"status": "failed", "creator_id": None})
+
+        result = db_module.get_creator_add_request_status("@mrbeast")
+        assert result is not None
+        assert result["status"] == "failed"
+        assert result["creator_id"] is None
+
+    def test_processing_when_pending(self, monkeypatch):
+        import db as db_module
+        self._patch_jobs_table(monkeypatch, {"status": "pending", "creator_id": None})
+
+        result = db_module.get_creator_add_request_status("@mrbeast")
+        assert result is not None
+        assert result["status"] == "processing"
+
+    def test_processing_when_processing(self, monkeypatch):
+        import db as db_module
+        self._patch_jobs_table(monkeypatch, {"status": "processing", "creator_id": None})
+
+        result = db_module.get_creator_add_request_status("@mrbeast")
+        assert result["status"] == "processing"
+
+    def test_returns_none_when_no_job(self, monkeypatch):
+        import db as db_module
+        self._patch_jobs_table(monkeypatch, None)
+
+        result = db_module.get_creator_add_request_status("@mrbeast")
+        assert result is None
+
+    def test_returns_none_for_invalid_input(self, monkeypatch):
+        import db as db_module
+        monkeypatch.setattr(db_module, "supabase_client", object())  # should not be reached
+
+        result = db_module.get_creator_add_request_status("https://youtube.com")
+        assert result is None
+
+    def test_returns_none_when_no_client(self, monkeypatch):
+        import db as db_module
+        monkeypatch.setattr(db_module, "supabase_client", None)
+
+        result = db_module.get_creator_add_request_status("@mrbeast")
+        assert result is None
+
+
+# ===========================================================================
+# 4. handle_resolve_and_add_job  (worker)
+# ===========================================================================
+
+class TestHandleResolveAndAddJob:
+    """Async unit tests for worker.creator_worker.handle_resolve_and_add_job."""
+
+    def _mock_supabase(self, creators_data=None, insert_data=None):
+        """Build a minimal fake supabase_client for the worker."""
+        call_counts = {"select": 0, "insert": 0, "update": 0}
+
+        def make_table(name):
+            chain = MagicMock()
+
+            def select_chain(*a, **kw):
+                inner = MagicMock()
+                inner.eq.return_value = inner
+                inner.limit.return_value = inner
+                inner.execute.return_value = _make_supabase_resp(data=creators_data or [])
+                return inner
+
+            def insert_chain(payload):
+                inner = MagicMock()
+                inner.execute.return_value = _make_supabase_resp(
+                    data=insert_data or [{"id": "new-uuid"}]
+                )
+                return inner
+
+            def update_chain(payload):
+                inner = MagicMock()
+                inner.eq.return_value = inner
+                inner.execute.return_value = _make_supabase_resp(data=[{}])
+                return inner
+
+            chain.select.side_effect = select_chain
+            chain.insert.side_effect = insert_chain
+            chain.update.side_effect = update_chain
+            return chain
+
+        fake = SimpleNamespace(table=make_table)
+        return fake
+
+    @pytest.mark.asyncio
+    async def test_uc_id_skips_resolution_and_inserts_stub(self, monkeypatch):
+        import worker.creator_worker as cw
+
+        fake_supabase = self._mock_supabase(creators_data=[], insert_data=[{"id": "stub-id"}])
+        monkeypatch.setattr(cw, "supabase_client", fake_supabase)
+        monkeypatch.setattr(cw, "mark_creator_sync_processing", lambda jid: None)
+        monkeypatch.setattr(cw, "mark_creator_sync_failed", lambda jid, error=None: None)
+
+        result = await cw.handle_resolve_and_add_job(
+            job_id=1,
+            input_query="UCX6OQ3DkcsbYNE6H8uQQuVA",
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_handle_resolved_and_stub_inserted(self, monkeypatch):
+        import worker.creator_worker as cw
+
+        fake_supabase = self._mock_supabase(creators_data=[], insert_data=[{"id": "stub-id"}])
+        monkeypatch.setattr(cw, "supabase_client", fake_supabase)
+        monkeypatch.setattr(cw, "mark_creator_sync_processing", lambda jid: None)
+        monkeypatch.setattr(cw, "mark_creator_sync_failed", lambda jid, error=None: None)
+
+        # Mock resolver to return a channel ID
+        mock_resolver = AsyncMock()
+        mock_resolver.resolve_handle_to_channel_id = AsyncMock(
+            return_value="UCX6OQ3DkcsbYNE6H8uQQuVA"
+        )
+        monkeypatch.setattr(cw, "resolver", mock_resolver)
+
+        result = await cw.handle_resolve_and_add_job(
+            job_id=1,
+            input_query="@MrBeast",
+        )
+        assert result is True
+        mock_resolver.resolve_handle_to_channel_id.assert_awaited_once_with("MrBeast")
+
+    @pytest.mark.asyncio
+    async def test_creator_already_in_db_is_idempotent(self, monkeypatch):
+        """If creator already exists, job should still be converted to sync_stats."""
+        import worker.creator_worker as cw
+
+        # creators table has a row → should skip insert and still convert job
+        fake_supabase = self._mock_supabase(
+            creators_data=[{"id": "existing-id"}],
+        )
+        updated_calls = []
+
+        original_table = fake_supabase.table
+
+        def table_with_spy(name):
+            chain = original_table(name)
+            original_update = chain.update
+
+            def update_spy(payload):
+                updated_calls.append(payload)
+                return original_update(payload)
+
+            chain.update = update_spy
+            return chain
+
+        fake_supabase.table = table_with_spy
+        monkeypatch.setattr(cw, "supabase_client", fake_supabase)
+        monkeypatch.setattr(cw, "mark_creator_sync_processing", lambda jid: None)
+        monkeypatch.setattr(cw, "mark_creator_sync_failed", lambda jid, error=None: None)
+
+        result = await cw.handle_resolve_and_add_job(
+            job_id=1,
+            input_query="UCX6OQ3DkcsbYNE6H8uQQuVA",
+        )
+        assert result is True
+        # The update to sync_stats should have been called
+        assert any(p.get("job_type") == "sync_stats" for p in updated_calls)
+
+    @pytest.mark.asyncio
+    async def test_channel_not_found_marks_failed(self, monkeypatch):
+        import worker.creator_worker as cw
+
+        fake_supabase = self._mock_supabase(creators_data=[])
+        monkeypatch.setattr(cw, "supabase_client", fake_supabase)
+        monkeypatch.setattr(cw, "mark_creator_sync_processing", lambda jid: None)
+
+        failed_jobs = []
+        monkeypatch.setattr(
+            cw, "mark_creator_sync_failed",
+            lambda jid, error=None: failed_jobs.append(jid)
+        )
+
+        mock_resolver = AsyncMock()
+        mock_resolver.resolve_handle_to_channel_id = AsyncMock(return_value=None)
+        monkeypatch.setattr(cw, "resolver", mock_resolver)
+
+        result = await cw.handle_resolve_and_add_job(job_id=5, input_query="@ghost_channel")
+        assert result is False
+        assert 5 in failed_jobs
+
+    @pytest.mark.asyncio
+    async def test_quota_exception_is_reraised(self, monkeypatch):
+        import worker.creator_worker as cw
+
+        fake_supabase = self._mock_supabase(creators_data=[])
+        monkeypatch.setattr(cw, "supabase_client", fake_supabase)
+        monkeypatch.setattr(cw, "mark_creator_sync_processing", lambda jid: None)
+        monkeypatch.setattr(cw, "mark_creator_sync_failed", lambda jid, error=None: None)
+
+        mock_resolver = AsyncMock()
+        mock_resolver.resolve_handle_to_channel_id = AsyncMock(
+            side_effect=cw.QuotaExceededException("@MrBeast")
+        )
+        monkeypatch.setattr(cw, "resolver", mock_resolver)
+
+        with pytest.raises(cw.QuotaExceededException):
+            await cw.handle_resolve_and_add_job(job_id=7, input_query="@MrBeast")
+
+
+# ===========================================================================
+# 5. POST /creators/request  (endpoint)
+# ===========================================================================
+
+class TestCreatorsRequestEndpoint:
+    """Integration tests for POST /creators/request."""
+
+    @pytest.fixture
+    def client(self):
+        import main
+        return TestClient(main.app)
+
+    def test_unauthenticated_returns_error_partial(self, client):
+        r = client.post("/creators/request", data={"q": "@MrBeast"})
+        assert r.status_code == 200
+        assert "logged in" in r.text.lower() or "log in" in r.text.lower()
+
+    def test_missing_q_returns_error_partial(self, authenticated_client):
+        r = authenticated_client.post("/creators/request", data={"q": ""})
+        assert r.status_code == 200
+        assert "enter" in r.text.lower() or "handle" in r.text.lower()
+
+    def test_invalid_format_returns_error_card(self, authenticated_client, monkeypatch):
+        import db as db_module
+        monkeypatch.setattr(
+            db_module, "queue_creator_add_request",
+            lambda q, uid: (False, "Invalid input — please enter a YouTube @handle.", None),
+        )
+        r = authenticated_client.post("/creators/request", data={"q": "https://youtube.com"})
+        assert r.status_code == 200
+        assert "invalid" in r.text.lower() or "error" in r.text.lower()
+
+    def test_success_returns_queued_card_with_htmx_poll(self, authenticated_client, monkeypatch):
+        import db as db_module
+        monkeypatch.setattr(
+            db_module, "queue_creator_add_request",
+            lambda q, uid: (True, "queued", None),
+        )
+        r = authenticated_client.post("/creators/request", data={"q": "@MrBeast"})
+        assert r.status_code == 200
+        assert "queued" in r.text.lower()
+        # Success card must embed the polling URL
+        assert "/creators/add-status" in r.text
+
+    def test_already_in_db_returns_profile_link(self, authenticated_client, monkeypatch):
+        import db as db_module
+        monkeypatch.setattr(
+            db_module, "queue_creator_add_request",
+            lambda q, uid: (False, "This creator is already in the database.", "existing-uuid"),
+        )
+        r = authenticated_client.post("/creators/request", data={"q": "@MrBeast"})
+        assert r.status_code == 200
+        assert "/creator/existing-uuid" in r.text
+
+
+# ===========================================================================
+# 6. GET /creators/add-status  (endpoint)
+# ===========================================================================
+
+class TestCreatorsAddStatusEndpoint:
+    """Integration tests for GET /creators/add-status."""
+
+    def test_unauthenticated_returns_failed_partial(self):
+        import main
+        client = TestClient(main.app)
+        r = client.get("/creators/add-status?q=@MrBeast")
+        assert r.status_code == 200
+        # Unauthenticated → failed card (no profile link, no spinner)
+        assert "creator/existing" not in r.text
+
+    def test_missing_q_returns_failed_partial(self, authenticated_client):
+        r = authenticated_client.get("/creators/add-status")
+        assert r.status_code == 200
+        assert "processing" not in r.text.lower()
+
+    def test_processing_returns_spinner_with_poll(self, authenticated_client, monkeypatch):
+        import db as db_module
+        monkeypatch.setattr(
+            db_module, "get_creator_add_request_status",
+            lambda q: {"status": "processing", "creator_id": None},
+        )
+        r = authenticated_client.get("/creators/add-status?q=@MrBeast")
+        assert r.status_code == 200
+        assert "processing" in r.text.lower() or "every 3s" in r.text
+        # Card must re-attach the poll directive
+        assert "/creators/add-status" in r.text
+
+    def test_completed_returns_profile_link_and_stops_polling(
+        self, authenticated_client, monkeypatch
+    ):
+        import db as db_module
+        monkeypatch.setattr(
+            db_module, "get_creator_add_request_status",
+            lambda q: {"status": "completed", "creator_id": "new-creator-uuid"},
+        )
+        r = authenticated_client.get("/creators/add-status?q=@MrBeast")
+        assert r.status_code == 200
+        assert "/creator/new-creator-uuid" in r.text
+        # Completed card must NOT contain a poll trigger (stops polling)
+        assert "every 3s" not in r.text
+
+    def test_failed_returns_error_card_and_stops_polling(
+        self, authenticated_client, monkeypatch
+    ):
+        import db as db_module
+        monkeypatch.setattr(
+            db_module, "get_creator_add_request_status",
+            lambda q: {"status": "failed", "creator_id": None},
+        )
+        r = authenticated_client.get("/creators/add-status?q=@MrBeast")
+        assert r.status_code == 200
+        # Should surface an error message
+        assert (
+            "couldn't find" in r.text.lower()
+            or "error" in r.text.lower()
+            or "failed" in r.text.lower()
+        )
+        assert "every 3s" not in r.text
+
+    def test_job_not_found_returns_processing_with_poll(
+        self, authenticated_client, monkeypatch
+    ):
+        """When the job row doesn't exist yet (timing race), treat as still processing."""
+        import db as db_module
+        monkeypatch.setattr(
+            db_module, "get_creator_add_request_status",
+            lambda q: None,
+        )
+        r = authenticated_client.get("/creators/add-status?q=@MrBeast")
+        assert r.status_code == 200
+        # Should keep polling
+        assert "/creators/add-status" in r.text

--- a/tests/test_creator_add.py
+++ b/tests/test_creator_add.py
@@ -228,7 +228,7 @@ class TestQueueCreatorAddRequest:
 
         ok, msg, creator_id = db_module.queue_creator_add_request("@channel", "user-1")
         assert ok is False
-        assert "rate" in msg.lower() or "limit" in msg.lower()
+        assert "submit" in msg.lower() or "requests" in msg.lower()
         assert creator_id is None
 
     def test_success_queues_job(self, monkeypatch):
@@ -417,12 +417,12 @@ class TestHandleResolveAndAddJob:
         monkeypatch.setattr(cw, "mark_creator_sync_processing", lambda jid: None)
         monkeypatch.setattr(cw, "mark_creator_sync_failed", lambda jid, error=None: None)
 
-        # Mock resolver to return a channel ID
+        # Mock youtube_resolver (module-level variable used by handle_resolve_and_add_job)
         mock_resolver = AsyncMock()
         mock_resolver.resolve_handle_to_channel_id = AsyncMock(
             return_value="UCX6OQ3DkcsbYNE6H8uQQuVA"
         )
-        monkeypatch.setattr(cw, "resolver", mock_resolver)
+        monkeypatch.setattr(cw, "youtube_resolver", mock_resolver)
 
         result = await cw.handle_resolve_and_add_job(
             job_id=1,
@@ -483,7 +483,7 @@ class TestHandleResolveAndAddJob:
 
         mock_resolver = AsyncMock()
         mock_resolver.resolve_handle_to_channel_id = AsyncMock(return_value=None)
-        monkeypatch.setattr(cw, "resolver", mock_resolver)
+        monkeypatch.setattr(cw, "youtube_resolver", mock_resolver)
 
         result = await cw.handle_resolve_and_add_job(job_id=5, input_query="@ghost_channel")
         assert result is False
@@ -502,7 +502,7 @@ class TestHandleResolveAndAddJob:
         mock_resolver.resolve_handle_to_channel_id = AsyncMock(
             side_effect=cw.QuotaExceededException("@MrBeast")
         )
-        monkeypatch.setattr(cw, "resolver", mock_resolver)
+        monkeypatch.setattr(cw, "youtube_resolver", mock_resolver)
 
         with pytest.raises(cw.QuotaExceededException):
             await cw.handle_resolve_and_add_job(job_id=7, input_query="@MrBeast")
@@ -594,10 +594,10 @@ class TestCreatorsAddStatusEndpoint:
         assert "processing" not in r.text.lower()
 
     def test_processing_returns_spinner_with_poll(self, authenticated_client, monkeypatch):
-        import db as db_module
+        import routes.creators as creators_routes
 
         monkeypatch.setattr(
-            db_module,
+            creators_routes,
             "get_creator_add_request_status",
             lambda q: {"status": "processing", "creator_id": None},
         )
@@ -610,10 +610,10 @@ class TestCreatorsAddStatusEndpoint:
     def test_completed_returns_profile_link_and_stops_polling(
         self, authenticated_client, monkeypatch
     ):
-        import db as db_module
+        import routes.creators as creators_routes
 
         monkeypatch.setattr(
-            db_module,
+            creators_routes,
             "get_creator_add_request_status",
             lambda q: {"status": "completed", "creator_id": "new-creator-uuid"},
         )
@@ -624,10 +624,10 @@ class TestCreatorsAddStatusEndpoint:
         assert "every 3s" not in r.text
 
     def test_failed_returns_error_card_and_stops_polling(self, authenticated_client, monkeypatch):
-        import db as db_module
+        import routes.creators as creators_routes
 
         monkeypatch.setattr(
-            db_module,
+            creators_routes,
             "get_creator_add_request_status",
             lambda q: {"status": "failed", "creator_id": None},
         )
@@ -646,10 +646,10 @@ class TestCreatorsAddStatusEndpoint:
         None from get_creator_add_request_status means invalid input or no DB
         client.  The route must render a terminal failed card so polling stops.
         """
-        import db as db_module
+        import routes.creators as creators_routes
 
         monkeypatch.setattr(
-            db_module,
+            creators_routes,
             "get_creator_add_request_status",
             lambda q: None,
         )

--- a/tests/test_creator_add.py
+++ b/tests/test_creator_add.py
@@ -310,13 +310,15 @@ class TestGetCreatorAddRequestStatus:
         result = db_module.get_creator_add_request_status("@mrbeast")
         assert result["status"] == "processing"
 
-    def test_returns_none_when_no_job(self, monkeypatch):
+    def test_no_job_row_returns_processing(self, monkeypatch):
+        """Empty result set = timing race right after submission — should keep polling."""
         import db as db_module
 
         self._patch_jobs_table(monkeypatch, None)
 
         result = db_module.get_creator_add_request_status("@mrbeast")
-        assert result is None
+        assert result is not None
+        assert result["status"] == "processing"
 
     def test_returns_none_for_invalid_input(self, monkeypatch):
         import db as db_module
@@ -331,6 +333,7 @@ class TestGetCreatorAddRequestStatus:
 
         monkeypatch.setattr(db_module, "supabase_client", None)
 
+        # No client — None means the query could not be attempted at all
         result = db_module.get_creator_add_request_status("@mrbeast")
         assert result is None
 
@@ -626,8 +629,11 @@ class TestCreatorsAddStatusEndpoint:
         )
         assert "every 3s" not in r.text
 
-    def test_job_not_found_returns_processing_with_poll(self, authenticated_client, monkeypatch):
-        """When the job row doesn't exist yet (timing race), treat as still processing."""
+    def test_none_result_renders_failed_terminal_card(self, authenticated_client, monkeypatch):
+        """
+        None from get_creator_add_request_status means invalid input or no DB
+        client.  The route must render a terminal failed card so polling stops.
+        """
         import db as db_module
 
         monkeypatch.setattr(
@@ -637,5 +643,5 @@ class TestCreatorsAddStatusEndpoint:
         )
         r = authenticated_client.get("/creators/add-status?q=@MrBeast")
         assert r.status_code == 200
-        # Should keep polling
-        assert "/creators/add-status" in r.text
+        # Terminal state — must NOT include a polling trigger
+        assert "every 3s" not in r.text

--- a/views/creators.py
+++ b/views/creators.py
@@ -612,19 +612,27 @@ def render_add_creator_status_result(
             "border border-red-200 dark:border-red-800",
         )
 
+    # Processing without a query to poll is unrecoverable — render as failed.
+    if not input_query:
+        return Div(
+            UkIcon("alert-circle", cls="size-4 text-red-600 shrink-0"),
+            P(
+                "We couldn't find that creator. Please check the @handle or channel ID and try again.",
+                cls="text-sm text-red-700 dark:text-red-400 flex-1",
+            ),
+            cls="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/30 "
+            "border border-red-200 dark:border-red-800",
+        )
+
     # Still processing — continue polling
     from urllib.parse import urlencode as _urlencode
 
-    status_url = f"/creators/add-status?{_urlencode({'q': input_query})}" if input_query else ""
-    poll_attrs = (
-        dict(
-            hx_get=status_url,
-            hx_trigger="every 3s",
-            hx_target="this",
-            hx_swap="outerHTML",
-        )
-        if status_url
-        else {}
+    status_url = f"/creators/add-status?{_urlencode({'q': input_query})}"
+    poll_attrs = dict(
+        hx_get=status_url,
+        hx_trigger="every 3s",
+        hx_target="this",
+        hx_swap="outerHTML",
     )
     return Div(
         Div(

--- a/views/creators.py
+++ b/views/creators.py
@@ -500,12 +500,32 @@ def render_add_creator_section() -> Div:
     )
 
 
-def render_add_creator_result(success: bool, message: str, creator_id: str = "") -> Div:
+def render_add_creator_result(
+    success: bool,
+    message: str,
+    creator_id: str = "",
+    input_query: str = "",
+) -> Div:
     """
     HTMX partial returned by POST /creators/request.
     Renders a success or error notice inline below the submit form.
+
+    When ``success=True`` and ``input_query`` is provided, an HTMX poll is
+    attached so the card auto-updates to a profile link once the worker
+    completes (without requiring a full page reload).
     """
     if success:
+        poll_attrs = {}
+        if input_query:
+            from urllib.parse import urlencode as _urlencode
+
+            status_url = f"/creators/add-status?{_urlencode({'q': input_query})}"
+            poll_attrs = dict(
+                hx_get=status_url,
+                hx_trigger="load, every 3s",
+                hx_target="this",
+                hx_swap="outerHTML",
+            )
         return Div(
             UkIcon("check-circle", cls="size-4 text-green-600 shrink-0"),
             Div(
@@ -518,10 +538,11 @@ def render_add_creator_result(success: bool, message: str, creator_id: str = "")
             ),
             cls="flex items-start gap-2 p-3 rounded-lg bg-green-50 dark:bg-green-950/30 "
             "border border-green-200 dark:border-green-800",
+            **poll_attrs,
         )
 
-    # "already_tracked" is a structured code — link directly to the profile
-    if message.startswith("already_tracked:") and creator_id:
+    # creator_id is non-empty when the creator already exists in the DB
+    if creator_id:
         return Div(
             UkIcon("info", cls="size-4 text-blue-600 shrink-0"),
             Div(
@@ -545,6 +566,76 @@ def render_add_creator_result(success: bool, message: str, creator_id: str = "")
         P(message, cls="text-sm text-red-700 dark:text-red-400 flex-1"),
         cls="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/30 "
         "border border-red-200 dark:border-red-800",
+    )
+
+
+def render_add_creator_status_result(
+    status: str,
+    creator_id: str = "",
+    input_query: str = "",
+) -> Div:
+    """
+    HTMX partial returned by GET /creators/add-status.
+
+    ``status`` values:
+        - ``"processing"`` — still in progress; card re-polls every 3 s.
+        - ``"completed"``  — creator is ready; renders a "View profile →" link.
+        - ``"failed"``     — worker could not resolve the creator.
+    """
+    if status == "completed" and creator_id:
+        return Div(
+            UkIcon("check-circle", cls="size-4 text-green-600 shrink-0"),
+            Div(
+                P(
+                    "Creator added!",
+                    cls="text-sm font-semibold text-green-700 dark:text-green-400",
+                ),
+                A(
+                    "View their profile →",
+                    href=f"/creator/{creator_id}",
+                    cls="text-xs text-primary hover:underline",
+                ),
+                cls="flex-1",
+            ),
+            cls="flex items-start gap-2 p-3 rounded-lg bg-green-50 dark:bg-green-950/30 "
+            "border border-green-200 dark:border-green-800",
+        )
+
+    if status == "failed":
+        return Div(
+            UkIcon("alert-circle", cls="size-4 text-red-600 shrink-0"),
+            P(
+                "We couldn't find that creator. Please check the @handle or channel ID and try again.",
+                cls="text-sm text-red-700 dark:text-red-400 flex-1",
+            ),
+            cls="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/30 "
+            "border border-red-200 dark:border-red-800",
+        )
+
+    # Still processing — continue polling
+    from urllib.parse import urlencode as _urlencode
+
+    status_url = f"/creators/add-status?{_urlencode({'q': input_query})}" if input_query else ""
+    poll_attrs = (
+        dict(
+            hx_get=status_url,
+            hx_trigger="every 3s",
+            hx_target="this",
+            hx_swap="outerHTML",
+        )
+        if status_url
+        else {}
+    )
+    return Div(
+        Div(
+            cls="size-4 rounded-full border-2 border-primary border-t-transparent animate-spin shrink-0"
+        ),
+        P(
+            "Processing… this usually takes under a minute.",
+            cls="text-sm text-muted-foreground flex-1",
+        ),
+        cls="flex items-center gap-2 p-3 rounded-lg bg-muted/40 border border-border",
+        **poll_attrs,
     )
 
 

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -810,7 +810,7 @@ async def handle_resolve_and_add_job(
             logger.info("%s Resolving @%s to channel ID via YouTube API…", job_tag, handle_raw)
 
             resolved = await asyncio.wait_for(
-                resolver.resolve_handle_to_channel_id(handle_raw),
+                youtube_resolver.resolve_handle_to_channel_id(handle_raw),
                 timeout=SYNC_TIMEOUT,
             )
             if not resolved:


### PR DESCRIPTION
## Summary by Sourcery

Add asynchronous, HTMX-driven flow to queue creator add requests and poll their completion status until a profile is available.

New Features:
- Introduce HTMX polling endpoint to fetch creator add job status and update the success notice in place.
- Expose new GET and POST routes for creator add requests and status checks, wired into the main router.

Enhancements:
- Update creator add request handler to be asynchronous and to drive an auto-updating success message instead of requiring manual refresh.
- Add database helper to look up the latest creator add job status for a given input query and map it to simplified status values.