### PR TITLE
feat(lists): heart/favourite lists pinned to user dashboard

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -345,6 +345,7 @@ CREATORS_TABLE = "creators"
 CREATOR_TABLE = "creators"
 CREATOR_SYNC_JOBS_TABLE = "creator_sync_jobs"
 USER_FAVOURITE_CREATORS_TABLE = "user_favourite_creators"
+USER_FAVOURITE_LISTS_TABLE = "user_favourite_lists"
 
 # Update frequency (frugal)
 CREATOR_WORKER_BATCH_SIZE = 2  # Process at a time

--- a/db.py
+++ b/db.py
@@ -36,6 +36,7 @@ from constants import (
     PLAYLIST_STATS_TABLE,
     SIGNUPS_TABLE,
     USER_FAVOURITE_CREATORS_TABLE,
+    USER_FAVOURITE_LISTS_TABLE,
     JobStatus,
 )
 from utils import (
@@ -2253,6 +2254,128 @@ def get_favourite_creators_with_stats(user_id: str, limit: int = 50) -> List[Dic
     except Exception as exc:
         logger.exception("[Favourites] get_favourite_creators_with_stats failed: %s", exc)
         return []
+
+
+# ============================================================================
+# 🔖  User Favourite Lists
+# ============================================================================
+
+_USER_FAVOURITE_LISTS_TABLE = USER_FAVOURITE_LISTS_TABLE
+
+# Allowlist of valid list_key formats (checked on write)
+import re as _re
+
+_LIST_KEY_RE = _re.compile(
+    r"^(top-rated|most-active|rising|veterans|by-country|by-category|by-language"
+    r"|country:[A-Z]{2}"
+    r"|category:[^:]{1,80}"
+    r"|language:[a-z]{2,10})$"
+)
+
+
+def add_favourite_list(
+    user_id: str,
+    list_key: str,
+    list_label: str,
+    list_url: str,
+) -> bool:
+    """
+    Bookmark a curated list for a user.
+
+    Uses upsert on (user_id, list_key) so the call is idempotent.
+    Validates list_key against an allowlist and list_url as an internal path.
+
+    Returns True on success, False on failure.
+    """
+    if not supabase_client or not user_id:
+        return False
+    if not _LIST_KEY_RE.match(list_key):
+        logger.warning("[FavLists] Rejected invalid list_key: %r", list_key)
+        return False
+    if not list_url.startswith("/lists"):
+        logger.warning("[FavLists] Rejected non-internal list_url: %r", list_url)
+        return False
+    # Sanitise label: strip leading/trailing whitespace, cap length
+    list_label = list_label.strip()[:100]
+    try:
+        supabase_client.table(_USER_FAVOURITE_LISTS_TABLE).upsert(
+            {
+                "user_id": user_id,
+                "list_key": list_key,
+                "list_label": list_label,
+                "list_url": list_url,
+            },
+            on_conflict="user_id,list_key",
+        ).execute()
+        logger.info("[FavLists] Added list %s for user %s", list_key, user_id)
+        return True
+    except Exception as exc:
+        logger.exception("[FavLists] add_favourite_list failed: %s", exc)
+        return False
+
+
+def remove_favourite_list(user_id: str, list_key: str) -> bool:
+    """
+    Remove a bookmarked list for a user.
+
+    Returns True on success (including when the row did not exist).
+    """
+    if not supabase_client or not user_id or not list_key:
+        return False
+    try:
+        supabase_client.table(_USER_FAVOURITE_LISTS_TABLE).delete().eq("user_id", user_id).eq(
+            "list_key", list_key
+        ).execute()
+        logger.info("[FavLists] Removed list %s for user %s", list_key, user_id)
+        return True
+    except Exception as exc:
+        logger.exception("[FavLists] remove_favourite_list failed: %s", exc)
+        return False
+
+
+def get_user_favourite_lists(user_id: str, limit: int = 50) -> List[Dict[str, Any]]:
+    """
+    Return all bookmarked lists for a user, ordered by most recently saved first.
+
+    Each item has keys: list_key, list_label, list_url, created_at.
+    """
+    if not supabase_client or not user_id:
+        return []
+    try:
+        resp = (
+            supabase_client.table(_USER_FAVOURITE_LISTS_TABLE)
+            .select("list_key, list_label, list_url, created_at")
+            .eq("user_id", user_id)
+            .order("created_at", desc=True)
+            .limit(limit)
+            .execute()
+        )
+        return resp.data or []
+    except Exception as exc:
+        logger.exception("[FavLists] get_user_favourite_lists failed: %s", exc)
+        return []
+
+
+def get_user_favourite_list_keys(user_id: str) -> frozenset:
+    """
+    Return the set of list_key strings the user has bookmarked.
+
+    Lightweight: fetches only list_key column.  Used by list renderers to
+    decide filled vs. outline heart icons without per-item DB queries.
+    """
+    if not supabase_client or not user_id:
+        return frozenset()
+    try:
+        resp = (
+            supabase_client.table(_USER_FAVOURITE_LISTS_TABLE)
+            .select("list_key")
+            .eq("user_id", user_id)
+            .execute()
+        )
+        return frozenset(row["list_key"] for row in (resp.data or []))
+    except Exception as exc:
+        logger.exception("[FavLists] get_user_favourite_list_keys failed: %s", exc)
+        return frozenset()
 
 
 def get_or_create_creator_from_playlist(

--- a/db/migrations/021_user_favourite_lists.sql
+++ b/db/migrations/021_user_favourite_lists.sql
@@ -1,0 +1,31 @@
+-- Migration 021: User favourite lists
+--
+-- Lets authenticated users bookmark curated lists (tabs, country pages,
+-- category pages, language pages) for one-click access from their dashboard.
+--
+-- Design choices:
+--   • list_key  — compact identifier, e.g. "top-rated", "country:US",
+--                 "category:Gaming", "language:en".  Unique per user.
+--   • list_label — human-readable label stored at save time so the dashboard
+--                  can render tiles without re-fetching list metadata.
+--   • list_url  — relative path stored at save time so the tile can link
+--                 directly without URL reconstruction logic on the dashboard.
+--   • ON DELETE CASCADE on user FK: favourites vanish when the user is deleted.
+--   • UNIQUE(user_id, list_key): prevents duplicates; used as upsert target.
+--   • No soft-delete: toggling removes the row outright.
+--
+-- Run once in the Supabase SQL editor.
+
+CREATE TABLE IF NOT EXISTS public.user_favourite_lists (
+    id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    uuid        NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    list_key   text        NOT NULL,
+    list_label text        NOT NULL DEFAULT '',
+    list_url   text        NOT NULL DEFAULT '',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT uq_user_favourite_list UNIQUE (user_id, list_key)
+);
+
+-- Efficient lookup: "which lists has this user bookmarked?"
+CREATE INDEX IF NOT EXISTS idx_user_fav_lists_user_id
+    ON public.user_favourite_lists (user_id, created_at DESC);

--- a/main.py
+++ b/main.py
@@ -77,6 +77,10 @@ from db import (
     get_playlist_preview_info,
     get_user_dashboards,
     get_user_favourite_creators,
+    get_user_favourite_list_keys,
+    get_user_favourite_lists,
+    add_favourite_list,
+    remove_favourite_list,
     get_user_plan,
     init_supabase,
     resolve_playlist_url_from_dashboard_id,
@@ -94,8 +98,8 @@ from views.favourites import render_favourites_page
 from views.my_dashboards import (
     render_my_dashboards_page,
     render_dashboard_page_partial,
-    render_dashboard_page_partial,
 )
+from views.lists import _list_heart_btn
 from views.table import DISPLAY_HEADERS, get_sort_col, render_playlist_table
 from routes.analysis import analysis_page_content
 from routes.creators import (
@@ -1451,6 +1455,7 @@ def my_dashboards(
     plan_info = get_user_plan(user_id)
     plan = plan_info.get("plan", "free")
     fav_creators = get_favourite_creators_with_stats(user_id) if plan in ("pro", "agency") else []
+    fav_lists = get_user_favourite_lists(user_id)
 
     return Titled(
         f"{user_name}'s Dashboards - YouTube",
@@ -1463,11 +1468,47 @@ def my_dashboards(
                 sort=sort,
                 plan_info=plan_info,
                 fav_creators=fav_creators,
+                fav_lists=fav_lists,
                 has_more=has_more,
                 page=page,
             ),
         ),
     )
+
+
+@rt("/me/favourite-list", methods=["POST"])
+def toggle_favourite_list(req, sess, list_key: str = "", list_label: str = "", list_url: str = ""):
+    """
+    POST /me/favourite-list — toggle a curated list bookmark.
+
+    Returns the replacement _list_heart_btn form so HTMX can swap it in place.
+    Requires authentication; redirects to /login if not logged in.
+    """
+    user_id = sess.get("user_id") if sess else None
+    auth = sess.get("auth") if sess else None
+
+    if not auth or not user_id:
+        return RedirectResponse("/login", status_code=303)
+
+    # Validate inputs (list_key is further validated inside add_favourite_list)
+    if not list_key:
+        return Response(status_code=400)
+    # Clamp label/url lengths as a safety measure
+    list_label = list_label.strip()[:100]
+    list_url = list_url.strip()[:200]
+
+    # Determine current state and toggle
+    fav_keys = get_user_favourite_list_keys(user_id)
+    is_currently_fav = list_key in fav_keys
+
+    if is_currently_fav:
+        remove_favourite_list(user_id, list_key)
+        new_fav = False
+    else:
+        ok = add_favourite_list(user_id, list_key, list_label, list_url)
+        new_fav = ok  # False if validation failed
+
+    return _list_heart_btn(list_key, list_label, list_url, new_fav, authenticated=True)
 
 
 @rt("/me/favourites")

--- a/routes/lists.py
+++ b/routes/lists.py
@@ -8,6 +8,7 @@ from urllib.parse import unquote
 from fasthtml.common import Div
 
 from db import get_creators
+from db import get_user_favourite_list_keys
 from db_lists import (
     _count_distinct_languages,
     get_category_groups,
@@ -60,6 +61,11 @@ def lists_route(request):
     """
     active_tab = request.query_params.get("tab", "top-rated")
 
+    # Auth context for heart buttons
+    user_id = request.session.get("user_id") if hasattr(request, "session") else None
+    authenticated = bool(user_id)
+    fav_keys = get_user_favourite_list_keys(user_id) if user_id else frozenset()
+
     # ── Fetch live DB meta (one combined aggregation scan) ──────────────────
     meta = get_lists_meta()
 
@@ -105,7 +111,12 @@ def lists_route(request):
     # a zero-row-transfer COUNT(DISTINCT) query that has no row cap.
     tab_data["total_languages"] = meta.get("total_languages") or _count_distinct_languages()
 
-    return render_lists_page(active_tab=active_tab, tab_data=tab_data)
+    return render_lists_page(
+        active_tab=active_tab,
+        tab_data=tab_data,
+        fav_keys=fav_keys,
+        authenticated=authenticated,
+    )
 
 
 def lists_more_countries_route(request):
@@ -116,6 +127,10 @@ def lists_more_countries_route(request):
     ``total`` is forwarded from the initial page load so that we avoid
     re-running the 50k-row get_lists_meta() scan on every click.
     """
+    user_id = request.session.get("user_id") if hasattr(request, "session") else None
+    authenticated = bool(user_id)
+    fav_keys = get_user_favourite_list_keys(user_id) if user_id else frozenset()
+
     try:
         offset = int(request.query_params.get("offset", INITIAL_GROUPS))
     except (TypeError, ValueError):
@@ -137,7 +152,14 @@ def lists_more_countries_route(request):
     next_offset = offset + len(groups)
     has_more = next_offset < total
 
-    return render_more_countries(groups, next_offset=next_offset, has_more=has_more, total=total)
+    return render_more_countries(
+        groups,
+        next_offset=next_offset,
+        has_more=has_more,
+        total=total,
+        fav_keys=fav_keys,
+        authenticated=authenticated,
+    )
 
 
 def lists_more_categories_route(request):
@@ -148,6 +170,10 @@ def lists_more_categories_route(request):
     ``total`` is forwarded from the initial page load so that we avoid
     re-running the 50k-row get_lists_meta() scan on every click.
     """
+    user_id = request.session.get("user_id") if hasattr(request, "session") else None
+    authenticated = bool(user_id)
+    fav_keys = get_user_favourite_list_keys(user_id) if user_id else frozenset()
+
     try:
         offset = int(request.query_params.get("offset", INITIAL_GROUPS))
     except (TypeError, ValueError):
@@ -167,7 +193,14 @@ def lists_more_categories_route(request):
     next_offset = offset + len(groups)
     has_more = next_offset < total
 
-    return render_more_categories(groups, next_offset=next_offset, has_more=has_more, total=total)
+    return render_more_categories(
+        groups,
+        next_offset=next_offset,
+        has_more=has_more,
+        total=total,
+        fav_keys=fav_keys,
+        authenticated=authenticated,
+    )
 
 
 def lists_more_languages_route(request):
@@ -178,6 +211,10 @@ def lists_more_languages_route(request):
     ``total`` is forwarded from the initial page load so that we avoid
     re-running the get_lists_meta() scan on every click.
     """
+    user_id = request.session.get("user_id") if hasattr(request, "session") else None
+    authenticated = bool(user_id)
+    fav_keys = get_user_favourite_list_keys(user_id) if user_id else frozenset()
+
     try:
         offset = int(request.query_params.get("offset", INITIAL_GROUPS))
     except (TypeError, ValueError):
@@ -197,7 +234,14 @@ def lists_more_languages_route(request):
     next_offset = offset + len(groups)
     has_more = next_offset < total
 
-    return render_more_languages(groups, next_offset=next_offset, has_more=has_more, total=total)
+    return render_more_languages(
+        groups,
+        next_offset=next_offset,
+        has_more=has_more,
+        total=total,
+        fav_keys=fav_keys,
+        authenticated=authenticated,
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/routes/lists.py
+++ b/routes/lists.py
@@ -43,6 +43,13 @@ from views.lists import (
 
 logger = logging.getLogger(__name__)
 
+
+def _auth_context(request) -> tuple[str | None, bool, frozenset]:
+    """Extract (user_id, authenticated, fav_keys) from a request session."""
+    user_id = request.session.get("user_id") if hasattr(request, "session") else None
+    return user_id, bool(user_id), get_user_favourite_list_keys(user_id) if user_id else frozenset()
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Tuning constants — how many groups/creators to show initially vs on load-more
 # ─────────────────────────────────────────────────────────────────────────────
@@ -62,9 +69,7 @@ def lists_route(request):
     active_tab = request.query_params.get("tab", "top-rated")
 
     # Auth context for heart buttons
-    user_id = request.session.get("user_id") if hasattr(request, "session") else None
-    authenticated = bool(user_id)
-    fav_keys = get_user_favourite_list_keys(user_id) if user_id else frozenset()
+    user_id, authenticated, fav_keys = _auth_context(request)
 
     # ── Fetch live DB meta (one combined aggregation scan) ──────────────────
     meta = get_lists_meta()
@@ -127,9 +132,7 @@ def lists_more_countries_route(request):
     ``total`` is forwarded from the initial page load so that we avoid
     re-running the 50k-row get_lists_meta() scan on every click.
     """
-    user_id = request.session.get("user_id") if hasattr(request, "session") else None
-    authenticated = bool(user_id)
-    fav_keys = get_user_favourite_list_keys(user_id) if user_id else frozenset()
+    user_id, authenticated, fav_keys = _auth_context(request)
 
     try:
         offset = int(request.query_params.get("offset", INITIAL_GROUPS))
@@ -170,9 +173,7 @@ def lists_more_categories_route(request):
     ``total`` is forwarded from the initial page load so that we avoid
     re-running the 50k-row get_lists_meta() scan on every click.
     """
-    user_id = request.session.get("user_id") if hasattr(request, "session") else None
-    authenticated = bool(user_id)
-    fav_keys = get_user_favourite_list_keys(user_id) if user_id else frozenset()
+    user_id, authenticated, fav_keys = _auth_context(request)
 
     try:
         offset = int(request.query_params.get("offset", INITIAL_GROUPS))
@@ -211,9 +212,7 @@ def lists_more_languages_route(request):
     ``total`` is forwarded from the initial page load so that we avoid
     re-running the get_lists_meta() scan on every click.
     """
-    user_id = request.session.get("user_id") if hasattr(request, "session") else None
-    authenticated = bool(user_id)
-    fav_keys = get_user_favourite_list_keys(user_id) if user_id else frozenset()
+    user_id, authenticated, fav_keys = _auth_context(request)
 
     try:
         offset = int(request.query_params.get("offset", INITIAL_GROUPS))

--- a/views/lists.py
+++ b/views/lists.py
@@ -362,9 +362,10 @@ def _list_heart_btn(
         "fill-red-500 text-red-500" if is_fav else "text-gray-300 group-hover:text-red-400"
     )
     if not authenticated:
-        return Span(
+        return A(
             UkIcon("heart", cls="size-4 text-gray-200"),
             id=btn_id,
+            href="/login",
             title="Sign in to save lists to your dashboard",
             cls="inline-flex items-center p-1",
         )

--- a/views/lists.py
+++ b/views/lists.py
@@ -336,37 +336,101 @@ def _creator_mini_row(creator: dict, rank: int):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# List Heart Button — save/unsave a list to the user dashboard
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _list_heart_btn(
+    list_key: str,
+    list_label: str,
+    list_url: str,
+    is_fav: bool,
+    *,
+    authenticated: bool = False,
+):
+    """
+    Heart toggle button that bookmarks/unbookmarks a curated list.
+
+    Authenticated users see a clickable heart that toggles via HTMX POST.
+    Unauthenticated users see a greyed-out heart that links to login.
+
+    The POST response is this same component with the new is_fav state, so
+    hx-swap=outerHTML replaces the entire form in-place.
+    """
+    btn_id = f"heart-{list_key.replace(':', '-').replace(' ', '-')}"
+    icon_cls = "size-4 " + (
+        "fill-red-500 text-red-500" if is_fav else "text-gray-300 group-hover:text-red-400"
+    )
+    if not authenticated:
+        return Span(
+            UkIcon("heart", cls="size-4 text-gray-200"),
+            id=btn_id,
+            title="Sign in to save lists to your dashboard",
+            cls="inline-flex items-center p-1",
+        )
+    return Form(
+        Input(type="hidden", name="list_key", value=list_key),
+        Input(type="hidden", name="list_label", value=list_label),
+        Input(type="hidden", name="list_url", value=list_url),
+        Button(
+            UkIcon("heart", cls=icon_cls),
+            type="submit",
+            title="Remove from dashboard" if is_fav else "Save to dashboard",
+            cls="inline-flex items-center p-1 rounded hover:bg-gray-100 transition-colors group",
+        ),
+        id=btn_id,
+        hx_post="/me/favourite-list",
+        hx_swap="outerHTML",
+        hx_target=f"#{btn_id}",
+        cls="inline m-0 p-0",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Group card builders (country / category) — used by both initial render
 # and HTMX load-more partials
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _country_group_card(country_data: dict) -> Div:
+def _country_group_card(
+    country_data: dict,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
     """Render a single country group card with its top creators."""
     country_code = country_data["country_code"]
     count = country_data["count"]
     creators = country_data["creators"]
 
     country_name = get_country_name(country_code)
+    list_key = f"country:{country_code}"
+    list_label = f"{get_country_flag(country_code) or '🌍'} {country_name}"
+    list_url = f"/lists/country/{country_code}"
 
     return Div(
-        # Header links to the full ranked list (detail route added in next step)
-        A(
-            Span(get_country_flag(country_code), cls="text-2xl shrink-0"),
-            Div(
-                H3(
-                    country_name,
-                    cls="text-base font-bold text-foreground leading-tight",
+        # Header: flag + name + creator count + heart
+        Div(
+            A(
+                Span(get_country_flag(country_code), cls="text-2xl shrink-0"),
+                Div(
+                    H3(
+                        country_name,
+                        cls="text-base font-bold text-foreground leading-tight",
+                    ),
+                    Span(country_code, cls="text-xs text-muted-foreground font-mono"),
+                    cls="flex flex-col min-w-0",
                 ),
-                Span(country_code, cls="text-xs text-muted-foreground font-mono"),
-                cls="flex flex-col min-w-0",
+                Span(
+                    f"{format_number(count)} creators →",
+                    cls="ml-auto shrink-0 text-xs font-medium text-primary",
+                ),
+                href=list_url,
+                cls="flex items-center gap-2 hover:opacity-75 transition-opacity flex-1 min-w-0",
             ),
-            Span(
-                f"{format_number(count)} creators →",
-                cls="ml-auto shrink-0 text-xs font-medium text-primary",
+            _list_heart_btn(
+                list_key, list_label, list_url, list_key in fav_keys, authenticated=authenticated
             ),
-            href=f"/lists/country/{country_code}",
-            cls="flex items-center gap-2 hover:opacity-75 transition-opacity",
+            cls="flex items-center gap-2",
         ),
         (
             Div(
@@ -380,7 +444,11 @@ def _country_group_card(country_data: dict) -> Div:
     )
 
 
-def _category_group_card(category_data: dict) -> Div:
+def _category_group_card(
+    category_data: dict,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
     """Render a single category group card with its top creators."""
     category = category_data["category"]
     count = category_data["count"]
@@ -392,20 +460,30 @@ def _category_group_card(category_data: dict) -> Div:
     # Title-case for readability
     display_name = display_name.title() if display_name == display_name.lower() else display_name
 
+    list_key = f"category:{display_name}"
+    list_label = f"{emoji} {display_name}"
+    list_url = f"/lists/category/{quote(display_name, safe='')}"
+
     return Div(
-        # Header links to the full ranked list (detail route added in next step)
-        A(
-            Span(emoji, cls="text-2xl shrink-0"),
-            Span(
-                display_name,
-                cls="text-base font-bold text-foreground leading-tight flex-1 min-w-0",
+        # Header: emoji + name + creator count + heart
+        Div(
+            A(
+                Span(emoji, cls="text-2xl shrink-0"),
+                Span(
+                    display_name,
+                    cls="text-base font-bold text-foreground leading-tight flex-1 min-w-0",
+                ),
+                Span(
+                    f"{format_number(count)} creators →",
+                    cls="ml-auto shrink-0 text-xs font-medium text-primary",
+                ),
+                href=list_url,
+                cls="flex items-center gap-2 hover:opacity-75 transition-opacity flex-1 min-w-0",
             ),
-            Span(
-                f"{format_number(count)} creators →",
-                cls="ml-auto shrink-0 text-xs font-medium text-primary",
+            _list_heart_btn(
+                list_key, list_label, list_url, list_key in fav_keys, authenticated=authenticated
             ),
-            href=f"/lists/category/{quote(display_name, safe='')}",
-            cls="flex items-center gap-2 hover:opacity-75 transition-opacity",
+            cls="flex items-center gap-2",
         ),
         (
             Div(
@@ -419,7 +497,11 @@ def _category_group_card(category_data: dict) -> Div:
     )
 
 
-def _language_group_card(language_data: dict) -> Div:
+def _language_group_card(
+    language_data: dict,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
     """Render a single language group card with its top creators."""
     language_code = language_data["language_code"]
     count = language_data["count"]
@@ -428,23 +510,34 @@ def _language_group_card(language_data: dict) -> Div:
     language_name = get_language_name(language_code)
     emoji = get_language_emoji(language_code)
 
+    list_key = f"language:{language_code.lower()}"
+    list_label = f"{emoji} {language_name}"
+    list_url = f"/lists/language/{language_code.lower()}"
+
     return Div(
-        A(
-            Span(emoji, cls="text-2xl shrink-0"),
-            Div(
-                H3(
-                    language_name,
-                    cls="text-base font-bold text-foreground leading-tight",
+        # Header: emoji + name + creator count + heart
+        Div(
+            A(
+                Span(emoji, cls="text-2xl shrink-0"),
+                Div(
+                    H3(
+                        language_name,
+                        cls="text-base font-bold text-foreground leading-tight",
+                    ),
+                    Span(language_code.upper(), cls="text-xs text-muted-foreground font-mono"),
+                    cls="flex flex-col min-w-0",
                 ),
-                Span(language_code.upper(), cls="text-xs text-muted-foreground font-mono"),
-                cls="flex flex-col min-w-0",
+                Span(
+                    f"{format_number(count)} creators →",
+                    cls="ml-auto shrink-0 text-xs font-medium text-primary",
+                ),
+                href=list_url,
+                cls="flex items-center gap-2 hover:opacity-75 transition-opacity flex-1 min-w-0",
             ),
-            Span(
-                f"{format_number(count)} creators →",
-                cls="ml-auto shrink-0 text-xs font-medium text-primary",
+            _list_heart_btn(
+                list_key, list_label, list_url, list_key in fav_keys, authenticated=authenticated
             ),
-            href=f"/lists/language/{language_code.lower()}",
-            cls="flex items-center gap-2 hover:opacity-75 transition-opacity",
+            cls="flex items-center gap-2",
         ),
         (
             Div(
@@ -547,13 +640,18 @@ def _page_based_load_more_button(
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _render_top_rated_content(creators: list[dict], description: str) -> Div:
+def _render_top_rated_content(
+    creators: list[dict],
+    description: str,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
     """Renders Top Rated tab with quality-sorted creators."""
     if not creators:
         return _placeholder_content(description, coming_soon=False)
 
     return Div(
-        # Description + count
+        # Description + count + heart
         DivFullySpaced(
             P(description, cls="text-sm text-muted-foreground max-w-xl"),
             Div(
@@ -561,7 +659,14 @@ def _render_top_rated_content(creators: list[dict], description: str) -> Div:
                     f"{len(creators)} creators",
                     cls="text-sm font-medium text-foreground",
                 ),
-                cls="shrink-0 hidden sm:block",
+                _list_heart_btn(
+                    "top-rated",
+                    "🏆 Top Rated",
+                    "/lists?tab=top-rated",
+                    "top-rated" in fav_keys,
+                    authenticated=authenticated,
+                ),
+                cls="shrink-0 hidden sm:flex items-center gap-2",
             ),
             cls="mb-6 gap-4 flex-col sm:flex-row items-start sm:items-center",
         ),
@@ -574,7 +679,12 @@ def _render_top_rated_content(creators: list[dict], description: str) -> Div:
     )
 
 
-def _render_most_active_content(creators: list[dict], description: str) -> Div:
+def _render_most_active_content(
+    creators: list[dict],
+    description: str,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
     """Renders Most Active tab with upload frequency."""
     if not creators:
         return _placeholder_content(description, coming_soon=False)
@@ -587,7 +697,14 @@ def _render_most_active_content(creators: list[dict], description: str) -> Div:
                     f"{len(creators)} creators",
                     cls="text-sm font-medium text-foreground",
                 ),
-                cls="shrink-0 hidden sm:block",
+                _list_heart_btn(
+                    "most-active",
+                    "⚡ Most Active",
+                    "/lists?tab=most-active",
+                    "most-active" in fav_keys,
+                    authenticated=authenticated,
+                ),
+                cls="shrink-0 hidden sm:flex items-center gap-2",
             ),
             cls="mb-6 gap-4 flex-col sm:flex-row items-start sm:items-center",
         ),
@@ -606,6 +723,8 @@ def _render_by_country_content(
     country_rankings: list[dict],
     description: str,
     total_countries: int = 0,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
 ) -> Div:
     """
     Renders By Country tab with grouped country sections.
@@ -640,7 +759,10 @@ def _render_by_country_content(
         ),
         # Country cards grid — HTMX load-more appends into this div
         Div(
-            *[_country_group_card(c) for c in country_rankings],
+            *[
+                _country_group_card(c, fav_keys=fav_keys, authenticated=authenticated)
+                for c in country_rankings
+            ],
             id="country-groups-grid",
             cls="grid grid-cols-1 md:grid-cols-2 gap-4",
         ),
@@ -664,6 +786,8 @@ def _render_by_category_content(
     category_rankings: list[dict],
     description: str,
     total_categories: int = 0,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
 ) -> Div:
     """
     Renders By Category tab with grouped category sections.
@@ -702,7 +826,10 @@ def _render_by_category_content(
         ),
         # Category cards grid — HTMX load-more appends into this div
         Div(
-            *[_category_group_card(c) for c in category_rankings],
+            *[
+                _category_group_card(c, fav_keys=fav_keys, authenticated=authenticated)
+                for c in category_rankings
+            ],
             id="category-groups-grid",
             cls="grid grid-cols-1 md:grid-cols-2 gap-4",
         ),
@@ -726,6 +853,8 @@ def _render_by_language_content(
     language_rankings: list[dict],
     description: str,
     total_languages: int = 0,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
 ) -> Div:
     """
     Renders By Language tab with grouped language sections.
@@ -760,7 +889,10 @@ def _render_by_language_content(
         ),
         # Language cards grid — HTMX load-more appends into this div
         Div(
-            *[_language_group_card(c) for c in language_rankings],
+            *[
+                _language_group_card(c, fav_keys=fav_keys, authenticated=authenticated)
+                for c in language_rankings
+            ],
             id="language-groups-grid",
             cls="grid grid-cols-1 md:grid-cols-2 gap-4",
         ),
@@ -780,7 +912,12 @@ def _render_by_language_content(
     )
 
 
-def _render_rising_content(creators: list[dict], description: str) -> Div:
+def _render_rising_content(
+    creators: list[dict],
+    description: str,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
     """Renders Rising Stars tab with growth metrics."""
     if not creators:
         return _placeholder_content(description, coming_soon=False)
@@ -793,7 +930,14 @@ def _render_rising_content(creators: list[dict], description: str) -> Div:
                     f"{len(creators)} creators",
                     cls="text-sm font-medium text-foreground",
                 ),
-                cls="shrink-0 hidden sm:block",
+                _list_heart_btn(
+                    "rising",
+                    "🚀 Rising Stars",
+                    "/lists?tab=rising",
+                    "rising" in fav_keys,
+                    authenticated=authenticated,
+                ),
+                cls="shrink-0 hidden sm:flex items-center gap-2",
             ),
             cls="mb-6 gap-4 flex-col sm:flex-row items-start sm:items-center",
         ),
@@ -808,7 +952,12 @@ def _render_rising_content(creators: list[dict], description: str) -> Div:
     )
 
 
-def _render_veterans_content(creators: list[dict], description: str) -> Div:
+def _render_veterans_content(
+    creators: list[dict],
+    description: str,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
     """Renders Veterans tab with channel age."""
     if not creators:
         return _placeholder_content(description, coming_soon=False)
@@ -821,7 +970,14 @@ def _render_veterans_content(creators: list[dict], description: str) -> Div:
                     f"{len(creators)} creators",
                     cls="text-sm font-medium text-foreground",
                 ),
-                cls="shrink-0 hidden sm:block",
+                _list_heart_btn(
+                    "veterans",
+                    "🏅 Veterans",
+                    "/lists?tab=veterans",
+                    "veterans" in fav_keys,
+                    authenticated=authenticated,
+                ),
+                cls="shrink-0 hidden sm:flex items-center gap-2",
             ),
             cls="mb-6 gap-4 flex-col sm:flex-row items-start sm:items-center",
         ),
@@ -941,6 +1097,8 @@ def render_more_countries(
     next_offset: int,
     has_more: bool,
     total: int = 0,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
 ) -> FT:
     """
     HTMX partial response for load-more countries.
@@ -949,7 +1107,7 @@ def render_more_countries(
         - New country group cards (appended into #country-groups-grid by hx-swap=beforeend)
         - An oob-swap to replace the old load-more button div
     """
-    cards = [_country_group_card(g) for g in groups]
+    cards = [_country_group_card(g, fav_keys=fav_keys, authenticated=authenticated) for g in groups]
 
     # Build the replacement load-more element; oob=True makes the element
     # carry hx-swap-oob itself so no extra wrapper div is needed.
@@ -974,6 +1132,8 @@ def render_more_categories(
     next_offset: int,
     has_more: bool,
     total: int = 0,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
 ) -> FT:
     """
     HTMX partial response for load-more categories.
@@ -982,7 +1142,9 @@ def render_more_categories(
         - New category group cards (appended into #category-groups-grid)
         - An oob-swap to replace the old load-more button div
     """
-    cards = [_category_group_card(g) for g in groups]
+    cards = [
+        _category_group_card(g, fav_keys=fav_keys, authenticated=authenticated) for g in groups
+    ]
 
     new_button = (
         _load_more_button(
@@ -1005,6 +1167,8 @@ def render_more_languages(
     next_offset: int,
     has_more: bool,
     total: int = 0,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
 ) -> FT:
     """
     HTMX partial response for load-more languages.
@@ -1013,7 +1177,9 @@ def render_more_languages(
         - New language group cards (appended into #language-groups-grid by hx-swap=beforeend)
         - An oob-swap to replace the old load-more button div
     """
-    cards = [_language_group_card(g) for g in groups]
+    cards = [
+        _language_group_card(g, fav_keys=fav_keys, authenticated=authenticated) for g in groups
+    ]
 
     new_button = (
         _load_more_button(
@@ -1031,7 +1197,12 @@ def render_more_languages(
     return (*cards, new_button)
 
 
-def render_lists_page(active_tab: str = "top-rated", tab_data: dict = None) -> FT:
+def render_lists_page(
+    active_tab: str = "top-rated",
+    tab_data: dict = None,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> FT:
     """
     Renders the full /lists page with tabbed creator list navigation.
     Tabs use UIkit's switcher for zero-JS panel switching.
@@ -1074,10 +1245,14 @@ def render_lists_page(active_tab: str = "top-rated", tab_data: dict = None) -> F
             panel_items.append(Li(_placeholder_content(description, coming_soon=True)))
         elif tab_id == "top-rated":
             creators = tab_data.get("top_rated", [])
-            panel_items.append(Li(_render_top_rated_content(creators, description)))
+            panel_items.append(
+                Li(_render_top_rated_content(creators, description, fav_keys, authenticated))
+            )
         elif tab_id == "most-active":
             creators = tab_data.get("most_active", [])
-            panel_items.append(Li(_render_most_active_content(creators, description)))
+            panel_items.append(
+                Li(_render_most_active_content(creators, description, fav_keys, authenticated))
+            )
         elif tab_id == "by-country":
             country_rankings = tab_data.get("country_rankings", [])
             panel_items.append(
@@ -1086,6 +1261,8 @@ def render_lists_page(active_tab: str = "top-rated", tab_data: dict = None) -> F
                         country_rankings,
                         description,
                         total_countries=total_countries,
+                        fav_keys=fav_keys,
+                        authenticated=authenticated,
                     )
                 )
             )
@@ -1097,6 +1274,8 @@ def render_lists_page(active_tab: str = "top-rated", tab_data: dict = None) -> F
                         category_rankings,
                         description,
                         total_categories=total_categories,
+                        fav_keys=fav_keys,
+                        authenticated=authenticated,
                     )
                 )
             )
@@ -1108,15 +1287,21 @@ def render_lists_page(active_tab: str = "top-rated", tab_data: dict = None) -> F
                         language_rankings,
                         description,
                         total_languages=total_languages,
+                        fav_keys=fav_keys,
+                        authenticated=authenticated,
                     )
                 )
             )
         elif tab_id == "rising":
             creators = tab_data.get("rising", [])
-            panel_items.append(Li(_render_rising_content(creators, description)))
+            panel_items.append(
+                Li(_render_rising_content(creators, description, fav_keys, authenticated))
+            )
         elif tab_id == "veterans":
             creators = tab_data.get("veterans", [])
-            panel_items.append(Li(_render_veterans_content(creators, description)))
+            panel_items.append(
+                Li(_render_veterans_content(creators, description, fav_keys, authenticated))
+            )
         else:
             panel_items.append(Li(_placeholder_content(description, coming_soon=False)))
 

--- a/views/my_dashboards.py
+++ b/views/my_dashboards.py
@@ -172,6 +172,7 @@ def render_my_dashboards_page(
     sort: str = "recent",
     plan_info: dict | None = None,
     fav_creators: list[dict] | None = None,
+    fav_lists: list[dict] | None = None,
     has_more: bool = False,
     page: int = 1,
 ) -> Div:
@@ -193,6 +194,7 @@ def render_my_dashboards_page(
     }
     plan = _plan_info.get("plan", "free")
     _fav_creators = fav_creators or []
+    _fav_lists = fav_lists or []
 
     return Container(
         # ── 1. Header ──────────────────────────────────────────────────────
@@ -202,7 +204,7 @@ def render_my_dashboards_page(
         # ── 3. Playlist Analysis ───────────────────────────────────────────
         _section_analysis(dashboards, search, sort, has_more=has_more, page=page),
         # ── 4. Lists ───────────────────────────────────────────────────────
-        _section_lists(),
+        _section_lists(_fav_lists),
         # ── 5. Campaigns ───────────────────────────────────────────────────
         _section_campaigns(plan),
         cls=ContainerT.xl,
@@ -277,14 +279,71 @@ def _section_analysis(
     )
 
 
-def _section_lists() -> Div:
-    """Quick-access tiles for the public Lists product."""
+def _section_lists(fav_lists: list[dict] | None = None) -> Div:
+    """Quick-access tiles for the public Lists product.
+
+    When the user has saved lists, shows those tiles (with unsave hearts).
+    Falls back to 5 default discovery tiles otherwise.
+    """
+    if fav_lists:
+
+        def _saved_tile(item: dict):
+            key = item.get("list_key", "")
+            label = item.get("list_label", "List")
+            url = item.get("list_url", "/lists")
+            btn_id = f"heart-{key.replace(':', '-').replace(' ', '-')}"
+            unsave_form = Form(
+                Input(type="hidden", name="list_key", value=key),
+                Input(type="hidden", name="list_label", value=label),
+                Input(type="hidden", name="list_url", value=url),
+                Button(
+                    UkIcon("heart", cls="size-3.5 fill-red-400 text-red-400"),
+                    type="submit",
+                    title="Remove from dashboard",
+                    cls="absolute top-1.5 right-1.5 p-0.5 rounded hover:bg-red-50 transition-colors",
+                ),
+                id=btn_id,
+                hx_post="/me/favourite-list",
+                hx_swap="none",
+                hx_on__after_request="this.closest('[data-list-tile]').remove()",
+                cls="contents",
+            )
+            return Div(
+                A(
+                    Div(
+                        Span(label[:2], cls="text-2xl mb-1 block"),
+                        Span(
+                            label[2:].strip() if len(label) > 2 else label,
+                            cls="text-xs font-medium text-gray-700 text-center leading-tight line-clamp-2",
+                        ),
+                        cls="flex flex-col items-center justify-center p-3 pt-4",
+                    ),
+                    href=url,
+                    cls="block no-underline flex-1",
+                ),
+                unsave_form,
+                data_list_tile="1",
+                cls=(
+                    "relative rounded-xl border border-red-200 bg-red-50/40 hover:border-red-300 "
+                    "hover:shadow-sm transition-all duration-150 flex flex-col"
+                ),
+            )
+
+        return Div(
+            _section_label("📋", "Saved Lists", href="/lists"),
+            Div(
+                *[_saved_tile(item) for item in fav_lists[:8]],
+                cls="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-8 gap-3",
+            ),
+            cls="mb-10",
+        )
+
     tiles = [
-        ("🏆", "Top Rated", "/lists/top-rated"),
-        ("🚀", "Rising Stars", "/lists/rising-stars"),
-        ("⚡", "Most Active", "/lists/most-active"),
-        ("🌍", "By Country", "/lists"),
-        ("🎮", "By Category", "/lists"),
+        ("🏆", "Top Rated", "/lists?tab=top-rated"),
+        ("🚀", "Rising Stars", "/lists?tab=rising"),
+        ("⚡", "Most Active", "/lists?tab=most-active"),
+        ("🌍", "By Country", "/lists?tab=by-country"),
+        ("🎨", "By Category", "/lists?tab=by-category"),
     ]
 
     def _tile(emoji, label, href):
@@ -306,6 +365,14 @@ def _section_lists() -> Div:
         Div(
             *[_tile(e, l, h) for e, l, h in tiles],
             cls="grid grid-cols-5 gap-3",
+        ),
+        P(
+            A(
+                "♥ Heart any list on the Lists page to pin it here.",
+                href="/lists",
+                cls="text-red-400 hover:underline",
+            ),
+            cls="text-xs text-gray-400 mt-2",
         ),
         cls="mb-10",
     )


### PR DESCRIPTION
- Add user_favourite_lists table (migration 021) with unique constraint on (user_id, list_key)
- Add add/remove/get_user_favourite_lists/get_user_favourite_list_keys DB functions with input validation (_LIST_KEY_RE allowlist, /lists URL guard)
- Render heart toggle button (_list_heart_btn) on all list cards and tab views; unauthenticated users see a static greyed icon
- Thread fav_keys + authenticated context through all list renderers and HTMX partial routes
- Add POST /me/favourite-list toggle route returning replacement HTMX component (outerHTML swap)
- Show pinned list tiles on /me/dashboards; client-side DOM removal on unsave (no round-trip); falls back to discovery tiles with "♥ Heart any list" hint when empty

## Summary by Sourcery

Add support for users to bookmark curated lists and surface them on their dashboards.

New Features:
- Introduce a user_favourite_lists table and related DB helpers to store bookmarked list metadata per user.
- Add heart toggle controls to list and group views so authenticated users can save or unsave curated lists via an HTMX POST endpoint.
- Display a Saved Lists section on the user dashboard populated from the user’s bookmarked lists, with quick unsave controls and a fallback discovery layout when empty.

Enhancements:
- Thread authenticated state and favourite list keys through list rendering and HTMX load-more routes to drive heart button state.