### PR TITLE
fix(manage_admins): resolve by email, validate against public.users b…

### DIFF
--- a/scripts/manage_admins.py
+++ b/scripts/manage_admins.py
@@ -1,147 +1,238 @@
 #!/usr/bin/env python3
 """
-scripts/manage_admins.py — Grant/revoke admin access for users.
+scripts/manage_admins.py — Grant/revoke admin access for ViralVibes users.
 
-Usage:
-    python3 scripts/manage_admins.py grant <user_id> <reason>
-    python3 scripts/manage_admins.py revoke <user_id>
-    python3 scripts/manage_admins.py list
-    python3 scripts/manage_admins.py check <user_id>
+IMPORTANT: user_id refers to public.users.id, NOT auth.users.id.
+           Use the email-based commands to avoid ambiguity.
 
-Example:
-    python3 scripts/manage_admins.py grant 550e8400-e29b-41d4-a716-446655440000 "Main developer"
+Commands:
+    grant  <email|uuid> [reason]  — grant admin access
+    revoke <email|uuid>           — revoke admin access
+    check  <email|uuid>           — check if a user is an admin
+    list                          — list all admins with email lookup
+
+Environment:
+    Loads .env by default. Override with --env /path/to/.env
+
+Examples:
+    python3 scripts/manage_admins.py grant user@example.com "Main developer"
+    python3 scripts/manage_admins.py check user@example.com
+    python3 scripts/manage_admins.py revoke user@example.com
     python3 scripts/manage_admins.py list
-    python3 scripts/manage_admins.py revoke 550e8400-e29b-41d4-a716-446655440000
+    python3 scripts/manage_admins.py --env .env.production list
 """
 
 import sys
 import os
 from pathlib import Path
 
-# Add parent directory to path so we can import db, etc.
+# ---------------------------------------------------------------------------
+# Bootstrap: allow --env <file> as first two args before anything else loads
+# ---------------------------------------------------------------------------
+_args = sys.argv[1:]
+_env_file = ".env"
+if len(_args) >= 2 and _args[0] == "--env":
+    _env_file = _args[1]
+    _args = _args[2:]  # strip --env <file> so the rest of the script sees clean args
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from dotenv import load_dotenv
 
-# Load env vars
-load_dotenv()
+load_dotenv(_env_file, override=True)
 
-# Initialize Supabase
 from db import init_supabase
 
-supabase_client = init_supabase()
-
-if not supabase_client:
-    print("❌ Error: Supabase client not initialized. Check SUPABASE_URL and SUPABASE_KEY.")
+sb = init_supabase()
+if not sb:
+    print(f"❌  Supabase not initialised (env: {_env_file}).")
+    print("    Check NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_KEY are set.")
     sys.exit(1)
 
 
