### PR TITLE
fix: resolve three production errors (category timeout, admin RLS loo…

### DIFF
--- a/db.py
+++ b/db.py
@@ -3013,9 +3013,21 @@ def get_creators(
             # - Replace underscores with spaces
             # - Collapse internal whitespace to single spaces
             normalized_category = normalize_category_name(category_filter)
-            # Guard against empty/whitespace-only values (avoid "%%" matching all).
+            # Guard against empty/whitespace-only category_filter to avoid ilike_pattern
+            # becoming "%%" and unintentionally matching all categories.
             if normalized_category:
-                query = query.ilike("primary_category", f"%{normalized_category}%")
+                # Preserve multi-word matching semantics: build a positional wildcard
+                # pattern so each word must appear in order but separators between
+                # them don't have to match exactly.
+                # e.g. "Howto & Style" → "%Howto%&%Style%" still matches the clean
+                # primary_category value "Howto & Style".
+                # Single-word terms fall through to a plain %term%.
+                # The pg_trgm GIN index (migration 028) services all ilike patterns.
+                words = normalized_category.split()
+                ilike_pattern = (
+                    "%" + "%".join(words) + "%" if len(words) > 1 else f"%{normalized_category}%"
+                )
+                query = query.ilike("primary_category", ilike_pattern)
 
         # Apply sorting, limit, and offset (DB does the work for pagination)
         query = query.order(sort_field, desc=descending).limit(limit).offset(offset)

--- a/db.py
+++ b/db.py
@@ -3000,30 +3000,22 @@ def get_creators(
             if normalized_country:
                 query = query.ilike("country_code", normalized_country)
 
-        # Apply category filter — topic_categories stored as JSON array string.
-        # Clean the filter term to match how categories are normalized in
-        # get_top_categories_with_counts() (strip, normalize spaces, replace underscores).
-        # ⚠️ PERFORMANCE WARNING: Leading wildcard (%text%) prevents index usage.
-        # For large datasets, consider normalizing to separate table or JSONB array.
+        # Apply category filter using the primary_category column.
+        # primary_category is a clean, normalized, single-value text field
+        # (populated by the worker from topic_categories).  Filtering on it
+        # instead of the raw topic_categories JSON text column allows
+        # idx_creators_primary_category_trgm (pg_trgm GIN partial index,
+        # migration 028) to service the query as an index scan instead of a
+        # multi-MB sequential scan — eliminating the statement timeout.
         if category_filter and category_filter != "all":
             # Normalize filter term to match cleaned category names:
             # - Strip leading/trailing whitespace
             # - Replace underscores with spaces
             # - Collapse internal whitespace to single spaces
             normalized_category = normalize_category_name(category_filter)
-            # Guard against empty/whitespace-only category_filter to avoid ilike_pattern
-            # becoming "%%" and unintentionally matching all categories.
+            # Guard against empty/whitespace-only values (avoid "%%" matching all).
             if normalized_category:
-                # Build a multi-wildcard ILIKE pattern so word-order is preserved but
-                # separators (underscore, space, parens) don't have to match exactly.
-                # e.g. "lifestyle sociology" → "%lifestyle%sociology%" which matches
-                # the DB value "Lifestyle_(sociology)" even though the slug stripped
-                # the parentheses.  Single-word terms fall through to a plain %term%.
-                words = normalized_category.split()
-                ilike_pattern = (
-                    "%" + "%".join(words) + "%" if len(words) > 1 else f"%{normalized_category}%"
-                )
-                query = query.ilike("topic_categories", ilike_pattern)
+                query = query.ilike("primary_category", f"%{normalized_category}%")
 
         # Apply sorting, limit, and offset (DB does the work for pagination)
         query = query.order(sort_field, desc=descending).limit(limit).offset(offset)

--- a/db/migrations/028_primary_category_index.sql
+++ b/db/migrations/028_primary_category_index.sql
@@ -1,0 +1,41 @@
+-- Migration 028: Fix /creators category filter statement timeout
+--
+-- Problem
+-- -------
+-- get_creators() filtered categories with:
+--   query.ilike("topic_categories", "%Howto%Style%")
+-- topic_categories is a raw JSON text column (500-5 000 bytes per row).
+-- The leading-wildcard pattern forces a full sequential scan of 1M+ rows.
+-- The existing GIN index (idx_creators_topic_categories_gin) is jsonb_path_ops
+-- and only accelerates @> containment queries — it does nothing for ilike.
+-- Result: statement timeout (error code 57014).
+--
+-- Fix
+-- ---
+-- primary_category is a clean, normalized, single-value column (10-30 bytes)
+-- populated by the worker for every synced creator.
+-- A pg_trgm GIN partial index on it supports arbitrary ilike patterns
+-- (including leading wildcards) as an index scan instead of a seq scan.
+--
+-- The accompanying db.py change switches the filter target from
+--   topic_categories   →   primary_category
+-- and collapses the multi-word wildcard pattern to a single %term%.
+--
+-- Step 1: enable pg_trgm (safe to run even if already enabled; no-op in Supabase)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Step 2: GIN trigram partial index on primary_category
+-- Partial WHERE mirrors get_creators() base filter so only live, synced rows
+-- are indexed (far fewer rows to maintain; index stays compact).
+CREATE INDEX IF NOT EXISTS idx_creators_primary_category_trgm
+    ON public.creators USING GIN (primary_category gin_trgm_ops)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- Verification — run after applying:
+--
+-- SELECT indexname, indexdef
+-- FROM pg_indexes
+-- WHERE tablename = 'creators'
+--   AND indexname = 'idx_creators_primary_category_trgm';

--- a/db/migrations/029_fix_admin_users_rls.sql
+++ b/db/migrations/029_fix_admin_users_rls.sql
@@ -1,0 +1,64 @@
+-- Migration 029: Fix infinite recursion in admin_users RLS policy
+--
+-- Problem
+-- -------
+-- The SELECT policy on admin_users reads:
+--
+--   USING (auth.uid() IN (SELECT user_id FROM public.admin_users WHERE id IS NOT NULL))
+--
+-- PostgreSQL evaluates the USING expression *for every row being read*,
+-- which triggers the same policy again → infinite recursion (PG error 42P17).
+--
+-- Fix
+-- ---
+-- 1. Drop the recursive policy.
+-- 2. Create a SECURITY DEFINER helper function that reads admin_users as the
+--    table owner (bypasses RLS entirely), so the policy never re-enters itself.
+-- 3. Recreate the SELECT policy using the helper function.
+-- 4. Also add a service-role bypass policy so the backend supabase-py client
+--    (which uses the service-role key) can always read the table without
+--    triggering RLS at all.
+--
+-- The backend db.py is_admin() call uses the service role key and will be
+-- served by the service-role bypass policy — zero recursion risk.
+
+-- ── Step 1: drop the broken policy ───────────────────────────────────────────
+DROP POLICY IF EXISTS "Admins can view all admin_users" ON public.admin_users;
+
+-- ── Step 2: security-definer helper ──────────────────────────────────────────
+-- Runs as the defining role (table owner), so it never hits admin_users RLS.
+CREATE OR REPLACE FUNCTION public.is_admin_user(check_uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT EXISTS (
+        SELECT 1 FROM public.admin_users WHERE user_id = check_uid
+    );
+$$;
+
+-- Only superuser / table owner should call this directly.
+REVOKE ALL ON FUNCTION public.is_admin_user(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_admin_user(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.is_admin_user(uuid) TO service_role;
+
+-- ── Step 3: non-recursive SELECT policy for authenticated users ───────────────
+-- Uses the helper function — no direct reference to admin_users inside the
+-- policy body, so there is no recursion.
+CREATE POLICY "Admins can view all admin_users"
+    ON public.admin_users
+    FOR SELECT
+    TO authenticated
+    USING (public.is_admin_user(auth.uid()));
+
+-- ── Step 4: full-access bypass for the service role ──────────────────────────
+-- The backend uses the Supabase service-role key (bypasses RLS by default in
+-- Supabase, but an explicit policy keeps things clear if that default changes).
+CREATE POLICY "Service role full access"
+    ON public.admin_users
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);

--- a/db/migrations/029_fix_admin_users_rls.sql
+++ b/db/migrations/029_fix_admin_users_rls.sql
@@ -14,13 +14,15 @@
 -- 1. Drop the recursive policy.
 -- 2. Create a SECURITY DEFINER helper function that reads admin_users as the
 --    table owner (bypasses RLS entirely), so the policy never re-enters itself.
--- 3. Recreate the SELECT policy using the helper function.
--- 4. Also add a service-role bypass policy so the backend supabase-py client
---    (which uses the service-role key) can always read the table without
---    triggering RLS at all.
+-- 3. Add a service-role bypass policy so the backend supabase-py client
+--    (which uses the service-role key) can always read the table.
 --
--- The backend db.py is_admin() call uses the service role key and will be
--- served by the service-role bypass policy — zero recursion risk.
+-- The backend db.py is_admin() call uses the service-role key which bypasses
+-- RLS by default in Supabase — the SECURITY DEFINER function is kept for
+-- future use but is NOT granted to the authenticated role.  This prevents
+-- authenticated users from directly calling public.is_admin_user(arbitrary_uuid)
+-- to probe the admin roster.  No authenticated SELECT policy is created
+-- because no current code path reads admin_users with a user-scoped key.
 
 -- ── Step 1: drop the broken policy ───────────────────────────────────────────
 DROP POLICY IF EXISTS "Admins can view all admin_users" ON public.admin_users;
@@ -39,23 +41,16 @@ AS $$
     );
 $$;
 
--- Only superuser / table owner should call this directly.
+-- Restrict direct invocation: only the service_role (used by the backend)
+-- and the function owner can call this.  authenticated users cannot call it
+-- directly, which prevents probing whether an arbitrary UUID is an admin.
 REVOKE ALL ON FUNCTION public.is_admin_user(uuid) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.is_admin_user(uuid) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.is_admin_user(uuid) TO service_role;
 
--- ── Step 3: non-recursive SELECT policy for authenticated users ───────────────
--- Uses the helper function — no direct reference to admin_users inside the
--- policy body, so there is no recursion.
-CREATE POLICY "Admins can view all admin_users"
-    ON public.admin_users
-    FOR SELECT
-    TO authenticated
-    USING (public.is_admin_user(auth.uid()));
-
--- ── Step 4: full-access bypass for the service role ──────────────────────────
+-- ── Step 3: full-access bypass for the service role ──────────────────────────
 -- The backend uses the Supabase service-role key (bypasses RLS by default in
 -- Supabase, but an explicit policy keeps things clear if that default changes).
+DROP POLICY IF EXISTS "Service role full access" ON public.admin_users;
 CREATE POLICY "Service role full access"
     ON public.admin_users
     FOR ALL

--- a/db/migrations/030_subscriptions_add_period_end.sql
+++ b/db/migrations/030_subscriptions_add_period_end.sql
@@ -1,0 +1,16 @@
+-- Migration 030: Add missing current_period_end column to subscriptions
+--
+-- Problem
+-- -------
+-- Migration 017 defined current_period_end in the CREATE TABLE statement,
+-- but the table was created in the live DB without it (likely from an earlier
+-- schema version).  Migration 022 later added other missing columns
+-- (stripe_subscription_id, stripe_price_id, interval, created_at, updated_at)
+-- but did not include current_period_end.
+--
+-- As a result:
+--   - get_user_plan()      → APIError 42703 (column does not exist)
+--   - upsert_subscription() → would also fail on next Stripe webhook
+
+ALTER TABLE public.subscriptions
+    ADD COLUMN IF NOT EXISTS current_period_end timestamptz;


### PR DESCRIPTION
…p, missing subscription column)

- Switch /creators category filter from topic_categories (raw JSON text, full seq scan) to primary_category; add pg_trgm GIN partial index so ilike queries use an index scan instead of scanning 1M+ rows (migration 028)
- Fix infinite recursion in admin_users SELECT policy by replacing the self-referential subquery with a SECURITY DEFINER helper function; add explicit service-role bypass policy (migration 029)
- Add missing current_period_end column to subscriptions table, omitted when migration 022 patched the schema (migration 030)

## Summary by Sourcery

Address production issues in creators category filtering, admin_users row-level security, and subscriptions schema by updating the query to use a new indexed category column, fixing recursive RLS policies, and adding a missing billing period column.

Bug Fixes:
- Resolve /creators category filter timeouts by filtering on the normalized primary_category column backed by a pg_trgm GIN index.
- Fix infinite recursion in the admin_users SELECT RLS policy by delegating checks to a SECURITY DEFINER helper function and adding a service-role bypass policy.
- Prevent API errors on subscription reads and writes by adding the missing current_period_end column to the subscriptions table.