### PR TITLE
fix: category stats cache only refreshing 1 of 62 categories

### DIFF
--- a/db.py
+++ b/db.py
@@ -3034,22 +3034,15 @@ def refresh_category_stats_cache() -> int:
         return 0
 
     try:
-        # Fetch all distinct categories that have at least one synced creator
-        cats_resp = (
-            supabase_client.table(CREATOR_TABLE)
-            .select("primary_category")
-            .eq("sync_status", "synced")
-            .gt("current_subscribers", 0)
-            .not_.is_("primary_category", None)
-            .execute()
-        )
-        categories = list(
-            {
-                row["primary_category"]
-                for row in (cats_resp.data or [])
-                if row.get("primary_category")
-            }
-        )
+        # Fetch all distinct categories via RPC — avoids the PostgREST server-side
+        # row limit (default 1,000) that silently truncated results when using a
+        # plain table query against 100k+ qualifying rows.
+        # Uses the get_distinct_synced_categories() RPC (migration 020) which does
+        # a DB-side SELECT DISTINCT backed by idx_creators_category_synced.
+        cats_resp = supabase_client.rpc("get_distinct_synced_categories").execute()
+        categories = [
+            row["primary_category"] for row in (cats_resp.data or []) if row.get("primary_category")
+        ]
 
         if not categories:
             logger.warning("refresh_category_stats_cache: no synced categories found")

--- a/db.py
+++ b/db.py
@@ -2986,6 +2986,7 @@ def get_creator_hero_stats() -> dict:
 # Table:      category_stats_cache (PK: category)
 
 CATEGORY_STATS_CACHE_TABLE = "category_stats_cache"
+RPC_DISTINCT_SYNCED_CATEGORIES = "get_distinct_synced_categories"
 
 
 def get_cached_category_box_stats(category: str) -> Optional[Dict[str, Any]]:
@@ -3037,9 +3038,9 @@ def refresh_category_stats_cache() -> int:
         # Fetch all distinct categories via RPC — avoids the PostgREST server-side
         # row limit (default 1,000) that silently truncated results when using a
         # plain table query against 100k+ qualifying rows.
-        # Uses the get_distinct_synced_categories() RPC (migration 020) which does
+        # Uses the RPC_DISTINCT_SYNCED_CATEGORIES RPC (migration 020) which does
         # a DB-side SELECT DISTINCT backed by idx_creators_category_synced.
-        cats_resp = supabase_client.rpc("get_distinct_synced_categories").execute()
+        cats_resp = supabase_client.rpc(RPC_DISTINCT_SYNCED_CATEGORIES).execute()
         categories = [
             row["primary_category"] for row in (cats_resp.data or []) if row.get("primary_category")
         ]

--- a/db/migrations/020_get_distinct_synced_categories.sql
+++ b/db/migrations/020_get_distinct_synced_categories.sql
@@ -1,0 +1,40 @@
+-- Migration 020: RPC for distinct synced categories
+--
+-- Fixes refresh_category_stats_cache() in db.py which called:
+--
+--   .table(CREATOR_TABLE)
+--   .select("primary_category")
+--   .eq("sync_status", "synced")
+--   .gt("current_subscribers", 0)
+--   .not_.is_("primary_category", None)
+--   .execute()
+--
+-- PostgREST applies a server-side row limit (default 1,000) to all table
+-- queries with no explicit limit.  With 117k+ qualifying rows the first 1,000
+-- returned happened to share a single primary_category, so Pass 4 only ever
+-- refreshed ONE category instead of all ~62.
+--
+-- This RPC returns the distinct set in a single DB-side aggregation.
+-- It uses the partial index idx_creators_category_synced (added in migration 006)
+-- so the scan is O(distinct categories), not O(total rows).
+
+CREATE OR REPLACE FUNCTION public.get_distinct_synced_categories()
+RETURNS TABLE (primary_category text)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT DISTINCT primary_category
+    FROM public.creators
+    WHERE sync_status = 'synced'
+      AND current_subscribers > 0
+      AND primary_category IS NOT NULL
+    ORDER BY primary_category;
+$$;
+
+COMMENT ON FUNCTION public.get_distinct_synced_categories() IS
+    'Returns the distinct set of primary_category values for synced creators with '
+    'subscribers > 0.  Used by refresh_category_stats_cache() to drive the '
+    'per-category box-plot RPC loop.  Uses idx_creators_category_synced for '
+    'efficient O(distinct categories) execution at any table size.';

--- a/db/migrations/020_get_distinct_synced_categories.sql
+++ b/db/migrations/020_get_distinct_synced_categories.sql
@@ -23,14 +23,13 @@ RETURNS TABLE (primary_category text)
 LANGUAGE sql
 STABLE
 SECURITY DEFINER
-SET search_path = public, pg_catalog
+SET search_path = pg_catalog, public
 AS $$
     SELECT DISTINCT primary_category
     FROM public.creators
     WHERE sync_status = 'synced'
       AND current_subscribers > 0
-      AND primary_category IS NOT NULL
-    ORDER BY primary_category;
+      AND primary_category IS NOT NULL;
 $$;
 
 COMMENT ON FUNCTION public.get_distinct_synced_categories() IS


### PR DESCRIPTION
refresh_category_stats_cache() fetched creator rows via a plain table query to build the distinct-category set. PostgREST's default server-side row cap (1,000 rows) silently truncated the result — the first 1,000 rows off the index all shared the same primary_category value, so Pass 4 only ever processed 1 category instead of all 62.

Fix:
- Add migration 020: get_distinct_synced_categories() RPC performs a DB-side SELECT DISTINCT backed by the existing idx_creators_category_synced partial index (migration 006); returns all distinct values in one round trip regardless of table size
- Update refresh_category_stats_cache() in db.py to call the RPC instead of the row-fetching table query

Root cause confirmed by query: 117,735 of 134,786 synced creators have primary_category set (87.3%), but Pass 4 was computing stats for only 1.

Deploy order: run migration 020 in Supabase SQL Editor before pushing this commit, otherwise the RPC call will 404 on first bootstrap run.

## Summary by Sourcery

Ensure category stats cache refresh processes all distinct synced categories by querying categories via a dedicated RPC instead of a row-limited table scan.

New Features:
- Add get_distinct_synced_categories() RPC to return all distinct primary categories for synced creators with subscribers in a single DB-side query.

Bug Fixes:
- Fix category stats cache refresh to consider all qualifying categories by switching from a table query to the new distinct-categories RPC.