-def grant_admin(user_id: str, reason: str = "", granted_by_id: str | None = None):
-    """Grant admin access to a user."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve(email_or_uuid: str) -> tuple[str, str] | None:
+    """
+    Return (user_id, email) from public.users for the given email or UUID.
+    Prints a clear error and returns None when not found.
+
+    This is the critical guard: admin_users.user_id is a FK to public.users.id.
+    Inserting an auth.users.id (or any random UUID) that has no matching
+    public.users row will raise a FK violation.
+    """
+    field = "email" if "@" in email_or_uuid else "id"
     try:
-        supabase_client.table("admin_users").insert(
+        resp = sb.table("users").select("id, email").eq(field, email_or_uuid).limit(1).execute()
+    except Exception as e:
+        print(f"❌  DB error resolving {email_or_uuid!r}: {e}")
+        return None
+
+    if not resp.data:
+        if field == "id":
+            print(f"❌  No row found in public.users for id={email_or_uuid!r}")
+            print("    Note: admin_users references public.users, not auth.users.")
+            print("    Try using the email address instead to avoid UUID confusion.")
+        else:
+            print(f"❌  No user found with email {email_or_uuid!r}")
+            print("    The user must have logged in at least once before being granted admin.")
+        return None
+
+    row = resp.data[0]
+    return row["id"], row["email"]
+
+
+def _already_admin(user_id: str) -> bool:
+    resp = sb.table("admin_users").select("id").eq("user_id", user_id).limit(1).execute()
+    return bool(resp.data)
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def grant_admin(target: str, reason: str = "") -> bool:
+    resolved = _resolve(target)
+    if not resolved:
+        return False
+    user_id, email = resolved
+
+    if _already_admin(user_id):
+        print(f"ℹ️   {email} ({user_id}) is already an admin. No change.")
+        return True
+
+    try:
+        sb.table("admin_users").insert(
             {
                 "user_id": user_id,
                 "reason": reason or None,
-                "granted_by": granted_by_id,
             }
         ).execute()
-        print(f"✅ Granted admin access to {user_id}")
-        print(f"   Reason: {reason or '(none)'}")
-        return True
-    except Exception as e:
-        print(f"❌ Error granting admin access: {e}")
-        return False
-
-
-def revoke_admin(user_id: str):
-    """Revoke admin access from a user."""
-    try:
-        supabase_client.table("admin_users").delete().eq("user_id", user_id).execute()
-        print(f"✅ Revoked admin access from {user_id}")
-        return True
-    except Exception as e:
-        print(f"❌ Error revoking admin access: {e}")
-        return False
-
-
-def list_admins():
-    """List all admin users."""
-    try:
-        resp = (
-            supabase_client.table("admin_users")
-            .select("id, user_id, reason, granted_at")
-            .order("granted_at", desc=True)
-            .execute()
-        )
-
-        if not resp.data:
-            print("ℹ️  No admin users yet.")
-            return
-
-        print(f"\n📋 {len(resp.data)} admin user(s):\n")
-        print(f"{'User ID':<36} {'Reason':<30} {'Granted':<20}")
-        print("-" * 86)
-
-        for admin in resp.data:
-            user_id = admin.get("user_id", "")[:36]
-            reason = admin.get("reason") or "(none)"
-            granted_at = admin.get("granted_at", "")[:19] if admin.get("granted_at") else "?"
-
-            print(f"{user_id:<36} {reason:<30} {granted_at:<20}")
-
+        print(f"✅  Granted admin access to {email} ({user_id})")
+        print(f"    Reason : {reason or '(none)'}")
         print()
+        print("    ⚠️  The user must log out and back in for the change to take effect.")
+        print("        (is_admin is cached in session at login time)")
+        return True
     except Exception as e:
-        print(f"❌ Error listing admins: {e}")
+        print(f"❌  Error inserting into admin_users: {e}")
+        return False
 
 
-def check_admin(user_id: str):
-    """Check if a user is an admin."""
+def revoke_admin(target: str) -> bool:
+    resolved = _resolve(target)
+    if not resolved:
+        return False
+    user_id, email = resolved
+
+    if not _already_admin(user_id):
+        print(f"ℹ️   {email} ({user_id}) is not an admin. No change.")
+        return True
+
+    try:
+        sb.table("admin_users").delete().eq("user_id", user_id).execute()
+        print(f"✅  Revoked admin access from {email} ({user_id})")
+        print()
+        print("    ⚠️  The user must log out and back in for the change to take effect.")
+        return True
+    except Exception as e:
+        print(f"❌  Error revoking admin access: {e}")
+        return False
+
+
+def check_admin(target: str) -> None:
+    resolved = _resolve(target)
+    if not resolved:
+        return
+    user_id, email = resolved
+
     try:
         resp = (
-            supabase_client.table("admin_users")
-            .select("id, reason, granted_at")
+            sb.table("admin_users")
+            .select("reason, granted_at")
             .eq("user_id", user_id)
             .limit(1)
             .execute()
         )
-
-        if resp.data:
-            admin = resp.data[0]
-            print(f"✅ {user_id} IS an admin")
-            print(f"   Reason: {admin.get('reason') or '(none)'}")
-            print(f"   Granted: {admin.get('granted_at', '?')[:19]}")
-        else:
-            print(f"❌ {user_id} is NOT an admin")
-            print("\n   To grant admin access:")
-            print(f"   python3 scripts/manage_admins.py grant {user_id} <reason>")
     except Exception as e:
-        print(f"❌ Error checking admin: {e}")
+        print(f"❌  DB error: {e}")
+        return
+
+    if resp.data:
+        row = resp.data[0]
+        print(f"✅  {email} IS an admin")
+        print(f"    user_id : {user_id}")
+        print(f"    reason  : {row.get('reason') or '(none)'}")
+        print(f"    granted : {(row.get('granted_at') or '')[:19]}")
+    else:
+        print(f"❌  {email} ({user_id}) is NOT an admin")
+        print(f'\n    To grant: python3 scripts/manage_admins.py grant {email} "<reason>"')
 
 
-def main():
-    """CLI entrypoint."""
-    if len(sys.argv) < 2:
+def list_admins() -> None:
+    try:
+        resp = (
+            sb.table("admin_users")
+            .select("user_id, reason, granted_at")
+            .order("granted_at", desc=True)
+            .execute()
+        )
+    except Exception as e:
+        print(f"❌  DB error: {e}")
+        return
+
+    if not resp.data:
+        print("ℹ️   No admin users yet.")
+        return
+
+    # Bulk-resolve emails from public.users
+    ids = [r["user_id"] for r in resp.data]
+    try:
+        users_resp = sb.table("users").select("id, email").in_("id", ids).execute()
+        id_to_email = {u["id"]: u["email"] for u in (users_resp.data or [])}
+    except Exception:
+        id_to_email = {}
+
+    print(f"\n📋  {len(resp.data)} admin user(s):\n")
+    print(f"{'Email':<35} {'User ID':<36} {'Reason':<25} {'Granted':<19}")
+    print("-" * 118)
+    for row in resp.data:
+        uid = row.get("user_id", "")
+        email = id_to_email.get(uid, "(unknown)")
+        reason = row.get("reason") or "(none)"
+        granted_at = (row.get("granted_at") or "")[:19]
+        print(f"{email:<35} {uid:<36} {reason:<25} {granted_at:<19}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    if not _args:
         print(__doc__)
         sys.exit(1)
 
-    command = sys.argv[1].lower()
+    cmd = _args[0].lower()
 
-    if command == "grant" and len(sys.argv) >= 3:
-        user_id = sys.argv[2]
-        reason = " ".join(sys.argv[3:]) if len(sys.argv) > 3 else ""
-        grant_admin(user_id, reason)
+    if cmd == "grant" and len(_args) >= 2:
+        reason = " ".join(_args[2:]) if len(_args) > 2 else ""
+        grant_admin(_args[1], reason)
 
-    elif command == "revoke" and len(sys.argv) >= 3:
-        user_id = sys.argv[2]
-        revoke_admin(user_id)
+    elif cmd == "revoke" and len(_args) >= 2:
+        revoke_admin(_args[1])
 
-    elif command == "list":
+    elif cmd == "check" and len(_args) >= 2:
+        check_admin(_args[1])
+
+    elif cmd == "list":
         list_admins()
-
-    elif command == "check" and len(sys.argv) >= 3:
-        user_id = sys.argv[2]
-        check_admin(user_id)
 
     else:
         print(__doc__)

--- a/scripts/manage_admins.py
+++ b/scripts/manage_admins.py
@@ -24,6 +24,7 @@ Examples:
 
 import sys
 import os
+import uuid
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -64,7 +65,13 @@ def _resolve(email_or_uuid: str) -> tuple[str, str] | None:
     Inserting an auth.users.id (or any random UUID) that has no matching
     public.users row will raise a FK violation.
     """
