### PR TITLE
feat(dashboard): product-driven user home with Watchlist Pulse, Lists…

### DIFF
--- a/db.py
+++ b/db.py
@@ -2211,6 +2211,50 @@ def get_user_favourite_creators(user_id: str, limit: int = 50) -> List[Dict[str,
         return []
 
 
+def get_favourite_creators_with_stats(user_id: str, limit: int = 50) -> List[Dict[str, Any]]:
+    """
+    Return saved creators for a user, sorted by 30-day subscriber growth (highest first).
+
+    Fetches a focused set of columns needed for the Watchlist Pulse card:
+        channel_name, channel_thumbnail_url, current_subscribers,
+        subscribers_change_30d, engagement_score, quality_grade, country_code, category
+
+    Two-query pattern (same as get_user_favourite_creators) because supabase-py
+    does not support cross-table ORDER BY in a single .select() call.
+    """
+    if not supabase_client or not user_id:
+        return []
+    try:
+        fav_resp = (
+            supabase_client.table(_USER_FAVOURITE_CREATORS_TABLE)
+            .select("creator_id")
+            .eq("user_id", user_id)
+            .limit(limit)
+            .execute()
+        )
+        rows = fav_resp.data or []
+        if not rows:
+            return []
+
+        creator_ids = [r["creator_id"] for r in rows]
+
+        creators_resp = (
+            supabase_client.table(CREATOR_TABLE)
+            .select(
+                "id, channel_name, channel_thumbnail_url, current_subscribers, "
+                "subscribers_change_30d, engagement_score, quality_grade, country_code, category"
+            )
+            .in_("id", creator_ids)
+            .order("subscribers_change_30d", desc=True, nullsfirst=False)
+            .execute()
+        )
+        return creators_resp.data or []
+
+    except Exception as exc:
+        logger.exception("[Favourites] get_favourite_creators_with_stats failed: %s", exc)
+        return []
+
+
 def get_or_create_creator_from_playlist(
     channel_id: str,
     channel_name: str,

--- a/main.py
+++ b/main.py
@@ -71,6 +71,7 @@ from controllers.preview import preview_playlist_controller
 from db import (
     get_cached_playlist_stats,
     get_estimated_stats,
+    get_favourite_creators_with_stats,
     get_job_progress,
     get_playlist_job_status,
     get_playlist_preview_info,
@@ -1436,6 +1437,8 @@ def my_dashboards(req, sess, search: str = "", sort: str = "recent"):
     # Fetch dashboards with filters
     dashboards = get_user_dashboards(user_id, search=search, sort=sort)
     plan_info = get_user_plan(user_id)
+    plan = plan_info.get("plan", "free")
+    fav_creators = get_favourite_creators_with_stats(user_id) if plan in ("pro", "agency") else []
 
     # Render page
     return Titled(
@@ -1448,6 +1451,7 @@ def my_dashboards(req, sess, search: str = "", sort: str = "recent"):
                 search=search,
                 sort=sort,
                 plan_info=plan_info,
+                fav_creators=fav_creators,
             ),
         ),
     )

--- a/main.py
+++ b/main.py
@@ -91,7 +91,11 @@ from utils import compute_dashboard_id, get_columns, get_language_name, sort_dat
 from validators import YoutubePlaylist, YoutubePlaylistValidator
 from views.dashboard import render_full_dashboard
 from views.favourites import render_favourites_page
-from views.my_dashboards import render_my_dashboards_page
+from views.my_dashboards import (
+    render_my_dashboards_page,
+    render_dashboard_page_partial,
+    render_dashboard_page_partial,
+)
 from views.table import DISPLAY_HEADERS, get_sort_col, render_playlist_table
 from routes.analysis import analysis_page_content
 from routes.creators import (
@@ -1408,8 +1412,12 @@ async def add_creator(req, sess):
 
 
 @rt("/me/dashboards")
-def my_dashboards(req, sess, search: str = "", sort: str = "recent"):
+def my_dashboards(
+    req, sess, htmx: HtmxHeaders, search: str = "", sort: str = "recent", page: int = 1
+):
     """User's personal dashboards page - PROTECTED route"""
+
+    _PAGE_SIZE = 12
 
     # Extract user info
     user_id = sess.get("user_id") if sess else None
@@ -1426,32 +1434,37 @@ def my_dashboards(req, sess, search: str = "", sort: str = "recent"):
     if intended_playlist_url:
         sess.pop("intended_playlist_url", None)  # Remove after using
         logger.info(f"Submitting job for {intended_playlist_url} after login")
-
-        # Submit the playlist job
         submit_playlist_job(intended_playlist_url, user_id=user_id)
-
-        # Redirect to their dashboard
         dashboard_id = compute_dashboard_id(intended_playlist_url)
         return RedirectResponse(f"/d/{dashboard_id}", status_code=303)
 
-    # Fetch dashboards with filters
-    dashboards = get_user_dashboards(user_id, search=search, sort=sort)
+    # Fetch all matching dashboards (search/sort applied in DB), paginate in Python
+    all_dashboards = get_user_dashboards(user_id, search=search, sort=sort)
+    offset = (page - 1) * _PAGE_SIZE
+    page_items = all_dashboards[offset : offset + _PAGE_SIZE]
+    has_more = len(all_dashboards) > offset + _PAGE_SIZE
+
+    # HTMX load-more: return only new rows + OOB button replacement
+    if htmx and page > 1:
+        return render_dashboard_page_partial(page_items, has_more, page, search, sort)
+
     plan_info = get_user_plan(user_id)
     plan = plan_info.get("plan", "free")
     fav_creators = get_favourite_creators_with_stats(user_id) if plan in ("pro", "agency") else []
 
-    # Render page
     return Titled(
         f"{user_name}'s Dashboards - YouTube",
         Container(
             NavComponent(oauth, req, sess),
             render_my_dashboards_page(
-                dashboards=dashboards,
+                dashboards=page_items,
                 user_name=user_name,
                 search=search,
                 sort=sort,
                 plan_info=plan_info,
                 fav_creators=fav_creators,
+                has_more=has_more,
+                page=page,
             ),
         ),
     )

--- a/views/my_dashboards.py
+++ b/views/my_dashboards.py
@@ -171,11 +171,17 @@ def render_my_dashboards_page(
     search: str = "",
     sort: str = "recent",
     plan_info: dict | None = None,
+    fav_creators: list[dict] | None = None,
 ) -> Div:
     """
-    Render the My Dashboards page with grid layout.
+    Product-driven user home.
 
-    Uses MonsterUI Grid component for responsive layout.
+    Sections (top → bottom):
+      1. Header  — greeting + plan badge
+      2. Creators / Watchlist Pulse  — saved creators ranked by growth (Pro/Agency)
+      3. Playlist Analysis  — the core job-to-be-done, search + grid
+      4. Lists  — discovery shortcuts to public lists
+      5. Campaigns  — stub, coming soon
     """
     _plan_info = plan_info or {
         "plan": "free",
@@ -183,24 +189,315 @@ def render_my_dashboards_page(
         "interval": None,
         "current_period_end": None,
     }
+    plan = _plan_info.get("plan", "free")
+    _fav_creators = fav_creators or []
 
     return Container(
-        # Page header
-        Div(
-            H1(f"👋 Welcome back, {user_name}!", cls="text-4xl font-bold mb-2"),
-            P(
-                f"You have {len(dashboards)} dashboard{'s' if len(dashboards) != 1 else ''}",
-                cls="text-gray-600 text-lg",
-            ),
-            cls="mb-8 mt-8",
-        ),
-        # Billing summary
-        render_billing_section(_plan_info),
-        # Search & Filter Bar
-        render_search_filter_bar(search=search, sort=sort),
-        # Dashboard Grid or Empty State
-        (render_dashboard_grid(dashboards) if dashboards else render_empty_state(search)),
+        # ── 1. Header ──────────────────────────────────────────────────────
+        _section_header(user_name, len(dashboards), _plan_info),
+        # ── 2. Watchlist Pulse ─────────────────────────────────────────────
+        render_watchlist_pulse(_fav_creators, plan),
+        # ── 3. Playlist Analysis ───────────────────────────────────────────
+        _section_analysis(dashboards, search, sort),
+        # ── 4. Lists ───────────────────────────────────────────────────────
+        _section_lists(plan),
+        # ── 5. Campaigns ───────────────────────────────────────────────────
+        _section_campaigns(plan),
         cls=ContainerT.xl,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section helpers
+# ---------------------------------------------------------------------------
+
+
+def _section_header(user_name: str, dashboard_count: int, plan_info: dict) -> Div:
+    plan = plan_info.get("plan", "free")
+    plan_cls = {
+        "free": "bg-gray-100 text-gray-600",
+        "pro": "bg-red-100 text-red-700",
+        "agency": "bg-purple-100 text-purple-700",
+    }.get(plan, "bg-gray-100 text-gray-600")
+
+    return Div(
+        Div(
+            H1(
+                f"👋 Welcome back, {user_name}",
+                cls="text-3xl font-bold text-gray-900",
+            ),
+            Span(
+                plan.capitalize(),
+                cls=f"text-xs font-bold px-2.5 py-1 rounded-full {plan_cls} ml-3 align-middle",
+            ),
+            cls="flex items-center mb-1",
+        ),
+        P(
+            f"{dashboard_count} playlist{'s' if dashboard_count != 1 else ''} analyzed",
+            cls="text-gray-500 text-sm",
+        ),
+        cls="mb-8 mt-8",
+    )
+
+
+def _section_label(icon: str, title: str, href: str | None = None) -> Div:
+    """Consistent section heading with optional 'View all' link."""
+    return Div(
+        Div(
+            Span(icon, cls="mr-2 text-base"),
+            Span(title, cls="font-semibold text-gray-800 text-sm uppercase tracking-wide"),
+            cls="flex items-center",
+        ),
+        *(
+            [A("View all →", href=href, cls="text-xs text-red-500 hover:underline font-medium")]
+            if href
+            else []
+        ),
+        cls="flex items-center justify-between mb-3",
+    )
+
+
+def _section_analysis(dashboards: list[dict], search: str, sort: str) -> Div:
+    """Playlist analysis section — search bar + grid or empty state."""
+    return Div(
+        _section_label("📊", "Playlist Analysis", href="/analysis"),
+        render_search_filter_bar(search=search, sort=sort),
+        render_dashboard_grid(dashboards) if dashboards else render_empty_state(search),
+        cls="mb-10",
+    )
+
+
+def _section_lists(plan: str) -> Div:
+    """Quick-access tiles for the public Lists product."""
+    tiles = [
+        ("🏆", "Top Rated", "/lists/top-rated"),
+        ("🚀", "Rising Stars", "/lists/rising-stars"),
+        ("⚡", "Most Active", "/lists/most-active"),
+        ("🌍", "By Country", "/lists"),
+        ("🎮", "By Category", "/lists"),
+    ]
+
+    def _tile(emoji, label, href):
+        return A(
+            Div(
+                Span(emoji, cls="text-2xl mb-1 block"),
+                Span(label, cls="text-xs font-medium text-gray-700 text-center leading-tight"),
+                cls="flex flex-col items-center justify-center p-3",
+            ),
+            href=href,
+            cls=(
+                "rounded-xl border border-border bg-white hover:border-gray-300 "
+                "hover:shadow-sm transition-all duration-150 no-underline"
+            ),
+        )
+
+    return Div(
+        _section_label("📋", "Lists", href="/lists"),
+        Div(
+            *[_tile(e, l, h) for e, l, h in tiles],
+            cls="grid grid-cols-5 gap-3",
+        ),
+        cls="mb-10",
+    )
+
+
+def _section_campaigns(plan: str) -> Div:
+    """Campaigns stub — gated behind agency plan, coming soon for others."""
+    is_agency = plan == "agency"
+
+    if is_agency:
+        body = Div(
+            P(
+                "Manage outreach campaigns across your saved creators.",
+                cls="text-sm text-gray-500 mb-3",
+            ),
+            A(
+                Button("+ New Campaign", cls=ButtonT.primary),
+                href="/campaigns/new",
+            ),
+            cls="py-2",
+        )
+    else:
+        body = Div(
+            P(
+                "Run outreach campaigns across your saved creators — schedule, track, and report in one place.",
+                cls="text-sm text-gray-500 mb-3 max-w-lg",
+            ),
+            Div(
+                Span(
+                    "Coming soon · Agency plan",
+                    cls="text-xs font-semibold text-purple-700 bg-purple-100 px-3 py-1 rounded-full",
+                ),
+                A(
+                    "Learn more →",
+                    href="/pricing",
+                    cls="text-xs text-red-500 hover:underline font-medium ml-4",
+                ),
+                cls="flex items-center gap-2 flex-wrap",
+            ),
+            cls="py-2",
+        )
+
+    return Div(
+        _section_label("📣", "Campaigns"),
+        Div(
+            body,
+            cls="p-4 rounded-xl border border-dashed border-gray-200 bg-gray-50/60",
+        ),
+        cls="mb-10",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Watchlist Pulse
+# ---------------------------------------------------------------------------
+
+_GRADE_CLS = {
+    "A+": "bg-emerald-100 text-emerald-800",
+    "A": "bg-green-100 text-green-700",
+    "B+": "bg-blue-100 text-blue-800",
+    "B": "bg-blue-50 text-blue-700",
+    "C": "bg-yellow-100 text-yellow-800",
+    "D": "bg-red-100 text-red-700",
+}
+
+
+def _flag(country_code: str | None) -> str:
+    if not country_code or len(country_code) != 2:
+        return ""
+    try:
+        a, b = country_code.upper()
+        return chr(0x1F1E6 + ord(a) - 65) + chr(0x1F1E6 + ord(b) - 65)
+    except Exception:
+        return ""
+
+
+def _growth_cell(delta: int | None) -> Span:
+    if delta is None:
+        return Span("─  n/a", cls="text-gray-400 text-sm tabular-nums")
+    if delta > 0:
+        return Span(f"▲ +{delta:,}", cls="text-emerald-600 font-semibold text-sm tabular-nums")
+    if delta < 0:
+        return Span(f"▼ {delta:,}", cls="text-red-500 font-semibold text-sm tabular-nums")
+    return Span("─  0", cls="text-gray-400 text-sm tabular-nums")
+
+
+def _pulse_row(creator: dict) -> Div:
+    thumb = creator.get("channel_thumbnail_url") or ""
+    name = creator.get("channel_name") or "Unknown"
+    delta = creator.get("subscribers_change_30d")
+    grade = creator.get("quality_grade") or ""
+    code = creator.get("country_code") or ""
+    cat = creator.get("category") or ""
+
+    avatar = (
+        Img(src=thumb, alt=name, cls="w-9 h-9 rounded-full object-cover flex-shrink-0")
+        if thumb
+        else Div(
+            Span(name[:1].upper(), cls="text-xs font-bold text-gray-500"),
+            cls="w-9 h-9 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0",
+        )
+    )
+    grade_cls = _GRADE_CLS.get(grade, "bg-gray-100 text-gray-600")
+
+    return Div(
+        avatar,
+        Span(name, cls="flex-1 font-medium text-sm truncate min-w-0"),
+        _growth_cell(delta),
+        *(
+            [Span(grade, cls=f"text-xs font-bold px-2 py-0.5 rounded-full {grade_cls}")]
+            if grade
+            else []
+        ),
+        *(
+            [Span(f"{_flag(code)} {code}", cls="text-xs text-gray-400 w-10 text-center")]
+            if code
+            else []
+        ),
+        *(
+            [Span(cat, cls="text-xs text-gray-400 hidden sm:block truncate max-w-[5rem]")]
+            if cat
+            else []
+        ),
+        cls="flex items-center gap-3 py-2 border-b border-gray-100 last:border-0",
+    )
+
+
+def render_watchlist_pulse(creators: list[dict], plan: str) -> Div:
+    """
+    Watchlist Pulse — saved creators ranked by 30-day subscriber growth.
+    Gated to Pro / Agency plans.
+    """
+    label = _section_label("❤️", "Saved Creators", href="/me/favourites")
+
+    if plan not in ("pro", "agency"):
+        return Div(
+            label,
+            Div(
+                Div(
+                    Span("🔒", cls="text-xl mr-3"),
+                    Div(
+                        P(
+                            "Track subscriber growth for your saved creators.",
+                            cls="text-sm text-gray-600",
+                        ),
+                        P("Available on Pro and Agency plans.", cls="text-xs text-gray-400 mt-0.5"),
+                    ),
+                    A(
+                        UkIcon("arrow-up-circle", cls="w-4 h-4 mr-1"),
+                        Span("Upgrade"),
+                        href="/pricing",
+                        cls=(
+                            "ml-auto inline-flex items-center px-3 py-1.5 rounded-lg "
+                            "bg-red-500 hover:bg-red-600 text-white text-sm font-semibold "
+                            "transition-colors flex-shrink-0"
+                        ),
+                    ),
+                    cls="flex items-center gap-3",
+                ),
+                cls="p-4 rounded-xl border border-dashed border-red-200 bg-red-50/40",
+            ),
+            cls="mb-10",
+        )
+
+    if not creators:
+        body = Div(
+            P("No saved creators yet.", cls="text-sm text-gray-500 mb-2"),
+            A(
+                "Browse creators →",
+                href="/creators",
+                cls="text-sm text-red-500 hover:underline font-medium",
+            ),
+            cls="py-3 text-center",
+        )
+        return Div(
+            label,
+            Div(body, cls="p-4 rounded-xl border border-border bg-muted/30"),
+            cls="mb-10",
+        )
+
+    rows = [_pulse_row(c) for c in creators[:8]]
+    footer_link = (
+        Div(
+            A(
+                f"View all {len(creators)} saved creators →",
+                href="/me/favourites",
+                cls="text-xs text-red-500 hover:underline font-medium",
+            ),
+            cls="pt-2 text-right",
+        )
+        if len(creators) > 8
+        else None
+    )
+
+    return Div(
+        label,
+        Div(
+            Div(*rows),
+            *(([footer_link]) if footer_link else []),
+            cls="p-4 rounded-xl border border-border bg-white",
+        ),
+        cls="mb-10",
     )
 
 

--- a/views/my_dashboards.py
+++ b/views/my_dashboards.py
@@ -172,6 +172,8 @@ def render_my_dashboards_page(
     sort: str = "recent",
     plan_info: dict | None = None,
     fav_creators: list[dict] | None = None,
+    has_more: bool = False,
+    page: int = 1,
 ) -> Div:
     """
     Product-driven user home.
@@ -198,7 +200,7 @@ def render_my_dashboards_page(
         # ── 2. Watchlist Pulse ─────────────────────────────────────────────
         render_watchlist_pulse(_fav_creators, plan),
         # ── 3. Playlist Analysis ───────────────────────────────────────────
-        _section_analysis(dashboards, search, sort),
+        _section_analysis(dashboards, search, sort, has_more=has_more, page=page),
         # ── 4. Lists ───────────────────────────────────────────────────────
         _section_lists(),
         # ── 5. Campaigns ───────────────────────────────────────────────────
@@ -257,12 +259,20 @@ def _section_label(icon: str, title: str, href: str | None = None) -> Div:
     )
 
 
-def _section_analysis(dashboards: list[dict], search: str, sort: str) -> Div:
+def _section_analysis(
+    dashboards: list[dict], search: str, sort: str, has_more: bool = False, page: int = 1
+) -> Div:
     """Playlist analysis section — search bar + grid or empty state."""
     return Div(
         _section_label("📊", "Playlist Analysis", href="/analysis"),
         render_search_filter_bar(search=search, sort=sort),
-        render_dashboard_grid(dashboards) if dashboards else render_empty_state(search),
+        (
+            render_dashboard_grid(
+                dashboards, has_more=has_more, page=page, search=search, sort=sort
+            )
+            if dashboards
+            else render_empty_state(search)
+        ),
         cls="mb-10",
     )
 
@@ -533,23 +543,56 @@ def render_search_filter_bar(search: str = "", sort: str = "recent") -> Form:
     )
 
 
-def render_dashboard_grid(dashboards: list[dict]) -> Div:
-    """
-    Render responsive grid of dashboard cards.
-
-    Uses MonsterUI Grid component:
-    - 1 column on mobile
-    - 2 columns on tablet
-    - 3 columns on desktop
-    """
-
-    return Grid(
-        *[render_dashboard_card(d) for d in dashboards],
-        cols=1,  # Mobile: 1 column
-        cols_md=2,  # Tablet: 2 columns
-        cols_lg=3,  # Desktop: 3 columns
-        gap=6,  # 1.5rem gap
+def render_dashboard_grid(
+    dashboards: list[dict],
+    has_more: bool = False,
+    page: int = 1,
+    search: str = "",
+    sort: str = "recent",
+) -> Div:
+    """Flat list of compact cards + HTMX load-more button."""
+    return Div(
+        Div(
+            *[render_dashboard_card(d) for d in dashboards],
+            id="playlist-grid",
+            cls="rounded-xl border border-border bg-white overflow-hidden",
+        ),
+        _playlist_load_more_btn(page, search, sort) if has_more else None,
         cls="mb-12",
+    )
+
+
+def render_dashboard_page_partial(
+    items: list[dict], has_more: bool, page: int, search: str, sort: str
+):
+    """HTMX partial — new rows appended to #playlist-grid + OOB button replacement."""
+    return (
+        *[render_dashboard_card(d) for d in items],
+        (
+            _playlist_load_more_btn(page, search, sort, oob=True)
+            if has_more
+            else Div(id="playlist-grid-load-more", hx_swap_oob="true")
+        ),
+    )
+
+
+def _playlist_load_more_btn(page: int, search: str, sort: str, *, oob: bool = False) -> Div:
+    qs = f"page={page + 1}&sort={sort}" + (f"&search={search}" if search else "")
+    return Div(
+        Button(
+            UkIcon("chevrons-down", cls="size-4"),
+            "Load more",
+            hx_get=f"/me/dashboards?{qs}",
+            hx_target="#playlist-grid",
+            hx_swap="beforeend",
+            hx_indicator="#playlist-grid-spinner",
+            hx_disabled_elt="this",
+            cls="flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-lg border border-border bg-background hover:bg-accent transition-colors",
+        ),
+        Span(id="playlist-grid-spinner", cls="htmx-indicator"),
+        id="playlist-grid-load-more",
+        hx_swap_oob="true" if oob else None,
+        cls="flex justify-center mt-4",
     )
 
 
@@ -565,168 +608,78 @@ def get_engagement_gradient(rate: float) -> str:
 
 def render_dashboard_card(dashboard: dict) -> A:
     """
-    Render a single dashboard card with proper aspect ratio, creator thumbnail,
-    and rich metrics.
+    Compact horizontal row card.
 
-    Design:
-    - 16:9 aspect ratio thumbnail (respects playlist image proportions)
-    - Creator avatar overlay (bottom-left corner) - prominently featured
-    - Rich metrics with visual hierarchy
-    - Smooth hover effects and transitions
+    Layout: [56px thumb] [title + channel] [metrics] [date] [›]
+    Keeps the list dense so 10+ playlists scan instantly.
     """
-
-    # Extract data with safe defaults
     dashboard_id = dashboard.get("dashboard_id", "")
     title = dashboard.get("title", "Untitled Playlist")
-    channel_name = dashboard.get("channel_name", "Unknown Channel")
-
-    channel_thumbnail = dashboard.get("channel_thumbnail", "/static/favicon.jpeg")
-    video_count = dashboard.get("video_count", 0) or 0
-    view_count = dashboard.get("view_count", 0) or 0
+    channel_name = dashboard.get("channel_name", "")
+    thumb = dashboard.get("channel_thumbnail") or "/static/favicon.jpeg"
+    video_count = dashboard.get("video_count") or 0
+    view_count = dashboard.get("view_count") or 0
     processed_on = dashboard.get("processed_on")
-
-    # Additional metrics (if available in your data structure)
-    engagement_score = dashboard.get("engagement_score", 0)
-    avg_views_per_video = dashboard.get("avg_views_per_video", 0)
 
     summary_stats = dashboard.get("summary_stats")
     engagement_metrics = extract_engagement_metrics(summary_stats)
-
-    # Format date
-    date_str = format_date_relative(processed_on)
-
-    # Format large numbers using existing utility
-    views_formatted = format_number(view_count)
-
-    # Calculate derived metrics
-    avg_views_per_video = (view_count / video_count) if video_count > 0 else 0
     engagement_rate = engagement_metrics["engagement_rate"]
-    avg_likes = engagement_metrics["avg_likes"]
 
-    # Determine engagement level for badge styling
-    engagement_level = "low"  # gray
-    if engagement_rate > 5:
-        engagement_level = "medium"  # yellow
-    if engagement_rate > 10:
-        engagement_level = "high"  # green
+    date_str = format_date_relative(processed_on)
+    views_fmt = format_number(view_count)
 
-    engagement_colors = {
-        "low": "bg-gray-100 text-gray-700",
-        "medium": "bg-yellow-100 text-yellow-700",
-        "high": "bg-green-100 text-green-700",
-    }
+    eng_cls = (
+        "text-green-600"
+        if engagement_rate > 10
+        else "text-yellow-600" if engagement_rate > 5 else "text-gray-400"
+    )
 
-    # ===== RENDER CARD =====
     return A(
-        Card(
-            # Thumbnail with 16:9 aspect ratio (REUSE EXISTING)
-            Div(
-                Div(
-                    Img(
-                        src=channel_thumbnail,
-                        alt=f"{title} playlist thumbnail",
-                        cls="w-full h-full object-cover",
-                        onerror="this.src='/static/favicon.jpeg'",
-                    ),
-                    cls="absolute inset-0 bg-gray-300",
-                ),
-                # Creator avatar overlay (bottom-left)
-                Div(
-                    Img(
-                        src=channel_thumbnail,
-                        alt=f"{channel_name} channel avatar",
-                        cls="w-12 h-12 rounded-full border-2 border-white shadow-lg object-cover",
-                        onerror="this.src='/static/favicon.jpeg'",
-                    ),
-                    # Scale on hover for premium feel
-                    cls="absolute bottom-3 left-3 z-10 group-hover:scale-110 transition-transform duration-200",
-                ),
-                # Dark overlay on hover
-                Div(
-                    cls="absolute inset-0 bg-gradient-to-t from-black/50 via-black/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200",
-                ),
-                cls="relative w-full overflow-hidden bg-gray-300 aspect-video rounded-t-lg group",
+        Div(
+            # Small square thumbnail
+            Img(
+                src=thumb,
+                alt=title,
+                cls="w-12 h-12 rounded-lg object-cover flex-shrink-0 bg-gray-100",
+                onerror="this.src='/static/favicon.jpeg'",
             ),
-            # Content section
+            # Title + channel
             Div(
-                # Title
-                H3(
-                    title,
-                    cls="text-sm font-semibold mb-1 line-clamp-2 text-gray-900 group-hover:text-blue-600 transition-colors duration-200",
-                    title=title,
+                P(title, cls="text-sm font-medium text-gray-900 truncate", title=title),
+                (
+                    P(channel_name, cls="text-xs text-gray-500 truncate mt-0.5")
+                    if channel_name
+                    else None
                 ),
-                # Channel name
-                Div(
-                    UkIcon("tv", cls="w-3 h-3 text-gray-400 mr-1"),
-                    Span(
-                        channel_name,
-                        cls="text-xs text-gray-700 font-medium truncate group-hover:text-gray-900",
-                        title=channel_name,
-                    ),
-                    cls="flex items-center gap-0 mb-2 min-h-[1.25rem]",
-                ),
-                # ✨ NEW: Engagement badges (reuse Badge component from cards.py)
-                Div(
-                    Badge(
-                        f"📊 {engagement_rate:.1f}% engagement",
-                        cls=engagement_colors[engagement_level],
-                    ),
-                    Badge(
-                        f"❤️ {format_number(int(engagement_metrics['avg_likes']))} avg likes",
-                        cls="bg-red-50 text-red-700",
-                    ),
-                    cls="flex flex-wrap gap-2 mb-2",
-                ),
-                # Primary metrics row
-                Div(
-                    Div(
-                        UkIcon("film", cls="w-3 h-3 mr-0.5"),
-                        Span(
-                            f"{video_count:,}",
-                            cls="font-semibold text-gray-900 text-xs",
-                        ),
-                        Span(" videos", cls="text-gray-500 text-xs"),
-                        cls="flex items-center gap-0.5",
-                    ),
-                    Span("•", cls="text-gray-300 text-xs mx-1"),
-                    Div(
-                        UkIcon("eye", cls="w-3 h-3 mr-0.5"),
-                        Span(views_formatted, cls="font-semibold text-gray-900 text-xs"),
-                        Span(" views", cls="text-gray-500 text-xs"),
-                        cls="flex items-center gap-0.5",
-                    ),
-                    cls="flex items-center gap-1 mb-2 text-xs flex-wrap",
-                ),
-                # Secondary metrics
-                Div(
-                    UkIcon("trending-up", cls="w-3 h-3 mr-0.5 text-blue-600"),
-                    Span(
-                        f"{format_number(int(avg_views_per_video))} avg/video",
-                        cls="text-xs text-gray-700 font-medium",
-                    ),
-                    cls="flex items-center gap-1 mb-2",
-                ),
-                # Engagement gauge
-                Div(
-                    Div(
-                        cls=f"h-1 bg-gradient-to-r {get_engagement_gradient(engagement_rate)}",
-                        style=f"width: {min(100, engagement_rate * 10)}%",
-                    ),
-                    cls="w-full h-2 bg-gray-200 rounded-full mb-3",
-                ),
-                # Footer with date
-                Div(
-                    UkIcon("calendar", cls="w-3 h-3 mr-1"),
-                    Span(date_str, cls="text-xs text-gray-500"),
-                    cls="flex items-center pt-2 border-t border-gray-200 gap-1",
-                ),
-                cls="p-4 flex flex-col flex-1 justify-between",
+                cls="flex-1 min-w-0",
             ),
-            cls="flex flex-col h-full hover:shadow-xl transition-all duration-200 bg-white overflow-hidden",
+            # Metrics — hidden below md
+            Div(
+                Span(f"{video_count:,} videos", cls="text-xs text-gray-400"),
+                Span("·", cls="text-gray-200 text-xs"),
+                Span(f"{views_fmt} views", cls="text-xs text-gray-400"),
+                *(
+                    [
+                        Span("·", cls="text-gray-200 text-xs"),
+                        Span(f"{engagement_rate:.1f}% eng", cls=f"text-xs font-medium {eng_cls}"),
+                    ]
+                    if engagement_rate > 0
+                    else []
+                ),
+                cls="hidden md:flex items-center gap-2 flex-shrink-0",
+            ),
+            # Date
+            Span(date_str, cls="text-xs text-gray-400 flex-shrink-0 hidden sm:block"),
+            # Chevron
+            UkIcon("chevron-right", cls="w-4 h-4 text-gray-300 flex-shrink-0"),
+            cls="flex items-center gap-4 px-4 py-3",
         ),
         href=f"/d/{dashboard_id}",
-        cls="block group no-underline h-full",
-        title=f"View dashboard: {title}",
+        cls=(
+            "block no-underline hover:bg-gray-50 "
+            "border-b border-gray-100 last:border-0 transition-colors duration-100 group"
+        ),
+        title=title,
     )
 
 

--- a/views/my_dashboards.py
+++ b/views/my_dashboards.py
@@ -200,7 +200,7 @@ def render_my_dashboards_page(
         # ── 3. Playlist Analysis ───────────────────────────────────────────
         _section_analysis(dashboards, search, sort),
         # ── 4. Lists ───────────────────────────────────────────────────────
-        _section_lists(plan),
+        _section_lists(),
         # ── 5. Campaigns ───────────────────────────────────────────────────
         _section_campaigns(plan),
         cls=ContainerT.xl,
@@ -267,7 +267,7 @@ def _section_analysis(dashboards: list[dict], search: str, sort: str) -> Div:
     )
 
 
-def _section_lists(plan: str) -> Div:
+def _section_lists() -> Div:
     """Quick-access tiles for the public Lists product."""
     tiles = [
         ("🏆", "Top Rated", "/lists/top-rated"),
@@ -388,6 +388,7 @@ def _pulse_row(creator: dict) -> Div:
     delta = creator.get("subscribers_change_30d")
     grade = creator.get("quality_grade") or ""
     code = creator.get("country_code") or ""
+    flag = _flag(code)
     cat = creator.get("category") or ""
 
     avatar = (
@@ -410,7 +411,7 @@ def _pulse_row(creator: dict) -> Div:
             else []
         ),
         *(
-            [Span(f"{_flag(code)} {code}", cls="text-xs text-gray-400 w-10 text-center")]
+            [Span(f"{flag} {code}" if flag else code, cls="text-xs text-gray-400 w-10 text-center")]
             if code
             else []
         ),


### PR DESCRIPTION
…, and Campaigns stubs

- Redesign /me/dashboards layout into named product sections: Saved Creators (Watchlist Pulse), Playlist Analysis, Lists, Campaigns
- Add render_watchlist_pulse(): shows saved creators ranked by 30-day subscriber growth; gated to Pro/Agency; upsell tile for free users
- Add _section_lists(): 5 quick-access tiles to public Lists pages
- Add _section_campaigns(): Agency CTA or "Coming soon" stub for others
- Add _section_header(): greeting + plan badge inline
- Add _section_label(): consistent section headings with View-all links
- Remove render_billing_section() from main page flow (plan shown inline)
- db.py: add get_favourite_creators_with_stats(user_id) — two-query join of user_favourite_creators → creators, ordered by subscribers_change_30d
- main.py: fetch fav_creators for Pro/Agency users; pass to page render

## Summary by Sourcery

Redesign the My Dashboards page into a product-driven home with new sections for saved creators, playlist analysis, lists, and campaigns, powered by enriched favourite-creator data.

New Features:
- Introduce a Watchlist Pulse section that surfaces saved creators ranked by recent subscriber growth for Pro and Agency users with an upsell state for free users.
- Add Lists and Campaigns sections to the dashboard to promote list discovery and upcoming campaign management capabilities.
- Add a header section that surfaces a personalized greeting and inline plan badge on the dashboards page.

Enhancements:
- Refactor the dashboards page into composable section helpers for header, playlist analysis, lists, campaigns, and saved creators.
- Replace the standalone billing section on the dashboards page with inline plan information in the header.
- Add a new database helper to fetch favourite creators with growth and quality stats for use in Watchlist Pulse.
- Update the dashboards route to fetch enriched favourite-creators data for eligible users and pass it into the page renderer.