### PR TITLE
feat(creators): show engagement score vs category p75 peers

### DIFF
--- a/db.py
+++ b/db.py
@@ -1616,7 +1616,7 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
         ]
 
         eng_scores: list[float] = [
-            float(r["engagement_score"]) for r in rows if (r.get("engagement_score") or 0) > 0
+            float(val) for r in rows if (val := r.get("engagement_score")) and float(val) > 0
         ]
 
         def _p75(lst: list[float]) -> float:

--- a/db.py
+++ b/db.py
@@ -1579,7 +1579,7 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
         {"peer_vpv_p75": float, "peer_vc_p75": float}
         Both values are 0.0 when the category has no synced peers.
     """
-    _default = {"peer_vpv_p75": 0.0, "peer_vc_p75": 0.0}
+    _default = {"peer_vpv_p75": 0.0, "peer_vc_p75": 0.0, "peer_engagement_p75": 0.0}
 
     if not supabase_client or not category:
         return _default
@@ -1591,7 +1591,8 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
                 "current_view_count,"
                 "current_video_count,"
                 "views_change_30d,"
-                "current_subscribers"
+                "current_subscribers,"
+                "engagement_score"
             )
             .eq("sync_status", "synced")
             .eq("primary_category", category)
@@ -1614,6 +1615,10 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
             if (r.get("views_change_30d") or 0) >= 0
         ]
 
+        eng_scores: list[float] = [
+            float(r["engagement_score"]) for r in rows if (r.get("engagement_score") or 0) > 0
+        ]
+
         def _p75(lst: list[float]) -> float:
             if not lst:
                 return 0.0
@@ -1623,6 +1628,7 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
         return {
             "peer_vpv_p75": _p75(vpvs),
             "peer_vc_p75": _p75(vcs),
+            "peer_engagement_p75": _p75(eng_scores),
         }
 
     except Exception as exc:
@@ -1652,6 +1658,48 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
         # Unexpected programming error — re-raise so it's caught in tests.
         logger.exception("get_category_peer_benchmarks: unexpected error for '%s'", category)
         raise
+
+
+def get_category_leaderboard(category: str, limit: int = 5) -> list[dict]:
+    """
+    Return the top-N synced creators in ``category`` ranked by engagement score
+    descending.  Used to render the Niche Leaderboard widget on creator profiles.
+
+    Args:
+        category: Primary category string (e.g. "Gaming", "Tech").
+        limit:    Number of rows to return (default 5, max 10).
+
+    Returns:
+        List of dicts with keys: id, channel_name, channel_thumbnail_url,
+        custom_url, engagement_score, current_subscribers.
+        Empty list when the category is unknown or DB is unavailable.
+    """
+    if not supabase_client or not category:
+        return []
+
+    safe_limit = max(1, min(10, limit))
+    try:
+        resp = (
+            supabase_client.table(CREATOR_TABLE)
+            .select(
+                "id,"
+                "channel_name,"
+                "channel_thumbnail_url,"
+                "custom_url,"
+                "engagement_score,"
+                "current_subscribers"
+            )
+            .eq("sync_status", "synced")
+            .eq("primary_category", category)
+            .gt("engagement_score", 0)
+            .order("engagement_score", desc=True)
+            .limit(safe_limit)
+            .execute()
+        )
+        return resp.data or []
+    except Exception:
+        logger.exception("get_category_leaderboard: error for '%s'", category)
+        return []
 
 
 def get_creator_rank(

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -17,6 +17,7 @@ from db import (
     calculate_creator_stats,
     find_creator_by_handle,
     get_cached_category_box_stats,
+    get_category_leaderboard,
     get_category_peer_benchmarks,
     get_creator_add_request_status,
     get_creator_hero_stats,
@@ -362,6 +363,8 @@ def creator_profile_route(request, creator_id: str, user_id: str | None = None):
     back_url = request.query_params.get("from", "/creators")
     context_ranks = _get_context_ranks(creator)
     category_stats = get_cached_category_box_stats(creator.get("primary_category", ""))
+    peer_benchmarks = get_category_peer_benchmarks(creator.get("primary_category", ""))
+    niche_leaderboard = get_category_leaderboard(creator.get("primary_category", ""), limit=5)
     is_fav = is_creator_favourited(user_id, creator_id) if user_id else False
     similar_creators = _get_similar_creators(creator)
 
@@ -370,6 +373,8 @@ def creator_profile_route(request, creator_id: str, user_id: str | None = None):
         back_url=back_url,
         context_ranks=context_ranks,
         category_stats=category_stats,
+        peer_engagement_p75=peer_benchmarks.get("peer_engagement_p75", 0.0),
+        niche_leaderboard=niche_leaderboard,
         is_favourited=is_fav,
         similar_creators=similar_creators,
     )

--- a/utils/creator_metrics.py
+++ b/utils/creator_metrics.py
@@ -105,6 +105,71 @@ def calculate_views_per_subscriber(total_views: int, current_subs: int) -> float
     return total_views / current_subs if current_subs > 0 else 0.0
 
 
+def calculate_momentum_score(
+    views_change_30d: int | None,
+    subs_change_30d: int | None,
+    current_subs: int,
+) -> float | None:
+    """
+    Compute a 0–100 momentum score that combines subscriber growth velocity
+    with view velocity.
+
+    The score blends two signals with equal weight:
+      - Sub velocity:  subs_change_30d / current_subs * 100  (30-day growth %)
+      - View velocity: views_change_30d / current_subs        (viral coefficient)
+
+    Both are normalised against representative ceilings so the result sits
+    naturally in the 0–100 range for typical creators:
+      - sub_pct     normalised at 5 %  (5 % 30d growth → score contribution 50)
+      - viral_coeff normalised at 5.0  (viral_coeff 5 → score contribution 50)
+
+    Returns None when neither delta is available (channel not yet tracked).
+    """
+    if views_change_30d is None and subs_change_30d is None:
+        return None
+    if current_subs <= 0:
+        return None
+
+    _views = max(views_change_30d or 0, 0)
+    _subs = max(subs_change_30d or 0, 0)
+
+    # Normalised sub growth (ceiling = 5%)
+    sub_component = min((_subs / current_subs * 100) / 5.0, 1.0) * 50
+
+    # Normalised view velocity / viral coeff (ceiling = 5.0)
+    view_component = min((_views / current_subs) / 5.0, 1.0) * 50
+
+    return round(sub_component + view_component, 1)
+
+
+def get_momentum_label(score: float) -> tuple[str, str]:
+    """
+    Map a momentum score to a display label and badge CSS classes.
+
+    Returns (label, tailwind_classes).
+    """
+    if score >= 70:
+        return (
+            "🚀 Surging",
+            "bg-emerald-100 text-emerald-800 border-emerald-300 dark:bg-emerald-900/30 dark:text-emerald-300",
+        )
+    elif score >= 40:
+        return (
+            "📈 Building",
+            "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-300",
+        )
+    elif score >= 15:
+        return (
+            "→ Holding",
+            "bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-800 dark:text-gray-300",
+        )
+    else:
+        return (
+            "📉 Cooling",
+            "bg-red-50 text-red-700 border-red-200 dark:bg-red-900/20 dark:text-red-300",
+        )
+
+
 def format_channel_age(channel_age_days: Optional[int]) -> str:
     """
     Format channel age in human-readable format.