-    field = "email" if "@" in email_or_uuid else "id"
+    # Prefer UUID parsing over @-heuristic — UUIDs are unambiguous; everything
+    # else is treated as an email address.
+    try:
+        uuid.UUID(email_or_uuid)
+        field = "id"
+    except ValueError:
+        field = "email"
     try:
         resp = sb.table("users").select("id, email").eq(field, email_or_uuid).limit(1).execute()
     except Exception as e:
@@ -86,8 +93,12 @@ def _resolve(email_or_uuid: str) -> tuple[str, str] | None:
 
 
 def _already_admin(user_id: str) -> bool:
-    resp = sb.table("admin_users").select("id").eq("user_id", user_id).limit(1).execute()
-    return bool(resp.data)
+    try:
+        resp = sb.table("admin_users").select("id").eq("user_id", user_id).limit(1).execute()
+        return bool(resp.data)
+    except Exception as e:
+        print(f"❌  DB error checking admin status: {e}")
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -144,10 +155,10 @@ def revoke_admin(target: str) -> bool:
         return False
 
 
-def check_admin(target: str) -> None:
+def check_admin(target: str) -> bool:
     resolved = _resolve(target)
     if not resolved:
-        return
+        return False
     user_id, email = resolved
 
     try:
@@ -160,7 +171,7 @@ def check_admin(target: str) -> None:
         )
     except Exception as e:
         print(f"❌  DB error: {e}")
