### PR TITLE
feat(lists): implement New Channels tab

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 # Maximum rows fetched in client-side fallback scans (when RPC is unavailable).
 _MAX_FALLBACK_FETCH = 50_000
 
+# Channels created within this many days are considered "new".
+NEW_CHANNEL_MAX_AGE_DAYS = 365
+
 
 def _get_supabase_client():
     """Access the Supabase client (initialized at app startup via db.init_supabase())."""
@@ -668,7 +671,7 @@ def get_new_channels(limit: int = 20) -> list[dict]:
             .not_.is_("channel_name", "null")
             .gt("current_subscribers", 0)
             .not_.is_("channel_age_days", "null")
-            .lte("channel_age_days", 365)
+            .lte("channel_age_days", NEW_CHANNEL_MAX_AGE_DAYS)
             .order("engagement_score", desc=True)
             .limit(limit)
             .execute()

--- a/db_lists.py
+++ b/db_lists.py
@@ -637,6 +637,50 @@ def get_veteran_creators(limit: int = 20) -> list[dict]:
         return []
 
 
+def get_new_channels(limit: int = 20) -> list[dict]:
+    """
+    Get recently-created YouTube channels (channel_age_days <= 365).
+
+    Sorted by engagement_score descending so the highest-quality new
+    channels surface first rather than just the newest ones.
+
+    Filters:
+    - channel_age_days <= 365 (created within the last year on YouTube)
+    - sync_status = 'synced'
+    - current_subscribers > 0 (channel has an audience)
+
+    Args:
+        limit: Maximum number of creators to return
+
+    Returns:
+        List of creator dicts sorted by engagement_score descending
+    """
+    supabase_client = _get_supabase_client()
+    if not supabase_client:
+        logger.warning("[Lists] No Supabase client - returning empty list")
+        return []
+
+    try:
+        response = (
+            supabase_client.table("creators")
+            .select("*")
+            .eq("sync_status", "synced")
+            .not_.is_("channel_name", "null")
+            .gt("current_subscribers", 0)
+            .not_.is_("channel_age_days", "null")
+            .lte("channel_age_days", 365)
+            .order("engagement_score", desc=True)
+            .limit(limit)
+            .execute()
+        )
+
+        return response.data if response.data else []
+
+    except Exception as e:
+        logger.exception(f"Error fetching new channels: {e}")
+        return []
+
+
 # ─── Private helpers shared by all three get_top_*_with_counts functions ─────
 
 

