### PR TITLE
fix(worker): prevent segfaults and silent recent_upload drops

### DIFF
--- a/services/schema_detector.py
+++ b/services/schema_detector.py
@@ -65,7 +65,30 @@ class SchemaDetector:
             return self.available_columns
 
         try:
-            # Try to fetch schema via RPC or direct query
+            # Fetch column names from information_schema — this is reliable regardless
+            # of whether rows exist or have NULL values. PostgREST omits NULL-valued
+            # columns from SELECT * results, so reading keys() from a live row
+            # silently misses columns that haven't been populated yet (e.g. recent_upload).
+            try:
+                schema_resp = (
+                    supabase_client.table("information_schema.columns")
+                    .select("column_name")
+                    .eq("table_schema", "public")
+                    .eq("table_name", table_name)
+                    .execute()
+                )
+                if schema_resp.data:
+                    self.available_columns = {r["column_name"] for r in schema_resp.data}
+                    self.initialized = True
+                    logger.info(
+                        f"✅ Schema detected for '{table_name}': "
+                        f"{len(self.available_columns)} columns available"
+                    )
+                    return self.available_columns
+            except Exception:
+                pass  # Fall through to live-row detection
+
+            # Fallback: try to fetch schema via live row
             response = supabase_client.table(table_name).select("*").limit(1).execute()
 
             if response.data and len(response.data) > 0:

--- a/services/schema_detector.py
+++ b/services/schema_detector.py
@@ -85,8 +85,12 @@ class SchemaDetector:
                         f"{len(self.available_columns)} columns available"
                     )
                     return self.available_columns
-            except Exception:
-                pass  # Fall through to live-row detection
+            except Exception as e:
+                logger.debug(
+                    "information_schema lookup failed for '%s'; falling back to live-row detection",
+                    table_name,
+                    exc_info=e,
+                )
 
             # Fallback: try to fetch schema via live row
             response = supabase_client.table(table_name).select("*").limit(1).execute()

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -1139,24 +1139,25 @@ async def handle_sync_job(
         # Category costs 2 extra quota units — only fetch when primary_category
         # is NULL (never been set). To force a re-fetch, NULL the column in DB.
         # Recent upload costs 2 quota units (playlistItems + videos) every sync.
+        #
+        # IMPORTANT: these are called sequentially (not via asyncio.gather) because
+        # all three share the same httplib2-backed YouTube client via run_in_executor.
+        # httplib2's C internals are not thread-safe — concurrent executor threads
+        # corrupt its heap, producing segfaults and "free(): corrupted unsorted chunks"
+        # crashes. Sequential calls are safe and the per-job latency increase is
+        # acceptable given EXIT_AFTER_JOB=True means only one job runs per process.
         should_fetch_categories = _needs_category_fetch(creator.get("primary_category"))
+        engagement = await _calculate_engagement_score(channel_id)
         if should_fetch_categories:
-            engagement, cat_data, recent_upload = await asyncio.gather(
-                _calculate_engagement_score(channel_id),
-                _fetch_channel_category_distribution(channel_id),
-                _fetch_recent_upload(channel_id),
-            )
+            cat_data = await _fetch_channel_category_distribution(channel_id)
         else:
-            engagement, recent_upload = await asyncio.gather(
-                _calculate_engagement_score(channel_id),
-                _fetch_recent_upload(channel_id),
-            )
             cat_data = {
                 "primary_category": creator.get("primary_category"),
                 "primary_category_id": None,
                 "category_distribution": None,  # None = leave existing DB value as-is
             }
             logger.debug(f"{job_tag} Category already set — skipping fetch")
+        recent_upload = await _fetch_recent_upload(channel_id)
         quality = _compute_quality_grade(engagement, channel_data["current_subscribers"])
 
         subs = channel_data["current_subscribers"]

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -1144,8 +1144,10 @@ async def handle_sync_job(
         # all three share the same httplib2-backed YouTube client via run_in_executor.
         # httplib2's C internals are not thread-safe — concurrent executor threads
         # corrupt its heap, producing segfaults and "free(): corrupted unsorted chunks"
-        # crashes. Sequential calls are safe and the per-job latency increase is
-        # acceptable given EXIT_AFTER_JOB=True means only one job runs per process.
+        # crashes. Sequential calls are safe; the per-job latency increase is
+        # acceptable because EXIT_AFTER_JOB ensures only one job runs per process.
+        # If EXIT_AFTER_JOB is ever disabled, consider a per-call YouTube client
+        # instance to restore safe concurrency.
         should_fetch_categories = _needs_category_fetch(creator.get("primary_category"))
         engagement = await _calculate_engagement_score(channel_id)
         if should_fetch_categories:


### PR DESCRIPTION
- Replace asyncio.gather in Stage 3.5 with sequential awaits. All three optional fetches (engagement, category, recent_upload) share the same httplib2-backed YouTube client via run_in_executor. Concurrent threads corrupt httplib2's C heap, causing SIGABRT/SIGSEGV crashes ("free(): corrupted unsorted chunks", "double free or corruption").

- Fix schema_detector to query information_schema.columns instead of reading keys() from a live row. PostgREST silently omits NULL-valued JSONB columns from SELECT * results, so recent_upload (NULL on all existing rows) was never detected — causing it to be dropped from every update payload. Falls back to live-row detection if information_schema is not accessible.

## Summary by Sourcery

Prevent creator worker crashes and ensure all creator columns, including null-valued ones, are reliably detected in the schema.

Bug Fixes:
- Retrieve table column names from information_schema.columns so NULL-valued JSONB fields like recent_upload are not silently omitted from updates.
- Run engagement, category, and recent_upload fetches sequentially instead of concurrently to avoid httplib2 heap corruption and worker segfaults.