### PR TITLE
Potential fix for code scanning alert no. 20: Clear-text logging of sensitive information

### DIFF
--- a/secrets_loader.py
+++ b/secrets_loader.py
@@ -129,9 +129,8 @@ def _load_kaggle_secrets() -> None:
             # Unexpected client/runtime error — log clearly and abort.
             # Do NOT silently treat this as a missing key.
             logger.error(
-                "Unexpected error retrieving Kaggle secret '%s' — "
-                "check UserSecretsClient connectivity",
-                key,
+                "Unexpected error retrieving a Kaggle secret — "
+                "check UserSecretsClient connectivity"
             )
             raise
 


### PR DESCRIPTION
Potential fix for [https://github.com/navneeth/viralvibes/security/code-scanning/20](https://github.com/navneeth/viralvibes/security/code-scanning/20)

General fix: remove sensitive fields from log messages and replace them with non-sensitive context (counts, generic messages, or internal error types), while preserving behavior (raising the exception).

Best fix here: in `secrets_loader.py`, update the `logger.error(...)` call inside `except Exception:` in `_load_kaggle_secrets()` so it no longer includes `key`. Keep the same control flow and `raise` unchanged. This preserves functionality (still logs failure and aborts) without exposing secret identifiers.

Specific change:
- File: `secrets_loader.py`
- Region: `_load_kaggle_secrets()`, lines 131–135 in the provided snippet
- Replace formatted message that includes `key` with a generic error message that does not interpolate sensitive data.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent clear-text logging of Kaggle secret identifiers by replacing detailed error messages with a generic connectivity error description.