### PR TITLE
hero stats migration

### DIFF
--- a/db/migrations/027_shared_stats_rpc_update.sql
+++ b/db/migrations/027_shared_stats_rpc_update.sql
@@ -1,0 +1,26 @@
+-- 1. Drop the old function signature to resolve the "parameter defaults" error
+DROP FUNCTION IF EXISTS public.get_top_countries_with_counts(integer);
+
+-- 2. Create the optimized version aligned with Migration 003 and db_lists.py logic
+CREATE OR REPLACE FUNCTION public.get_top_countries_with_counts(p_limit integer DEFAULT 10)
+RETURNS TABLE (country_code text, creator_count bigint)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $$
+    SELECT
+        c.country_code,
+        COUNT(*)::bigint AS creator_count
+    FROM public.creators c
+    WHERE c.channel_name IS NOT NULL
+      AND c.country_code IS NOT NULL
+      AND c.sync_status = 'synced'      -- Crucial: Matches db_lists.py fallback logic
+      AND c.current_subscribers > 0     -- Crucial: Matches db_lists.py fallback logic
+    GROUP BY c.country_code
+    ORDER BY creator_count DESC
+    LIMIT p_limit;
+$$;
+
+-- 3. Add a comment for clarity
+COMMENT ON FUNCTION public.get_top_countries_with_counts(integer) IS
+    'Returns top countries by synced creator count. Optimized to avoid timeouts.';


### PR DESCRIPTION
## Summary by Sourcery

Update the database helper function for retrieving top countries by creator counts to use an optimized, defaulted signature and aligned filtering logic.

Enhancements:
- Replace the existing get_top_countries_with_counts function with a new version that applies synced, nonzero-subscriber creator filters and supports a default limit parameter.
- Add documentation comment to the get_top_countries_with_counts function describing its purpose and performance intent.