-        return
+        return False
 
     if resp.data:
         row = resp.data[0]
@@ -168,12 +179,14 @@ def check_admin(target: str) -> None:
         print(f"    user_id : {user_id}")
         print(f"    reason  : {row.get('reason') or '(none)'}")
         print(f"    granted : {(row.get('granted_at') or '')[:19]}")
+        return True
     else:
         print(f"❌  {email} ({user_id}) is NOT an admin")
         print(f'\n    To grant: python3 scripts/manage_admins.py grant {email} "<reason>"')
+        return False
 
 
-def list_admins() -> None:
+def list_admins() -> bool:
     try:
         resp = (
             sb.table("admin_users")
@@ -183,11 +196,11 @@ def list_admins() -> None:
         )
     except Exception as e:
         print(f"❌  DB error: {e}")
-        return
+        return False
 
     if not resp.data:
         print("ℹ️   No admin users yet.")
-        return
+        return True
 
     # Bulk-resolve emails from public.users
     ids = [r["user_id"] for r in resp.data]
@@ -207,6 +220,7 @@ def list_admins() -> None:
         granted_at = (row.get("granted_at") or "")[:19]
         print(f"{email:<35} {uid:<36} {reason:<25} {granted_at:<19}")
     print()
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -220,23 +234,26 @@ def main() -> None:
         sys.exit(1)
 
     cmd = _args[0].lower()
+    ok = False
 
     if cmd == "grant" and len(_args) >= 2:
         reason = " ".join(_args[2:]) if len(_args) > 2 else ""
-        grant_admin(_args[1], reason)
+        ok = grant_admin(_args[1], reason)
 
     elif cmd == "revoke" and len(_args) >= 2:
-        revoke_admin(_args[1])
+        ok = revoke_admin(_args[1])
 
     elif cmd == "check" and len(_args) >= 2:
-        check_admin(_args[1])
+        ok = check_admin(_args[1])
 
     elif cmd == "list":
-        list_admins()
+        ok = list_admins()
 
     else:
         print(__doc__)
         sys.exit(1)
+
+    sys.exit(0 if ok else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…efore insert

- Accept email or UUID for all commands (email preferred — avoids auth.users confusion)
- _resolve() looks up public.users first; fails loudly if UUID missing or wrong table
- Idempotent grant/revoke: prints no-op message instead of erroring or double-inserting
- list: bulk-resolves emails from public.users so output is human-readable
- Print logout reminder after grant/revoke (is_admin is session-cached at login)
- --env <file> flag to override which .env loads (e.g. .env.production)

## Summary by Sourcery

Improve the admin management script to operate on public.users via email-or-UUID identifiers and provide clearer, safer CLI behavior.

New Features:
- Allow specifying users by email or UUID across grant, revoke, check, and list commands instead of UUID-only.
- Add a --env <file> flag to control which .env configuration file is loaded when running the script.

Bug Fixes:
- Prevent inserting invalid user_ids into admin_users by resolving identifiers against public.users and failing clearly when no matching user exists.

Enhancements:
- Make grant and revoke operations idempotent with informative no-op messages when the target is already or not an admin.
- Enhance list output to resolve and display user emails alongside IDs for better readability.
- Add explicit messaging that admin status changes require logout/login due to session caching.
- Improve CLI help text, usage examples, and error messages for admin management operations.