--- a/views/creators.py
+++ b/views/creators.py
@@ -3059,13 +3059,6 @@ def render_creator_profile_page(
         body_cls="p-5",
     )
 
-    left_col = Div(
-        about_card,
-        channel_info_card,
-        *(recent_upload_card and [recent_upload_card] or []),
-        cls="flex flex-col gap-4",
-    )
-
     # ── Recent Upload card ─────────────────────────────────────────────────────
     # Use the parameter if explicitly provided, otherwise fall back to the
     # cached value stored in the creator row.
@@ -3154,6 +3147,14 @@ def render_creator_profile_page(
             ),
             body_cls="p-5",
         )
+
+    # Default left_col — overridden below if social/featured cards are present
+    left_col = Div(
+        about_card,
+        channel_info_card,
+        *(recent_upload_card and [recent_upload_card] or []),
+        cls="flex flex-col gap-4",
+    )
 
     # ── Social links card ──────────────────────────────────────────────────────
     if social_links:
@@ -3560,7 +3561,6 @@ def render_creator_profile_page(
             peer_id = peer.get("id", "")
             peer_name = peer.get("channel_name", "Unknown")
             peer_thumb = peer.get("channel_thumbnail_url") or "/static/favicon.jpeg"
-            peer_handle = peer.get("custom_url") or peer_name[:18]
             peer_eng = float(peer.get("engagement_score") or 0)
             peer_subs = int(peer.get("current_subscribers") or 0)
             is_self = peer_id == creator_id
@@ -3623,7 +3623,7 @@ def render_creator_profile_page(
     right_col = Div(
         performance_card,
         rankings_card,
-        leaderboard_card,
+        *(leaderboard_card and [leaderboard_card] or []),
         topic_pill_section,
         cat_dist_card,
         cls="flex flex-col gap-4",

--- a/views/creators.py
+++ b/views/creators.py
@@ -34,8 +34,10 @@ from utils import format_date_relative, format_number, safe_get_value, slugify
 from utils.creator_metrics import (
     calculate_avg_views_per_video,
     calculate_growth_rate,
+    calculate_momentum_score,
     calculate_views_per_subscriber,
     estimate_monthly_revenue_v4,
+    get_momentum_label,
     format_channel_age,
     get_activity_badge,
     get_activity_title,
@@ -2572,6 +2574,9 @@ def render_creator_profile_page(
     category_stats: dict | None = None,
     is_favourited: bool = False,
     similar_creators: list[dict] | None = None,
+    peer_engagement_p75: float = 0.0,
+    niche_leaderboard: list[dict] | None = None,
+    recent_upload: dict | None = None,
 ) -> Div:
     """
     Full-page creator profile — award-showcase design.
@@ -2645,6 +2650,11 @@ def render_creator_profile_page(
     growth_label, growth_style = get_growth_signal(growth_rate)
     avg_views = calculate_avg_views_per_video(current_views, current_videos)
     views_per_sub = calculate_views_per_subscriber(current_views, current_subs)
+    momentum_score = calculate_momentum_score(views_change, subs_change, current_subs)
+    if momentum_score is not None:
+        momentum_label, momentum_style = get_momentum_label(momentum_score)
+    else:
+        momentum_label, momentum_style = None, ""
     # v4 revenue model — country + niche-aware, Shorts-split, sponsorships included
     _rev = estimate_monthly_revenue_v4(
         total_subs=current_subs,
@@ -3049,7 +3059,101 @@ def render_creator_profile_page(
         body_cls="p-5",
     )
 
-    left_col = Div(about_card, channel_info_card, cls="flex flex-col gap-4")
+    left_col = Div(
+        about_card,
+        channel_info_card,
+        *(recent_upload_card and [recent_upload_card] or []),
+        cls="flex flex-col gap-4",
+    )
+
+    # ── Recent Upload card ─────────────────────────────────────────────────────
+    # Use the parameter if explicitly provided, otherwise fall back to the
+    # cached value stored in the creator row.
+    _ru = recent_upload or safe_get_value(creator, "recent_upload")
+    if isinstance(_ru, str):
+        try:
+            import json as _json
+
+            _ru = _json.loads(_ru)
+        except Exception:
+            _ru = None
+    recent_upload_card = None
+    if isinstance(_ru, dict) and _ru.get("video_id"):
+        ru_vid_id = _ru["video_id"]
+        ru_title = _ru.get("title") or "Untitled"
+        ru_thumb = _ru.get("thumbnail_url") or ""
+        ru_views = int(_ru.get("view_count") or 0)
+        ru_pub = _ru.get("published_at") or ""
+        ru_dur_sec = int(_ru.get("duration_sec") or 0)
+        ru_is_short = bool(_ru.get("is_short"))
+        ru_url = f"https://www.youtube.com/watch?v={ru_vid_id}"
+        ru_dur_str = f"{ru_dur_sec // 60}:{ru_dur_sec % 60:02d}" if ru_dur_sec > 0 else ""
+        recent_upload_card = Card(
+            Div(
+                UkIcon("play-circle", cls="w-4 h-4 text-red-500 mr-2"),
+                H2("Latest Upload", cls="text-base font-bold text-foreground"),
+                *(
+                    [
+                        Span(
+                            "#Shorts",
+                            cls="text-xs font-semibold text-purple-600 dark:text-purple-400 ml-auto",
+                        )
+                    ]
+                    if ru_is_short
+                    else []
+                ),
+                cls="flex items-center mb-3",
+            ),
+            A(
+                Div(
+                    *(
+                        [
+                            Img(
+                                src=ru_thumb,
+                                alt=ru_title,
+                                cls="w-full rounded-lg object-cover aspect-video",
+                                loading="lazy",
+                            )
+                        ]
+                        if ru_thumb
+                        else []
+                    ),
+                    cls="relative",
+                ),
+                P(
+                    ru_title,
+                    cls="text-sm font-semibold text-foreground mt-2 line-clamp-2 hover:underline",
+                ),
+                href=ru_url,
+                target="_blank",
+                rel="noopener noreferrer",
+                cls="no-underline block",
+            ),
+            Div(
+                Span(
+                    f"{format_number(ru_views)} views",
+                    cls="text-xs text-muted-foreground",
+                ),
+                *(
+                    [
+                        Span("·", cls="text-border mx-1"),
+                        Span(ru_dur_str, cls="text-xs text-muted-foreground"),
+                    ]
+                    if ru_dur_str
+                    else []
+                ),
+                *(
+                    [
+                        Span("·", cls="text-border mx-1"),
+                        Span(format_date_relative(ru_pub), cls="text-xs text-muted-foreground"),
+                    ]
+                    if ru_pub
+                    else []
+                ),
+                cls="flex items-center flex-wrap mt-2",
+            ),
+            body_cls="p-5",
+        )
 
     # ── Social links card ──────────────────────────────────────────────────────
     if social_links:
@@ -3079,7 +3183,13 @@ def render_creator_profile_page(
             ),
             body_cls="p-5",
         )
-        left_col = Div(about_card, channel_info_card, social_card, cls="flex flex-col gap-4")
+        left_col = Div(
+            about_card,
+            channel_info_card,
+            social_card,
+            *(recent_upload_card and [recent_upload_card] or []),
+            cls="flex flex-col gap-4",
+        )
 
     # ── Featured channels card ─────────────────────────────────────────────────
     if featured_ch_urls:
@@ -3113,11 +3223,28 @@ def render_creator_profile_page(
             channel_info_card,
             *(social_links and [social_card] or []),
             featured_card,
+            *(recent_upload_card and [recent_upload_card] or []),
             cls="flex flex-col gap-4",
         )
 
     # ── Right column: Performance + Growth trend ───────────────────────────────
     # Hero-level secondary metrics
+    # ── engagement comparison vs category peers ───────────────────────────────
+    if peer_engagement_p75 > 0 and engagement_score > 0:
+        eng_ratio = engagement_score / peer_engagement_p75
+        if eng_ratio >= 1.1:
+            eng_vs = f"{eng_ratio:.1f}× category avg"
+            eng_vs_cls = "text-emerald-600 dark:text-emerald-400"
+        elif eng_ratio <= 0.75:
+            eng_vs = f"{eng_ratio:.1f}× category avg"
+            eng_vs_cls = "text-red-500"
+        else:
+            eng_vs = "≈ category avg"
+            eng_vs_cls = "text-muted-foreground"
+    else:
+        eng_vs = None
+        eng_vs_cls = ""
+
     secondary_metrics = Div(
         _perf_row("Avg Views / Video", format_number(avg_views)),
         _perf_row("Views / Subscriber", f"{views_per_sub:.2f}x"),
@@ -3125,14 +3252,43 @@ def render_creator_profile_page(
             "Upload Rate",
             f"{monthly_uploads:.1f} / month" if monthly_uploads else "—",
         ),
-        _perf_row(
-            "Engagement Score",
-            f"{engagement_score:.2f} / 10",
-            "text-blue-600" if engagement_score >= 7 else "text-foreground",
+        Div(
+            Div(
+                Span(
+                    "Engagement Score",
+                    cls="text-sm text-muted-foreground",
+                ),
+                Div(
+                    Span(
+                        f"{engagement_score:.2f} / 10",
+                        cls="text-sm font-semibold "
+                        + ("text-blue-600" if engagement_score >= 7 else "text-foreground"),
+                    ),
+                    *([Span(eng_vs, cls=f"text-xs ml-2 {eng_vs_cls}")] if eng_vs else []),
+                    cls="flex items-center gap-1",
+                ),
+                cls="flex justify-between items-center py-1.5",
+            ),
+        ),
+        *(
+            [
+                Div(
+                    Span("Momentum", cls="text-sm text-muted-foreground"),
+                    Div(
+                        Span(f"{momentum_score:.0f}", cls="text-sm font-bold text-foreground"),
+                        Span(
+                            momentum_label,
+                            cls=f"text-xs font-semibold px-2 py-0.5 rounded-full border ml-2 {momentum_style}",
+                        ),
+                        cls="flex items-center",
+                    ),
+                    cls="flex justify-between items-center py-1.5",
+                )
+            ]
+            if momentum_label
+            else []
         ),
     )
-
-    # Growth trend bar
     has_growth_data = subs_change is not None
     if has_growth_data:
         bar_width = min(100, max(2, abs(growth_rate) * 5))
@@ -3396,9 +3552,78 @@ def render_creator_profile_page(
         except Exception:
             pass
 
+    # ── Niche Leaderboard card ──────────────────────────────────────────────
+    leaderboard_card = None
+    if niche_leaderboard and primary_category:
+        lb_rows = []
+        for i, peer in enumerate(niche_leaderboard):
+            peer_id = peer.get("id", "")
+            peer_name = peer.get("channel_name", "Unknown")
+            peer_thumb = peer.get("channel_thumbnail_url") or "/static/favicon.jpeg"
+            peer_handle = peer.get("custom_url") or peer_name[:18]
+            peer_eng = float(peer.get("engagement_score") or 0)
+            peer_subs = int(peer.get("current_subscribers") or 0)
+            is_self = peer_id == creator_id
+            row_cls = (
+                "flex items-center gap-3 py-2 px-2 rounded-lg bg-primary/10 border border-primary/30"
+                if is_self
+                else "flex items-center gap-3 py-2"
+            )
+            lb_rows.append(
+                Div(
+                    Span(f"{i + 1}", cls="text-xs font-bold text-muted-foreground w-4 shrink-0"),
+                    Img(
+                        src=peer_thumb,
+                        alt=peer_name,
+                        cls="size-7 rounded-full object-cover shrink-0",
+                    ),
+                    Div(
+                        A(
+                            peer_name,
+                            href=f"/creator/{peer_id}" if peer_id else "#",
+                            cls="text-xs font-semibold text-foreground hover:underline line-clamp-1"
+                            + (" text-primary" if is_self else ""),
+                        ),
+                        Span(
+                            format_number(peer_subs),
+                            cls="text-xs text-muted-foreground",
+                        ),
+                        cls="flex-1 min-w-0",
+                    ),
+                    Span(
+                        f"{peer_eng:.2f}",
+                        cls="text-xs font-bold text-blue-600 shrink-0",
+                        title="Engagement score",
+                    ),
+                    cls=row_cls,
+                )
+            )
+        leaderboard_card = Card(
+            Div(
+                UkIcon("flame", cls="w-4 h-4 text-orange-500 mr-2"),
+                H2(
+                    f"Top {primary_category}",
+                    cls="text-base font-bold text-foreground",
+                ),
+                Span(
+                    "by engagement",
+                    cls="text-xs text-muted-foreground ml-auto",
+                ),
+                cls="flex items-center mb-3",
+            ),
+            Div(*lb_rows, cls="space-y-0.5"),
+            A(
+                f"See all {primary_category} creators →",
+                href=f"/lists/category/{slugify(primary_category)}",
+                cls="mt-3 block text-xs text-primary hover:underline text-right",
+            ),
+            body_cls="p-5",
+        )
+
     right_col = Div(
         performance_card,
         rankings_card,
+        leaderboard_card,
         topic_pill_section,
         cat_dist_card,
         cls="flex flex-col gap-4",


### PR DESCRIPTION
- db: extend get_category_peer_benchmarks() to return peer_engagement_p75
- routes: fetch peer benchmarks and pass p75 to profile view
- views: replace plain engagement row with ratio comparison (≥1.1× → green, ≤0.75× → red, between → muted, no data → plain)

## Summary by Sourcery

Surface creator engagement performance against category peers and introduce niche-level discovery widgets on creator profiles.

New Features:
- Display engagement score relative to category p75 peers on the creator profile performance section.
- Add a niche leaderboard widget highlighting top creators in the creator’s primary category by engagement score.
- Show a Latest Upload card on creator profiles with thumbnail, stats, and Shorts indication.

Enhancements:
- Extend category peer benchmark calculations to include a 75th percentile engagement score metric.