### PR TITLE
perf: add poll indexes to creator_sync_jobs to fix worker throughput …

### DIFF
--- a/db/migrations/026_creator_sync_jobs_poll_indexes.sql
+++ b/db/migrations/026_creator_sync_jobs_poll_indexes.sql
@@ -15,19 +15,18 @@
 
 -- ── Index 1: fresh pending jobs (no retry scheduled) ─────────────────────────
 -- Covers: WHERE status = 'pending' AND retry_at IS NULL ORDER BY created_at ASC
-CREATE INDEX IF NOT EXISTS idx_creator_sync_jobs_pending_fresh
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_creator_sync_jobs_pending_fresh
     ON public.creator_sync_jobs (created_at ASC)
     WHERE status = 'pending' AND retry_at IS NULL;
 
 -- ── Index 2: retry-ready jobs (backoff window expired) ────────────────────────
 -- Covers: WHERE status = 'pending' AND retry_at IS NOT NULL AND retry_at <= now()
 --         ORDER BY retry_at ASC
-CREATE INDEX IF NOT EXISTS idx_creator_sync_jobs_pending_retry
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_creator_sync_jobs_pending_retry
     ON public.creator_sync_jobs (retry_at ASC)
     WHERE status = 'pending' AND retry_at IS NOT NULL;
 
--- Refresh planner statistics immediately so the new indexes are used at once
-ANALYZE public.creator_sync_jobs;
+-- (No explicit ANALYZE; rely on autovacuum or run manually if needed)
 
 -- ── Verification ─────────────────────────────────────────────────────────────
 -- Run after applying to confirm both indexes exist:

--- a/db/migrations/026_creator_sync_jobs_poll_indexes.sql
+++ b/db/migrations/026_creator_sync_jobs_poll_indexes.sql
@@ -1,0 +1,39 @@
+-- Migration 026: Add polling indexes to creator_sync_jobs
+-- Purpose: Fix progressive throughput decline in the Kaggle worker
+--
+-- Root cause: _fetch_pending_jobs() runs 2 queries per job:
+--   1. WHERE status='pending' AND retry_at IS NULL  ORDER BY created_at ASC LIMIT 1
+--   2. WHERE status='pending' AND retry_at IS NOT NULL AND retry_at <= now() ORDER BY retry_at ASC LIMIT 1
+--
+-- With 800K+ rows and no covering index, both queries perform full sequential
+-- scans. Each scan takes longer as the table grows, causing jobs/hour to
+-- decline progressively (280/hr → 70/hr over 4 days observed Apr 25–29 2026).
+--
+-- Fix: two partial indexes that cover exactly the predicate + ORDER BY of each
+-- query. PostgreSQL can satisfy each query with a tiny index scan rather than
+-- reading all 800K rows.
+
+-- ── Index 1: fresh pending jobs (no retry scheduled) ─────────────────────────
+-- Covers: WHERE status = 'pending' AND retry_at IS NULL ORDER BY created_at ASC
+CREATE INDEX IF NOT EXISTS idx_creator_sync_jobs_pending_fresh
+    ON public.creator_sync_jobs (created_at ASC)
+    WHERE status = 'pending' AND retry_at IS NULL;
+
+-- ── Index 2: retry-ready jobs (backoff window expired) ────────────────────────
+-- Covers: WHERE status = 'pending' AND retry_at IS NOT NULL AND retry_at <= now()
+--         ORDER BY retry_at ASC
+CREATE INDEX IF NOT EXISTS idx_creator_sync_jobs_pending_retry
+    ON public.creator_sync_jobs (retry_at ASC)
+    WHERE status = 'pending' AND retry_at IS NOT NULL;
+
+-- Refresh planner statistics immediately so the new indexes are used at once
+ANALYZE public.creator_sync_jobs;
+
+-- ── Verification ─────────────────────────────────────────────────────────────
+-- Run after applying to confirm both indexes exist:
+--
+-- SELECT indexname, indexdef
+-- FROM pg_indexes
+-- WHERE tablename = 'creator_sync_jobs'
+--   AND indexname LIKE 'idx_creator_sync_jobs_pending%'
+-- ORDER BY indexname;

--- a/db/migrations/026_creator_sync_jobs_poll_indexes.sql
+++ b/db/migrations/026_creator_sync_jobs_poll_indexes.sql
@@ -13,6 +13,11 @@
 -- query. PostgreSQL can satisfy each query with a tiny index scan rather than
 -- reading all 800K rows.
 
+-- NOTE: CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+-- If your migration runner wraps migrations in a transaction, run these manually:
+--   1. Paste each CREATE INDEX CONCURRENTLY statement into the SQL editor.
+--   2. Run one at a time, outside any transaction.
+
 -- ── Index 1: fresh pending jobs (no retry scheduled) ─────────────────────────
 -- Covers: WHERE status = 'pending' AND retry_at IS NULL ORDER BY created_at ASC
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_creator_sync_jobs_pending_fresh


### PR DESCRIPTION
…decline

Without indexes on the two _fetch_pending_jobs() hot paths, every poll was doing a full sequential scan of the 800K-row table. This caused jobs/hr to drop from 280 → 70 over 4 days as the table grew.

- idx_creator_sync_jobs_pending_fresh: partial index on (created_at ASC) WHERE status='pending' AND retry_at IS NULL — covers the fresh-job query
- idx_creator_sync_jobs_pending_retry: partial index on (retry_at ASC) WHERE status='pending' AND retry_at IS NOT NULL — covers the retry-ready query

Each poll now resolves via a tiny index scan instead of reading all rows. Expected throughput recovery: ~280+/hr → theoretical max ~2,700/hr.

## Summary by Sourcery

Build:
- Introduce a migration that adds two partial indexes on creator_sync_jobs to optimize queries used for fetching pending and retryable jobs.