### PR TITLE
fix(admin): correct column names and refine dashboard against real DB…

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -90,89 +90,216 @@ def _auth_response():
 # -- Data fetching ------------------------------------------------------------
 
 
-def _fetch_admin_data() -> tuple[dict, dict, dict, list[dict]]:
-    """Fetch all data needed for the admin page from Supabase."""
-    stats = {"total": 0, "synced_today": 0, "pending": 0, "failed": 0, "processing": 0}
-    breakdown = {"synced": 0, "pending": 0, "failed": 0, "invalid": 0}
-    throughput = {
-        "jobs_per_hour": "--",
-        "avg_duration": "--",
-        "last_job_ago": "--",
-        "quota_used": 0,
-        "quota_total": 10000,
+def _fetch_admin_data() -> dict:
+    """
+    Fetch all data for the admin dashboard. Returns a flat dict; every key has
+    a safe default so the view never crashes on a missing value.
+
+    Queries are grouped into independent try/except blocks so a single failing
+    query (e.g. missing column) degrades that section only, not the whole page.
+    """
+    now = datetime.now(timezone.utc)
+    cutoff_24h = (now - timedelta(hours=24)).isoformat()
+    cutoff_1h = (now - timedelta(hours=1)).isoformat()
+    cutoff_7d = (now - timedelta(days=7)).isoformat()
+    cutoff_30d = (now - timedelta(days=30)).isoformat()
+
+    data: dict = {
+        # Creator inventory
+        "total_creators": 0,
+        "synced": 0,
+        "pending_creators": 0,
+        "failed_creators": 0,
+        "invalid_creators": 0,
+        "visible": 0,
+        "fresh_7d": 0,
+        "stale_30d": 0,
+        "never_synced": 0,
+        # Job queue
+        "queue_pending": 0,
+        "queue_processing": 0,
+        "queue_failed": 0,
+        "oldest_pending_secs": None,
+        # Throughput
+        "completed_24h": 0,
+        "completed_1h": 0,
+        "avg_job_secs": None,
+        "last_completed_secs": None,
+        # Recent jobs table
+        "recent_jobs": [],
     }
-    jobs: list[dict] = []
 
     if not _db.supabase_client:
-        return stats, breakdown, throughput, jobs
+        return data
 
+    sc = _db.supabase_client
+
+    # ── Creator inventory ──────────────────────────────────────────────────────
     try:
-        # Total creators
-        r = _db.supabase_client.table("creators").select("id", count="exact").execute()
-        stats["total"] = r.count or 0
-
-        # Breakdown by sync_status
-        for status_key in ("synced", "pending", "failed", "invalid"):
-            r = (
-                _db.supabase_client.table("creators")
+        data["total_creators"] = (
+            sc.table("creators").select("id", count="exact").execute().count or 0
+        )
+        for col, status in [
+            ("synced", "synced"),
+            ("pending_creators", "pending"),
+            ("failed_creators", "failed"),
+            ("invalid_creators", "invalid"),
+        ]:
+            data[col] = (
+                sc.table("creators")
                 .select("id", count="exact")
-                .eq("sync_status", status_key)
+                .eq("sync_status", status)
                 .execute()
+                .count
+                or 0
             )
-            breakdown[status_key] = r.count or 0
-
-        # Synced today (last 24h)
-        cutoff = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
-        r = (
-            _db.supabase_client.table("creators")
+        data["visible"] = (
+            sc.table("creators")
             .select("id", count="exact")
-            .gte("last_synced_at", cutoff)
+            .eq("sync_status", "synced")
+            .not_.is_("channel_name", "null")
+            .gt("current_subscribers", 0)
             .execute()
+            .count
+            or 0
         )
-        stats["synced_today"] = r.count or 0
-        stats["pending"] = breakdown["pending"]
-        stats["failed"] = breakdown["failed"]
-
-        # Processing jobs count
-        r = (
-            _db.supabase_client.table("creator_sync_jobs")
+        data["fresh_7d"] = (
+            sc.table("creators")
             .select("id", count="exact")
-            .eq("status", "processing")
+            .eq("sync_status", "synced")
+            .gte("last_synced_at", cutoff_7d)
             .execute()
+            .count
+            or 0
         )
-        stats["processing"] = r.count or 0
+        data["stale_30d"] = (
+            sc.table("creators")
+            .select("id", count="exact")
+            .eq("sync_status", "synced")
+            .lt("last_synced_at", cutoff_30d)
+            .execute()
+            .count
+            or 0
+        )
+        data["never_synced"] = (
+            sc.table("creators")
+            .select("id", count="exact")
+            .is_("last_synced_at", "null")
+            .execute()
+            .count
+            or 0
+        )
+    except Exception:
+        logger.exception("[Admin] Creator inventory queries failed")
 
-        # Recent 50 jobs for the table
-        r = (
-            _db.supabase_client.table("creator_sync_jobs")
-            .select("id, creator_id, status, retry_count, created_at, updated_at")
-            .order("created_at", desc=True)
+    # ── Job queue ──────────────────────────────────────────────────────────────
+    try:
+        for col, status in [
+            ("queue_pending", "pending"),
+            ("queue_processing", "processing"),
+            ("queue_failed", "failed"),
+        ]:
+            data[col] = (
+                sc.table("creator_sync_jobs")
+                .select("id", count="exact")
+                .eq("status", status)
+                .execute()
+                .count
+                or 0
+            )
+        oldest = (
+            sc.table("creator_sync_jobs")
+            .select("created_at")
+            .eq("status", "pending")
+            .is_("next_retry_at", "null")
+            .order("created_at", desc=False)
+            .limit(1)
+            .execute()
+            .data
+        )
+        if oldest:
+            dt = datetime.fromisoformat(oldest[0]["created_at"].replace("Z", "+00:00"))
+            data["oldest_pending_secs"] = int((now - dt).total_seconds())
+    except Exception:
+        logger.exception("[Admin] Job queue queries failed")
+
+    # ── Throughput counts ──────────────────────────────────────────────────────
+    try:
+        data["completed_24h"] = (
+            sc.table("creator_sync_jobs")
+            .select("id", count="exact")
+            .eq("status", "completed")
+            .gte("completed_at", cutoff_24h)
+            .execute()
+            .count
+            or 0
+        )
+        data["completed_1h"] = (
+            sc.table("creator_sync_jobs")
+            .select("id", count="exact")
+            .eq("status", "completed")
+            .gte("completed_at", cutoff_1h)
+            .execute()
+            .count
+            or 0
+        )
+    except Exception:
+        logger.exception("[Admin] Throughput count queries failed")
+
+    # ── Avg duration + last heartbeat (from recent completed jobs) ─────────────
+    try:
+        rows = (
+            sc.table("creator_sync_jobs")
+            .select("started_at, completed_at")
+            .eq("status", "completed")
+            .order("completed_at", desc=True)
             .limit(50)
             .execute()
+            .data
+            or []
         )
-        jobs = r.data or []
-
-        # Throughput: last job time
-        if jobs:
-            last_ts = jobs[0].get("updated_at") or jobs[0].get("created_at")
-            if last_ts:
+        durations = []
+        for row in rows:
+            s, c = row.get("started_at"), row.get("completed_at")
+            if s and c:
                 try:
-                    last_dt = datetime.fromisoformat(last_ts.replace("Z", "+00:00"))
-                    diff = datetime.now(timezone.utc) - last_dt
-                    secs = int(diff.total_seconds())
-                    if secs < 60:
-                        throughput["last_job_ago"] = f"{secs}s ago"
-                    elif secs < 3600:
-                        throughput["last_job_ago"] = f"{secs // 60}m ago"
-                    else:
-                        throughput["last_job_ago"] = f"{secs // 3600}h ago"
+                    dur = (
+                        datetime.fromisoformat(c.replace("Z", "+00:00"))
+                        - datetime.fromisoformat(s.replace("Z", "+00:00"))
+                    ).total_seconds()
+                    if 0 < dur < 300:
+                        durations.append(dur)
                 except Exception:
                     pass
+        if durations:
+            data["avg_job_secs"] = round(sum(durations) / len(durations), 1)
+        if rows:
+            last_ts = rows[0].get("completed_at")
+            if last_ts:
+                dt = datetime.fromisoformat(last_ts.replace("Z", "+00:00"))
+                data["last_completed_secs"] = int((now - dt).total_seconds())
+    except Exception:
+        logger.exception("[Admin] Duration/heartbeat queries failed")
 
-    except Exception as e:
-        logger.exception("[Admin] Error fetching admin data: %s", e)
+    # ── Recent jobs table ──────────────────────────────────────────────────────
+    try:
+        data["recent_jobs"] = (
+            sc.table("creator_sync_jobs")
+            .select(
+                "id, creator_id, job_type, source, status, retry_count, "
+                "started_at, completed_at, created_at, error_message"
+            )
+            .neq("status", "pending")  # exclude 500k+ pending rows; show activity
+            .order("completed_at", desc=True)
+            .limit(20)
+            .execute()
+            .data
+            or []
+        )
+    except Exception:
+        logger.exception("[Admin] Recent jobs query failed")
 
-    return stats, breakdown, throughput, jobs
+    return data
 
 
 # -- Route handlers -----------------------------------------------------------
@@ -190,11 +317,9 @@ def admin_get(req, sess) -> Response | FT:
         resp.set_cookie("admin_token", ADMIN_TOKEN, httponly=True, samesite="strict")
         return resp
 
-    stats, breakdown, throughput, jobs = _fetch_admin_data()
+    data = _fetch_admin_data()
     now = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
-    return AdminPage(
-        stats=stats, breakdown=breakdown, throughput=throughput, jobs=jobs, refreshed_at=now
-    )
+    return AdminPage(data=data, refreshed_at=now)
 
 
 def admin_jobs_fragment(req, sess) -> Response | FT:
@@ -202,5 +327,5 @@ def admin_jobs_fragment(req, sess) -> Response | FT:
     if not _is_authorised(req, sess):
         return Response("Unauthorised", status_code=401)
 
-    _, _, _, jobs = _fetch_admin_data()
-    return _JobsSection(jobs)
+    data = _fetch_admin_data()
+    return _JobsSection(data["recent_jobs"])

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -25,6 +25,16 @@ logger = logging.getLogger(__name__)
 ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "")
 
 
+def _parse_iso_utc(s: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp (with or without trailing Z) to a UTC-aware datetime."""
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
 # -- Auth helpers ─────────────────────────────────────────────────────────────
 
 
@@ -218,8 +228,9 @@ def _fetch_admin_data() -> dict:
             .data
         )
         if oldest:
-            dt = datetime.fromisoformat(oldest[0]["created_at"].replace("Z", "+00:00"))
-            data["oldest_pending_secs"] = int((now - dt).total_seconds())
+            dt = _parse_iso_utc(oldest[0]["created_at"])
+            if dt:
+                data["oldest_pending_secs"] = int((now - dt).total_seconds())
     except Exception:
         logger.exception("[Admin] Job queue queries failed")
 
@@ -260,24 +271,18 @@ def _fetch_admin_data() -> dict:
         )
         durations = []
         for row in rows:
-            s, c = row.get("started_at"), row.get("completed_at")
-            if s and c:
-                try:
-                    dur = (
-                        datetime.fromisoformat(c.replace("Z", "+00:00"))
-                        - datetime.fromisoformat(s.replace("Z", "+00:00"))
-                    ).total_seconds()
-                    if 0 < dur < 300:
-                        durations.append(dur)
-                except Exception:
-                    pass
+            s_dt = _parse_iso_utc(row.get("started_at"))
+            c_dt = _parse_iso_utc(row.get("completed_at"))
+            if s_dt and c_dt:
+                dur = (c_dt - s_dt).total_seconds()
+                if 0 < dur < 300:
+                    durations.append(dur)
         if durations:
             data["avg_job_secs"] = round(sum(durations) / len(durations), 1)
         if rows:
-            last_ts = rows[0].get("completed_at")
-            if last_ts:
-                dt = datetime.fromisoformat(last_ts.replace("Z", "+00:00"))
-                data["last_completed_secs"] = int((now - dt).total_seconds())
+            last_dt = _parse_iso_utc(rows[0].get("completed_at"))
+            if last_dt:
+                data["last_completed_secs"] = int((now - last_dt).total_seconds())
     except Exception:
         logger.exception("[Admin] Duration/heartbeat queries failed")
 
@@ -305,6 +310,29 @@ def _fetch_admin_data() -> dict:
 # -- Route handlers -----------------------------------------------------------
 
 
+def _fetch_recent_jobs() -> list[dict]:
+    """Lightweight fetch for the HTMX jobs-panel fragment (30s poll)."""
+    if not _db.supabase_client:
+        return []
+    try:
+        return (
+            _db.supabase_client.table("creator_sync_jobs")
+            .select(
+                "id, creator_id, job_type, source, status, retry_count, "
+                "started_at, completed_at, created_at, error_message"
+            )
+            .neq("status", "pending")
+            .order("completed_at", desc=True)
+            .limit(20)
+            .execute()
+            .data
+            or []
+        )
+    except Exception:
+        logger.exception("[Admin] Recent jobs fragment query failed")
+        return []
+
+
 def admin_get(req, sess) -> Response | FT:
     """GET /admin -- full admin dashboard. Returns FT for main.py to wrap."""
     if not _is_authorised(req, sess):
@@ -323,9 +351,7 @@ def admin_get(req, sess) -> Response | FT:
 
 
 def admin_jobs_fragment(req, sess) -> Response | FT:
-    """GET /admin/jobs -- HTMX fragment: jobs panel only."""
+    """GET /admin/jobs — HTMX fragment; refreshes only the recent-jobs panel."""
     if not _is_authorised(req, sess):
-        return Response("Unauthorised", status_code=401)
-
-    data = _fetch_admin_data()
-    return _JobsSection(data["recent_jobs"])
+        return _auth_response()
+    return _JobsSection(_fetch_recent_jobs())

--- a/views/admin.py
+++ b/views/admin.py
@@ -12,6 +12,17 @@ from datetime import datetime, timezone
 from fasthtml.common import *
 from monsterui.all import *
 
+
+def _parse_iso_utc(s: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp (with or without trailing Z) to a UTC-aware datetime."""
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
 # ── Colour maps ───────────────────────────────────────────────────────────────
 
 _COLOR = {
@@ -141,32 +152,20 @@ def _JobRow(job: dict) -> Tr:
 
     # Per-job duration
     duration = "—"
-    s_ts, c_ts = job.get("started_at"), job.get("completed_at")
-    if s_ts and c_ts:
-        try:
-            dur = (
-                datetime.fromisoformat(c_ts.replace("Z", "+00:00"))
-                - datetime.fromisoformat(s_ts.replace("Z", "+00:00"))
-            ).total_seconds()
-            if dur >= 0:
-                duration = _fmt_dur(dur)
-        except Exception:
-            pass
+    s_dt = _parse_iso_utc(job.get("started_at"))
+    c_dt = _parse_iso_utc(job.get("completed_at"))
+    if s_dt and c_dt:
+        dur = (c_dt - s_dt).total_seconds()
+        if dur >= 0:
+            duration = _fmt_dur(dur)
 
     # Age of last update
     age_ts = job.get("completed_at") or job.get("created_at")
     age = "—"
-    if age_ts:
-        try:
-            secs = int(
-                (
-                    datetime.now(timezone.utc)
-                    - datetime.fromisoformat(age_ts.replace("Z", "+00:00"))
-                ).total_seconds()
-            )
-            age = _fmt_ago(secs)
-        except Exception:
-            pass
+    age_dt = _parse_iso_utc(age_ts)
+    if age_dt:
+        secs = int((datetime.now(timezone.utc) - age_dt).total_seconds())
+        age = _fmt_ago(secs)
 
     error = job.get("error_message") or ""
     error_cell = Td(
@@ -315,7 +314,7 @@ def _WorkerSection(data: dict) -> Div:
 
 
 def _BreakdownSection(data: dict) -> Div:
-    total = data["total_creators"] or 1
+    total = data["total_creators"]
     breakdown = {
         "synced": data["synced"],
         "pending": data["pending_creators"],

--- a/views/admin.py
+++ b/views/admin.py
@@ -2,7 +2,7 @@
 views/admin.py — Admin dashboard rendering.
 
 All FT components for the /admin page. No auth logic here — that lives in
-routes/admin.py. Data is passed in as plain dicts from the route handler.
+routes/admin.py. Data is passed in as a flat dict from _fetch_admin_data().
 """
 
 from __future__ import annotations
@@ -12,44 +12,108 @@ from datetime import datetime, timezone
 from fasthtml.common import *
 from monsterui.all import *
 
-# ── Palette constants ─────────────────────────────────────────────────────────
+# ── Colour maps ───────────────────────────────────────────────────────────────
 
-_STAT_COLORS = {
-    "total": "text-blue-600",
-    "synced": "text-green-600",
-    "pending": "text-yellow-600",
-    "failed": "text-red-600",
-    "processing": "text-purple-600",
+_COLOR = {
+    "blue": "text-blue-600",
+    "green": "text-green-600",
+    "yellow": "text-yellow-500",
+    "red": "text-red-600",
+    "purple": "text-purple-600",
+    "orange": "text-orange-500",
+    "gray": "text-gray-400",
 }
 
-_STATUS_BAR_COLORS = {
+_BAR_COLOR = {
     "synced": "bg-green-500",
     "pending": "bg-yellow-400",
     "failed": "bg-red-500",
     "invalid": "bg-gray-400",
 }
 
-_JOB_STATUS_CLS = {
-    "completed": "text-green-600 bg-green-50",
-    "synced": "text-green-600 bg-green-50",
-    "processing": "text-purple-600 bg-purple-50",
-    "pending": "text-yellow-600 bg-yellow-50",
-    "failed": "text-red-600 bg-red-50",
-    "blocked": "text-orange-600 bg-orange-50",
+_JOB_BADGE = {
+    "completed": "text-green-700 bg-green-100",
+    "processing": "text-purple-700 bg-purple-100",
+    "pending": "text-yellow-700 bg-yellow-100",
+    "failed": "text-red-700 bg-red-100",
 }
+
+
+# ── Formatting helpers ────────────────────────────────────────────────────────
+
+
+def _fmt_ago(secs: int | None) -> str:
+    if secs is None:
+        return "—"
+    if secs < 60:
+        return f"{secs}s ago"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h {(secs % 3600) // 60}m ago"
+    return f"{secs // 86400}d ago"
+
+
+def _fmt_dur(secs: float | None) -> str:
+    if secs is None:
+        return "—"
+    s = int(secs)
+    if s < 60:
+        return f"{s}s"
+    return f"{s // 60}m {s % 60}s"
+
+
+def _fmt_age(secs: int | None) -> str:
+    """Human-readable age (no 'ago' suffix — for queue wait times)."""
+    if secs is None:
+        return "—"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    if secs < 86400:
+        return f"{secs // 3600}h {(secs % 3600) // 60}m"
+    return f"{secs // 86400}d {(secs % 86400) // 3600}h"
+
+
+def _fmt_drain(pending: int, rate_per_hour: float) -> str:
+    if rate_per_hour <= 0 or pending <= 0:
+        return "—"
+    hours = pending / rate_per_hour
+    if hours < 1:
+        return f"~{int(hours * 60)}m"
+    if hours < 48:
+        return f"~{hours:.1f}h"
+    return f"~{hours / 24:.1f} days"
 
 
 # ── Atomic components ─────────────────────────────────────────────────────────
 
 
-def _StatCard(label: str, value: str, sublabel: str, color_key: str) -> Div:
-    color = _STAT_COLORS.get(color_key, "text-gray-700")
+def _StatCard(
+    label: str,
+    value: int | str,
+    sublabel: str = "",
+    color: str = "blue",
+    warn: bool = False,
+) -> Div:
+    val_str = f"{value:,}" if isinstance(value, int) else value
+    color_cls = _COLOR.get(color, "text-foreground")
+    warn_cls = " border-l-4 border-orange-400" if warn else ""
     return Card(
         P(label, cls="text-xs font-mono uppercase tracking-widest text-muted-foreground mb-1"),
-        P(value, cls=f"text-3xl font-bold {color} font-mono"),
-        P(sublabel, cls="text-xs text-muted-foreground mt-1"),
-        body_cls="p-5",
+        P(val_str, cls=f"text-3xl font-bold font-mono {color_cls}"),
+        (P(sublabel, cls="text-xs text-muted-foreground mt-1") if sublabel else None),
+        body_cls=f"p-5{warn_cls}",
         cls="hover:shadow-md transition-shadow",
+    )
+
+
+def _KVRow(label: str, value: str, warn: bool = False) -> Div:
+    val_cls = "text-sm font-mono font-medium"
+    val_cls += " text-orange-500" if warn else " text-foreground"
+    return DivFullySpaced(
+        Span(label, cls="text-sm text-muted-foreground"),
+        Span(value, cls=val_cls),
+        cls="py-2 border-b border-border last:border-0",
     )
 
 
@@ -57,12 +121,12 @@ def _StatusBar(label: str, count: int, total: int, color_cls: str) -> Div:
     pct = round(count / total * 100, 1) if total else 0.0
     bar_w = max(int(pct), 2) if count > 0 else 0
     return Div(
-        Span(label, cls="text-sm font-medium text-foreground w-20 inline-block"),
+        Span(label, cls="text-sm font-medium w-24 inline-block capitalize"),
         Div(
             Div(cls=f"{color_cls} h-3 rounded-full", style=f"width:{bar_w}%"),
             cls="flex-1 bg-accent rounded-full mx-3 h-3",
         ),
-        Span(f"{count:,}", cls="text-sm font-mono text-muted-foreground w-20 text-right"),
+        Span(f"{count:,}", cls="text-sm font-mono text-muted-foreground w-24 text-right"),
         Span(f"{pct}%", cls="text-sm font-mono text-muted-foreground w-14 text-right"),
         cls="flex items-center py-1",
     )
@@ -70,35 +134,68 @@ def _StatusBar(label: str, count: int, total: int, color_cls: str) -> Div:
 
 def _JobRow(job: dict) -> Tr:
     status = job.get("status", "unknown")
-    status_cls = _JOB_STATUS_CLS.get(status, "text-muted-foreground bg-accent")
-    icon = "✅" if status in ("completed", "synced") else "❌" if status == "failed" else "⏳"
+    badge_cls = _JOB_BADGE.get(status, "text-gray-600 bg-gray-100")
+    job_type = job.get("job_type") or "sync_stats"
+    creator = str(job.get("creator_id") or "")[:8]
+    retries = job.get("retry_count", 0)
 
-    started = job.get("started_at") or job.get("created_at")
-    finished = job.get("finished_at") or job.get("updated_at")
+    # Per-job duration
     duration = "—"
-    if started and finished:
+    s_ts, c_ts = job.get("started_at"), job.get("completed_at")
+    if s_ts and c_ts:
         try:
-            s = datetime.fromisoformat(started.replace("Z", "+00:00"))
-            f = datetime.fromisoformat(finished.replace("Z", "+00:00"))
-            secs = int((f - s).total_seconds())
-            duration = f"{secs}s" if secs >= 0 else "—"
+            dur = (
+                datetime.fromisoformat(c_ts.replace("Z", "+00:00"))
+                - datetime.fromisoformat(s_ts.replace("Z", "+00:00"))
+            ).total_seconds()
+            if dur >= 0:
+                duration = _fmt_dur(dur)
         except Exception:
             pass
 
-    creator_id = str(job.get("creator_id") or "")[:8]
+    # Age of last update
+    age_ts = job.get("completed_at") or job.get("created_at")
+    age = "—"
+    if age_ts:
+        try:
+            secs = int(
+                (
+                    datetime.now(timezone.utc)
+                    - datetime.fromisoformat(age_ts.replace("Z", "+00:00"))
+                ).total_seconds()
+            )
+            age = _fmt_ago(secs)
+        except Exception:
+            pass
+
+    error = job.get("error_message") or ""
+    error_cell = Td(
+        (
+            Span(error[:45] + "…" if len(error) > 45 else error, cls="text-xs text-red-500")
+            if error
+            else Span("—", cls="text-xs text-muted-foreground")
+        ),
+        cls="px-3 py-2 max-w-xs",
+    )
+
     return Tr(
-        Td(Code(f"#{job.get('id', '')}", cls="text-xs"), cls="px-3 py-2"),
-        Td(Code(creator_id + "…", cls="text-xs text-primary"), cls="px-3 py-2"),
+        Td(Code(f"#{job.get('id', '')}", cls="text-xs"), cls="px-3 py-2 whitespace-nowrap"),
+        Td(Code(creator + "…" if creator else "—", cls="text-xs text-primary"), cls="px-3 py-2"),
+        Td(Span(job_type, cls="text-xs text-muted-foreground"), cls="px-3 py-2"),
         Td(
-            Span(status, cls=f"text-xs font-medium px-2 py-0.5 rounded-full {status_cls}"),
+            Span(status, cls=f"text-xs font-medium px-2 py-0.5 rounded-full {badge_cls}"),
             cls="px-3 py-2",
         ),
-        Td(duration, cls="px-3 py-2 text-xs font-mono text-muted-foreground"),
+        Td(duration, cls="px-3 py-2 text-xs font-mono text-muted-foreground whitespace-nowrap"),
         Td(
-            Span(f"retry:{job.get('retry_count', 0)}", cls="text-xs text-muted-foreground"),
+            Span(
+                f"×{retries}",
+                cls=f"text-xs {'text-orange-500 font-medium' if retries > 0 else 'text-muted-foreground'}",
+            ),
             cls="px-3 py-2",
         ),
-        Td(icon, cls="px-3 py-2 text-center"),
+        error_cell,
+        Td(age, cls="px-3 py-2 text-xs text-muted-foreground whitespace-nowrap"),
         cls="border-b border-border hover:bg-accent/50",
     )
 
@@ -106,62 +203,136 @@ def _JobRow(job: dict) -> Tr:
 # ── Section builders ──────────────────────────────────────────────────────────
 
 
-def _HeroSection(stats: dict) -> Div:
+def _QueueSection(data: dict) -> Div:
+    pending = data["queue_pending"]
+    oldest_str = _fmt_age(data.get("oldest_pending_secs"))
+    warn_pending = pending > 100_000
+    warn_failed = data["queue_failed"] > 0
+
     return Div(
-        _StatCard("Total Creators", f"{stats.get('total', 0):,}", "in database", "total"),
-        _StatCard("Synced Today", f"{stats.get('synced_today', 0):,}", "last 24h", "synced"),
-        _StatCard("Pending", f"{stats.get('pending', 0):,}", "in queue", "pending"),
-        _StatCard("Failed", f"{stats.get('failed', 0):,}", "need attention", "failed"),
-        _StatCard(
-            "Processing", f"{stats.get('processing', 0):,}", "active right now", "processing"
+        H3(
+            "Job Queue",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
         ),
-        cls="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6",
-        id="hero-stats",
+        Grid(
+            _StatCard(
+                "Pending", pending, f"oldest waiting: {oldest_str}", "yellow", warn=warn_pending
+            ),
+            _StatCard("Processing", data["queue_processing"], "active right now", "purple"),
+            _StatCard(
+                "Failed", data["queue_failed"], "need manual review", "red", warn=warn_failed
+            ),
+            cols_md=3,
+            gap=4,
+        ),
+        cls="mb-6",
     )
 
 
-def _BreakdownSection(breakdown: dict, total: int) -> Div:
+def _InventorySection(data: dict) -> Div:
+    total = data["total_creators"]
+    invisible = total - data["visible"]
+
+    return Div(
+        H3(
+            "Creator Inventory",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        Grid(
+            _StatCard("Total in DB", total, "all records", "blue"),
+            _StatCard("Visible", data["visible"], "synced + named + has subscribers", "green"),
+            _StatCard("Invisible", invisible, "not yet synced, failed, or invalid", "gray"),
+            _StatCard("Fresh (<7d)", data["fresh_7d"], "synced within last 7 days", "green"),
+            _StatCard(
+                "Stale (>30d)",
+                data["stale_30d"],
+                "synced but overdue refresh",
+                "orange",
+                warn=data["stale_30d"] > 0,
+            ),
+            _StatCard(
+                "Never Synced",
+                data["never_synced"],
+                "last_synced_at is NULL",
+                "red",
+                warn=data["never_synced"] > 0,
+            ),
+            cols_md=3,
+            gap=4,
+        ),
+        cls="mb-6",
+    )
+
+
+def _WorkerSection(data: dict) -> Div:
+    completed_1h = data["completed_1h"]
+    completed_24h = data["completed_24h"]
+    pending = data["queue_pending"]
+
+    rate_24h = completed_24h / 24.0  # jobs/hour (24h window — authoritative for batch worker)
+
+    last_secs = data.get("last_completed_secs")
+    # Stale = nothing completed in last 24h (covers idle Kaggle workers between runs)
+    worker_stale = completed_24h == 0
+
+    # 1h row: distinguish "idle this hour but worked today" from "truly silent"
+    if completed_1h > 0:
+        completed_1h_str = f"{completed_1h:,}"
+    elif completed_24h > 0:
+        completed_1h_str = "0 (idle this hour)"
+    else:
+        completed_1h_str = "0"
+
+    throughput_card = Card(
+        H3(
+            "Worker Throughput",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        _KVRow("Jobs completed (last 1h)", completed_1h_str),
+        _KVRow("Jobs completed (last 24h)", f"{completed_24h:,}"),
+        _KVRow("Avg job duration", _fmt_dur(data.get("avg_job_secs"))),
+        _KVRow("Last completed", _fmt_ago(last_secs), warn=worker_stale),
+        body_cls="p-5",
+    )
+
+    drain_card = Card(
+        H3(
+            "Queue Drain Estimate",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        _KVRow(
+            "At 24h avg rate",
+            _fmt_drain(pending, rate_24h),
+            warn=pending > 0 and rate_24h > 0 and (pending / rate_24h) > 24 * 14,
+        ),
+        _KVRow("Rate (jobs/hr)", f"{rate_24h:.0f}" if rate_24h > 0 else "—"),
+        _KVRow("Queue depth", f"{pending:,} jobs"),
+        _KVRow("Oldest job waiting", _fmt_age(data.get("oldest_pending_secs"))),
+        body_cls="p-5",
+    )
+
+    return Grid(throughput_card, drain_card, cols_md=2, gap=4, cls="mb-6")
+
+
+def _BreakdownSection(data: dict) -> Div:
+    total = data["total_creators"] or 1
+    breakdown = {
+        "synced": data["synced"],
+        "pending": data["pending_creators"],
+        "failed": data["failed_creators"],
+        "invalid": data["invalid_creators"],
+    }
     return Card(
         H3(
-            "Sync Status",
+            "Sync Status Breakdown",
             cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
         ),
         *[
-            _StatusBar(k, breakdown.get(k, 0), total, _STATUS_BAR_COLORS.get(k, "bg-gray-300"))
+            _StatusBar(k, breakdown[k], total, _BAR_COLOR.get(k, "bg-gray-300"))
             for k in ("synced", "pending", "failed", "invalid")
         ],
         body_cls="p-5 space-y-1",
-    )
-
-
-def _ThroughputSection(throughput: dict) -> Div:
-    def _row(label, value):
-        return DivFullySpaced(
-            Span(label, cls="text-sm text-muted-foreground"),
-            Span(value, cls="text-sm font-mono font-medium text-foreground"),
-            cls="py-1.5 border-b border-border last:border-0",
-        )
-
-    quota_used = throughput.get("quota_used", 0)
-    quota_total = throughput.get("quota_total", 10000)
-    quota_pct = round(quota_used / quota_total * 100, 1) if quota_total else 0
-    return Card(
-        H3(
-            "Worker Health",
-            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
-        ),
-        _row("Jobs / hour (est.)", str(throughput.get("jobs_per_hour", "—"))),
-        _row("Avg duration", throughput.get("avg_duration", "—")),
-        _row("Last job", throughput.get("last_job_ago", "—")),
-        _row("YT Quota", f"{quota_used:,} / {quota_total:,} ({quota_pct}%)"),
-        Div(
-            Div(
-                cls="bg-orange-400 h-2 rounded-full transition-all",
-                style=f"width:{min(quota_pct, 100)}%",
-            ),
-            cls="w-full bg-accent rounded-full h-2 mt-3",
-        ),
-        body_cls="p-5",
+        cls="mb-6",
     )
 
 
@@ -169,6 +340,7 @@ def _JobsSection(jobs: list[dict]) -> Div:
     if not jobs:
         body = P("No recent jobs.", cls="text-sm text-muted-foreground py-6 text-center")
     else:
+        headers = ["ID", "Creator", "Type", "Status", "Duration", "Retries", "Error", "Age"]
         body = Div(
             Table(
                 Thead(
@@ -178,7 +350,7 @@ def _JobsSection(jobs: list[dict]) -> Div:
                                 h,
                                 cls="px-3 py-2 text-left text-xs font-mono uppercase tracking-wide text-muted-foreground",
                             )
-                            for h in ["ID", "Creator", "Status", "Duration", "Retries", ""]
+                            for h in headers
                         ]
                     ),
                     cls="border-b border-border",
@@ -191,13 +363,11 @@ def _JobsSection(jobs: list[dict]) -> Div:
 
     return Card(
         H3(
-            "Recent Jobs",
+            "Recent Jobs (20)",
             cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
         ),
-        # HTMX auto-refresh every 30s — only the jobs panel, no full reload
         body,
         body_cls="p-5",
-        cls="mb-6",
         id="jobs-panel",
         **{"hx-get": "/admin/jobs", "hx-trigger": "every 30s", "hx-swap": "outerHTML"},
     )
@@ -206,17 +376,10 @@ def _JobsSection(jobs: list[dict]) -> Div:
 # ── Full page ─────────────────────────────────────────────────────────────────
 
 
-def AdminPage(
-    stats: dict,
-    breakdown: dict,
-    throughput: dict,
-    jobs: list[dict],
-    refreshed_at: str = "",
-) -> FT:
-    """Admin page content. Caller wraps with Titled + NavComponent."""
-    total = sum(breakdown.values()) or 1
-
+def AdminPage(data: dict, refreshed_at: str = "") -> FT:
+    """Admin page content. Caller (main.py) wraps with Titled + NavComponent."""
     return Div(
+        # Sticky top bar
         Div(
             Div(
                 Span("⚙️", cls="mr-2"),
@@ -232,15 +395,11 @@ def AdminPage(
             cls="flex items-center justify-between bg-background border-b border-border px-6 py-3 mb-6 sticky top-0 z-40 shadow-sm",
         ),
         Container(
-            _HeroSection(stats),
-            Grid(
-                _BreakdownSection(breakdown, total),
-                _ThroughputSection(throughput),
-                cols_md=2,
-                gap=4,
-                cls="mb-6",
-            ),
-            _JobsSection(jobs),
+            _QueueSection(data),
+            _InventorySection(data),
+            _WorkerSection(data),
+            _BreakdownSection(data),
+            _JobsSection(data["recent_jobs"]),
             cls="max-w-6xl mx-auto px-4 pb-16",
         ),
     )


### PR DESCRIPTION
… state

- Fix retry_at → next_retry_at in oldest pending query
- Remove non-existent updated_at and input_query from job selects
- Order recent_jobs by completed_at DESC; exclude pending rows (was returning 20 of 591k pending stubs instead of actual activity)
- Fix _JobRow age display: use completed_at, not updated_at
- Worker stale logic: trigger on completed_24h==0, not last_secs>1h (batch/Kaggle worker runs periodically, idle-this-hour is normal)
- 1h completion row: show "0 (idle this hour)" when 24h count > 0
- Drain estimate: drop last-hour rate row; surface 24h rate and warn when drain exceeds 14 days (current: ~141 days at 175 jobs/hr)
- Inventory: update Invisible sublabel to reflect 99%+ never-synced
- Jobs table: rename "Updated" header to "Age"

## Summary by Sourcery

Revamp the admin dashboard to align with the real database schema, improve worker/queue observability, and make the recent jobs table show actual completion activity instead of pending stubs.

New Features:
- Add queue, inventory, worker throughput, and drain estimate sections to the admin dashboard with richer summary cards and key-value rows.
- Augment the recent jobs table with job type, error message, and age columns plus improved status badges and retry indicators.

Bug Fixes:
- Use next_retry_at instead of retry_at and completed_at instead of updated_at when querying and displaying job data.
- Exclude pending jobs from the recent jobs listing and order by completed_at descending to reflect real processing activity.
- Fix worker health logic to treat no completions in the last 24 hours as stale instead of relying on a last-seen threshold.

Enhancements:
- Introduce shared formatting helpers for durations, ages, and drain estimates to standardize admin dashboard display.
- Refactor admin data fetching into a single flat data dict with defensive defaults and isolated try/except blocks to prevent one failing query from breaking the page.