### PR TITLE
fix: admin dashboard renders as unstyled text due to missing NavCompo…

### DIFF
--- a/main.py
+++ b/main.py
@@ -1678,7 +1678,17 @@ def privacy(req, sess):
 @rt("/admin")
 def admin(req, sess):
     """Admin dashboard — protected by OAuth user ID or ADMIN_TOKEN."""
-    return admin_get(req, sess)
+    content = admin_get(req, sess)
+    # admin_get returns a Response (401) or FT content — only wrap FT in the layout
+    if isinstance(content, Response):
+        return content
+    return Titled(
+        "Admin — ViralVibes",
+        Container(
+            NavComponent(oauth, req, sess),
+            content,
+        ),
+    )
 
 
 @rt("/admin/jobs")

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -179,15 +179,9 @@ def _fetch_admin_data() -> tuple[dict, dict, dict, list[dict]]:
 
 
 def admin_get(req, sess) -> Response | FT:
-    """GET /admin -- full admin dashboard."""
+    """GET /admin -- full admin dashboard. Returns FT for main.py to wrap."""
     if not _is_authorised(req, sess):
         return _auth_response()
-
-    stats, breakdown, throughput, jobs = _fetch_admin_data()
-    now = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
-    page = AdminPage(
-        stats=stats, breakdown=breakdown, throughput=throughput, jobs=jobs, refreshed_at=now
-    )
 
     # After token auth: set cookie then redirect to clean URL so the token
     # doesn't remain in browser history, logs, or Referrer headers.
@@ -196,8 +190,11 @@ def admin_get(req, sess) -> Response | FT:
         resp.set_cookie("admin_token", ADMIN_TOKEN, httponly=True, samesite="strict")
         return resp
 
-    resp = Response(content=str(page), media_type="text/html")
-    return resp
+    stats, breakdown, throughput, jobs = _fetch_admin_data()
+    now = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+    return AdminPage(
+        stats=stats, breakdown=breakdown, throughput=throughput, jobs=jobs, refreshed_at=now
+    )
 
 
 def admin_jobs_fragment(req, sess) -> Response | FT:

--- a/views/admin.py
+++ b/views/admin.py
@@ -213,11 +213,10 @@ def AdminPage(
     jobs: list[dict],
     refreshed_at: str = "",
 ) -> FT:
-    """Full admin page. Data passed in as plain dicts from route handler."""
+    """Admin page content. Caller wraps with Titled + NavComponent."""
     total = sum(breakdown.values()) or 1
 
-    return Titled(
-        "Admin — ViralVibes",
+    return Div(
         Div(
             Div(
                 Span("⚙️", cls="mr-2"),


### PR DESCRIPTION
…nent and raw Response wrapping

AdminPage returned Titled() directly (no NavComponent, no stylesheet context) and admin_get serialised it with str() into a raw Response, bypassing FastHTML's rendering pipeline entirely.

- views/admin.py: AdminPage now returns Div content only (no Titled)
- routes/admin.py: admin_get returns FT directly; token redirect moved before data fetch as an early return
- main.py: /admin route wraps content with Titled + NavComponent + Container, matching every other page in the app

## Summary by Sourcery

Ensure the admin dashboard page is rendered within the standard app layout instead of as raw, unstyled HTML.

Bug Fixes:
- Return FastHTML content from the admin route handler instead of a raw HTML Response so the admin dashboard is properly styled and processed by the rendering pipeline.
- Guard the admin route layout wrapping so that only FT content is wrapped, while auth failures continue to return Response objects directly.

Enhancements:
- Move the admin layout composition (Titled, NavComponent, Container) into the main route handler so the AdminPage view now only provides the inner page content.