### PR TITLE
add admin dropdown endpoint

### DIFF
--- a/components/navigation.py
+++ b/components/navigation.py
@@ -9,6 +9,7 @@ from fasthtml.common import *
 from monsterui.all import *
 
 from .auth_dropdown import AuthDropdown
+from routes.admin import _is_admin  # ✅ Import admin check
 
 
 def _nav_link_cls(req, path):
@@ -105,8 +106,9 @@ def NavComponent(oauth, req=None, sess=None):
         # ✅ LOGGED IN: Use AuthDropdown component
 
         # Extract user data from session (populated by auth_service.py)
+        user_id = sess.get("user_id")
         user_data = {
-            "user_id": sess.get("user_id"),
+            "user_id": user_id,
             "user_name": sess.get("user_name"),
             "user_given_name": sess.get("user_given_name"),
             "user_email": sess.get("user_email"),
@@ -115,8 +117,15 @@ def NavComponent(oauth, req=None, sess=None):
         # Get avatar URL from session (set by auth_service.py)
         avatar_url = sess.get("avatar_url")
 
-        # is_admin is cached in session at login — no DB call here
-        is_admin = bool(sess.get("is_admin"))
+        # Check admin status — try session cache first (fast), then DB (fresh)
+        is_admin = bool(sess.get("is_admin"))  # Cached at login
+        if not is_admin and user_id:
+            # Fallback: check DB directly (in case they were just granted access)
+            try:
+                is_admin = _is_admin(user_id)
+            except Exception as e:
+                logging.warning(f"Failed to check admin status: {e}")
+                is_admin = False
 
         # Use the dropdown component with OAuth-aware login URL for consistency
         auth_section = AuthDropdown(

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -25,7 +25,28 @@ logger = logging.getLogger(__name__)
 ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "")
 
 
-# -- Auth ---------------------------------------------------------------------
+# -- Auth helpers ─────────────────────────────────────────────────────────────
+
+
+def _is_admin(user_id: str | None) -> bool:
+    """
+    Check if a user_id exists in the admin_users table.
+    Used by NavComponent to determine if admin link should be shown.
+    """
+    if not user_id or not supabase_client:
+        return False
+    try:
+        resp = (
+            supabase_client.table("admin_users")
+            .select("id")
+            .eq("user_id", user_id)
+            .limit(1)
+            .execute()
+        )
+        return bool(resp.data)
+    except Exception as e:
+        logger.warning("[Admin] Error checking admin status for %s: %s", user_id, e)
+        return False
 
 
 def _is_authorised(req, sess) -> bool:


### PR DESCRIPTION
## Summary by Sourcery

Add a server-side admin check helper and update navigation to use both cached and database-backed admin status when rendering the auth dropdown.

Enhancements:
- Introduce an admin lookup helper that verifies a user’s admin status against the admin_users table.
- Update navigation to fall back to a live admin status check when the cached session flag is not set, ensuring the admin link reflects recent changes to permissions.