--- a/routes/lists.py
+++ b/routes/lists.py
@@ -16,6 +16,7 @@ from db_lists import (
     get_language_groups,
     get_lists_meta,
     get_most_active_creators,
+    get_new_channels,
     get_rising_creators,
     get_top_categories_with_counts,
     get_top_countries_with_counts,
@@ -104,6 +105,9 @@ def lists_route(request):
 
     # Veterans: 10+ year channels
     tab_data["veterans"] = get_veteran_creators(limit=20)
+
+    # New Channels: created within the last year, sorted by engagement
+    tab_data["new_channels"] = get_new_channels(limit=20)
 
     # By Language: first page of groups (offset=0)
     tab_data["language_rankings"] = get_language_groups(

--- a/views/lists.py
+++ b/views/lists.py
@@ -953,13 +953,23 @@ def _render_rising_content(
     )
 
 
-def _render_veterans_content(
+def _render_simple_creator_list(
     creators: list[dict],
     description: str,
+    tab_id: str,
+    heart_label: str,
     fav_keys: frozenset = frozenset(),
     authenticated: bool = False,
+    show_growth: bool = False,
+    show_activity: bool = False,
 ) -> Div:
-    """Renders Veterans tab with channel age."""
+    """
+    Shared layout for tabs that render a flat ranked list of creators.
+
+    Handles the empty-state, header bar (description + count + heart button),
+    and creator rows. Tab-specific render functions delegate here so the
+    structure stays consistent and isn't duplicated.
+    """
     if not creators:
         return _placeholder_content(description, coming_soon=False)
 
@@ -972,10 +982,10 @@ def _render_veterans_content(
                     cls="text-sm font-medium text-foreground",
                 ),
                 _list_heart_btn(
-                    "veterans",
-                    "🏅 Veterans",
-                    "/lists?tab=veterans",
-                    "veterans" in fav_keys,
+                    tab_id,
+                    heart_label,
+                    f"/lists?tab={tab_id}",
+                    tab_id in fav_keys,
                     authenticated=authenticated,
                 ),
                 cls="shrink-0 hidden sm:flex items-center gap-2",
@@ -983,10 +993,32 @@ def _render_veterans_content(
             cls="mb-6 gap-4 flex-col sm:flex-row items-start sm:items-center",
         ),
         Div(
-            *[_creator_row(creator, rank=i + 1) for i, creator in enumerate(creators)],
+            *[
+                _creator_row(
+                    creator, rank=i + 1, show_growth=show_growth, show_activity=show_activity
+                )
+                for i, creator in enumerate(creators)
+            ],
             cls="space-y-3",
         ),
         cls="min-h-64",
+    )
+
+
+def _render_veterans_content(
+    creators: list[dict],
+    description: str,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
+    """Renders Veterans tab with channel age."""
+    return _render_simple_creator_list(
+        creators,
+        description,
+        tab_id="veterans",
+        heart_label="🏅 Veterans",
+        fav_keys=fav_keys,
+        authenticated=authenticated,
     )
 
 
@@ -997,36 +1029,14 @@ def _render_new_channels_content(
     authenticated: bool = False,
 ) -> Div:
     """Renders New Channels tab — channels created within the last year."""
-    if not creators:
-        return _placeholder_content(description, coming_soon=False)
-
-    return Div(
-        DivFullySpaced(
-            P(description, cls="text-sm text-muted-foreground max-w-xl"),
-            Div(
-                Span(
-                    f"{len(creators)} creators",
-                    cls="text-sm font-medium text-foreground",
-                ),
-                _list_heart_btn(
-                    "new-channels",
-                    "✨ New Channels",
-                    "/lists?tab=new-channels",
-                    "new-channels" in fav_keys,
-                    authenticated=authenticated,
-                ),
-                cls="shrink-0 hidden sm:flex items-center gap-2",
-            ),
-            cls="mb-6 gap-4 flex-col sm:flex-row items-start sm:items-center",
-        ),
-        Div(
-            *[
-                _creator_row(creator, rank=i + 1, show_activity=True)
-                for i, creator in enumerate(creators)
-            ],
-            cls="space-y-3",
-        ),
-        cls="min-h-64",
+    return _render_simple_creator_list(
+        creators,
+        description,
+        tab_id="new-channels",
+        heart_label="✨ New Channels",
+        fav_keys=fav_keys,
+        authenticated=authenticated,
+        show_activity=True,
     )
 
 

--- a/views/lists.py
+++ b/views/lists.py
@@ -142,7 +142,7 @@ LISTS_TABS = [
         "New Channels",
         "sparkles",
         "Channels created in the last year. Early-stage creators to watch.",
-        True,
+        False,
     ),
 ]
 
@@ -990,6 +990,46 @@ def _render_veterans_content(
     )
 
 
+def _render_new_channels_content(
+    creators: list[dict],
+    description: str,
+    fav_keys: frozenset = frozenset(),
+    authenticated: bool = False,
+) -> Div:
+    """Renders New Channels tab — channels created within the last year."""
+    if not creators:
+        return _placeholder_content(description, coming_soon=False)
+
+    return Div(
+        DivFullySpaced(
+            P(description, cls="text-sm text-muted-foreground max-w-xl"),
+            Div(
+                Span(
+                    f"{len(creators)} creators",
+                    cls="text-sm font-medium text-foreground",
+                ),
+                _list_heart_btn(
+                    "new-channels",
+                    "✨ New Channels",
+                    "/lists?tab=new-channels",
+                    "new-channels" in fav_keys,
+                    authenticated=authenticated,
+                ),
+                cls="shrink-0 hidden sm:flex items-center gap-2",
+            ),
+            cls="mb-6 gap-4 flex-col sm:flex-row items-start sm:items-center",
+        ),
+        Div(
+            *[
+                _creator_row(creator, rank=i + 1, show_activity=True)
+                for i, creator in enumerate(creators)
+            ],
+            cls="space-y-3",
+        ),
+        cls="min-h-64",
+    )
+
+
 def _placeholder_content(description: str, coming_soon: bool = False):
     """Renders the placeholder body for a single tab panel."""
 
@@ -1302,6 +1342,11 @@ def render_lists_page(
             creators = tab_data.get("veterans", [])
             panel_items.append(
                 Li(_render_veterans_content(creators, description, fav_keys, authenticated))
+            )
+        elif tab_id == "new-channels":
+            creators = tab_data.get("new_channels", [])
+            panel_items.append(
+                Li(_render_new_channels_content(creators, description, fav_keys, authenticated))
             )
         else:
             panel_items.append(Li(_placeholder_content(description, coming_soon=False)))


### PR DESCRIPTION
Replace "Coming Soon" placeholder with live data. Shows YouTube channels created within the last year (channel_age_days <= 365), sorted by engagement_score so the highest-quality emerging creators surface first. Displays monthly upload rate as the key stat column.

## Summary by Sourcery

Implement the New Channels list tab with live creator data and wire it into the lists page.

New Features:
- Add a database query for recently created YouTube channels sorted by engagement score.
- Render a New Channels tab panel showing eligible creators with activity stats and favorite support.

Enhancements:
- Replace the New Channels tab placeholder with real content driven by fetched creator data.