### PR TITLE
fix(admin): ground-truth fixes from live DB query results

### DIFF
--- a/db.py
+++ b/db.py
@@ -1391,6 +1391,8 @@ def mark_creator_sync_failed(job_id: int, error: str) -> bool:
         if retry_count >= CREATOR_WORKER_MAX_RETRIES:
             status = "failed"
             next_retry = None
+            # Rewrite the error message to make clear no more retries are scheduled
+            error = f"{error} (permanent — max retries reached)"
             logger.warning(f"Creator sync job {job_id} exhausted retries")
         else:
             status = "pending"

--- a/main.py
+++ b/main.py
@@ -138,7 +138,7 @@ from routes.lists import (
     lists_more_languages_route,
     lists_route,
 )
-from routes.admin import admin_get, admin_jobs_fragment
+from routes.admin import admin_get, admin_jobs_fragment, admin_rescue_quota_jobs
 from views.lists import _unslugify
 
 # Get logger instance
@@ -1695,6 +1695,12 @@ def admin(req, sess):
 def admin_jobs(req, sess):
     """Admin jobs fragment — HTMX endpoint for job table refresh."""
     return admin_jobs_fragment(req, sess)
+
+
+@rt("/admin/rescue-quota-jobs", methods=["POST"])
+def admin_rescue_quota(req, sess):
+    """Reset all quota-failed jobs back to pending."""
+    return admin_rescue_quota_jobs(req, sess)
 
 
 # ============================================================================

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -310,22 +310,28 @@ def _fetch_admin_data() -> dict:
 
     # ── Failed job breakdown (quota vs invalid vs other) ───────────────────────
     try:
-        failed_rows = (
+        data["failed_quota"] = (
             sc.table("creator_sync_jobs")
-            .select("error_message")
+            .select("id", count="exact")
             .eq("status", "failed")
+            .ilike("error_message", "%quota%")
             .execute()
-            .data
-            or []
+            .count
+            or 0
         )
-        for row in failed_rows:
-            msg = (row.get("error_message") or "").lower()
-            if "quota" in msg:
-                data["failed_quota"] += 1
-            elif "zero" in msg or "invalid" in msg or "suspicious" in msg:
-                data["failed_invalid"] += 1
-            else:
-                data["failed_other"] += 1
+        data["failed_invalid"] = (
+            sc.table("creator_sync_jobs")
+            .select("id", count="exact")
+            .eq("status", "failed")
+            .or_("error_message.ilike.%zero%,error_message.ilike.%suspicious%")
+            .execute()
+            .count
+            or 0
+        )
+        # Other = total failed minus the two classified buckets
+        data["failed_other"] = max(
+            0, data["queue_failed"] - data["failed_quota"] - data["failed_invalid"]
+        )
     except Exception:
         logger.exception("[Admin] Failed job breakdown query failed")
 
@@ -406,9 +412,9 @@ def admin_rescue_quota_jobs(req, sess) -> Response | FT:
             )
             .eq("status", "failed")
             .ilike("error_message", "%quota%")
-            .execute()
+            .execute(count="exact")
         )
-        rescued = len(result.data) if result.data else 0
+        rescued = result.count or 0
         if rescued == 0:
             return P("No quota-failed jobs found.", cls="text-sm text-muted-foreground")
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -129,6 +129,9 @@ def _fetch_admin_data() -> dict:
         "queue_pending": 0,
         "queue_processing": 0,
         "queue_failed": 0,
+        "failed_quota": 0,
+        "failed_invalid": 0,
+        "failed_other": 0,
         "oldest_pending_secs": None,
         # Throughput
         "completed_24h": 0,
@@ -221,8 +224,7 @@ def _fetch_admin_data() -> dict:
             sc.table("creator_sync_jobs")
             .select("created_at")
             .eq("status", "pending")
-            .is_("next_retry_at", "null")
-            .order("created_at", desc=False)
+            .order("created_at", desc=False)  # absolute oldest, regardless of retry state
             .limit(1)
             .execute()
             .data
@@ -295,7 +297,9 @@ def _fetch_admin_data() -> dict:
                 "started_at, completed_at, created_at, error_message"
             )
             .neq("status", "pending")  # exclude 500k+ pending rows; show activity
-            .order("completed_at", desc=True)
+            .order(
+                "created_at", desc=True
+            )  # completed_at is NULL on failed rows; created_at is always set
             .limit(20)
             .execute()
             .data
@@ -303,6 +307,27 @@ def _fetch_admin_data() -> dict:
         )
     except Exception:
         logger.exception("[Admin] Recent jobs query failed")
+
+    # ── Failed job breakdown (quota vs invalid vs other) ───────────────────────
+    try:
+        failed_rows = (
+            sc.table("creator_sync_jobs")
+            .select("error_message")
+            .eq("status", "failed")
+            .execute()
+            .data
+            or []
+        )
+        for row in failed_rows:
+            msg = (row.get("error_message") or "").lower()
+            if "quota" in msg:
+                data["failed_quota"] += 1
+            elif "zero" in msg or "invalid" in msg or "suspicious" in msg:
+                data["failed_invalid"] += 1
+            else:
+                data["failed_other"] += 1
+    except Exception:
+        logger.exception("[Admin] Failed job breakdown query failed")
 
     return data
 
@@ -322,7 +347,7 @@ def _fetch_recent_jobs() -> list[dict]:
                 "started_at, completed_at, created_at, error_message"
             )
             .neq("status", "pending")
-            .order("completed_at", desc=True)
+            .order("created_at", desc=True)  # completed_at is NULL on failed rows
             .limit(20)
             .execute()
             .data
@@ -355,3 +380,43 @@ def admin_jobs_fragment(req, sess) -> Response | FT:
     if not _is_authorised(req, sess):
         return _auth_response()
     return _JobsSection(_fetch_recent_jobs())
+
+
+def admin_rescue_quota_jobs(req, sess) -> Response | FT:
+    """POST /admin/rescue-quota-jobs — reset quota-failed jobs back to pending."""
+    if not _is_authorised(req, sess):
+        return _auth_response()
+
+    sc = _db.supabase_client
+    if not sc:
+        return Response("DB unavailable", status_code=503)
+
+    try:
+        # Single filter-based update — no ID fetch needed, avoids URL length limits
+        # with 952 IDs. The ilike filter matches "YouTube quota exceeded" rows exactly.
+        result = (
+            sc.table("creator_sync_jobs")
+            .update(
+                {
+                    "status": "pending",
+                    "retry_count": 0,
+                    "retry_at": None,
+                    "error_message": None,
+                }
+            )
+            .eq("status", "failed")
+            .ilike("error_message", "%quota%")
+            .execute()
+        )
+        rescued = len(result.data) if result.data else 0
+        if rescued == 0:
+            return P("No quota-failed jobs found.", cls="text-sm text-muted-foreground")
+
+        logger.info("[Admin] Rescued %d quota-failed jobs", rescued)
+        return P(
+            f"✅ Reset {rescued:,} quota-failed jobs to pending.",
+            cls="text-sm text-green-600 font-medium",
+        )
+    except Exception:
+        logger.exception("[Admin] rescue_quota_jobs failed")
+        return P("❌ Rescue failed — check server logs.", cls="text-sm text-red-600")

--- a/views/admin.py
+++ b/views/admin.py
@@ -158,6 +158,9 @@ def _JobRow(job: dict) -> Tr:
         dur = (c_dt - s_dt).total_seconds()
         if dur >= 0:
             duration = _fmt_dur(dur)
+    elif s_dt and not c_dt:
+        # Job was picked up by the worker but never completed (failed mid-run)
+        duration = Span("started", cls="text-xs text-orange-400 italic")
 
     # Age of last update
     age_ts = job.get("completed_at") or job.get("created_at")
@@ -208,6 +211,39 @@ def _QueueSection(data: dict) -> Div:
     warn_pending = pending > 100_000
     warn_failed = data["queue_failed"] > 0
 
+    failed_quota = data.get("failed_quota", 0)
+    failed_invalid = data.get("failed_invalid", 0)
+    failed_other = data.get("failed_other", 0)
+
+    failed_detail = Card(
+        H3(
+            "Failed Jobs",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        _KVRow("Quota exceeded", f"{failed_quota:,}", warn=failed_quota > 0),
+        _KVRow("Invalid channel", f"{failed_invalid:,}"),
+        _KVRow("Other", f"{failed_other:,}"),
+        Div(
+            (
+                Button(
+                    f"Rescue {failed_quota:,} quota jobs",
+                    cls="text-xs px-3 py-1.5 rounded bg-green-600 hover:bg-green-700 text-white font-medium mt-3",
+                    **{
+                        "hx-post": "/admin/rescue-quota-jobs",
+                        "hx-target": "#rescue-result",
+                        "hx-swap": "innerHTML",
+                        "hx-confirm": f"Reset {failed_quota:,} quota-failed jobs to pending?",
+                    },
+                )
+                if failed_quota > 0
+                else None
+            ),
+            Div(id="rescue-result", cls="mt-2"),
+        ),
+        body_cls="p-5",
+        cls="border-l-4 border-red-400" if warn_failed else "",
+    )
+
     return Div(
         H3(
             "Job Queue",
@@ -224,6 +260,7 @@ def _QueueSection(data: dict) -> Div:
             cols_md=3,
             gap=4,
         ),
+        (failed_detail if warn_failed else None),
         cls="mb-6",
     )
 

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -466,42 +466,27 @@ def _fetch_pending_jobs(batch_size: int) -> List[Dict]:
     now_iso = datetime.now(timezone.utc).isoformat()
 
     try:
-        # Jobs with no retry_at scheduled (fresh or first attempt)
-        fresh_resp = (
+        # Single query: fresh jobs (retry_at IS NULL) OR overdue retry jobs
+        # (retry_at IS NOT NULL AND retry_at <= now()), ordered by created_at FIFO.
+        #
+        # The previous two-query approach had a critical flaw: with batch_size=1,
+        # the retry branch was dead code — `if len(fresh_jobs) < 1` is always False
+        # when any fresh job exists, so retry-overdue jobs would wait until all
+        # ~547k fresh jobs were exhausted (~154 days).
+        resp = (
             supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
-            .select("id,creator_id,source,retry_count,job_type,input_query")
+            .select("id,creator_id,source,retry_count,job_type")
             .eq("status", JobStatus.PENDING.value)
-            .is_("retry_at", "null")
+            .or_(f"retry_at.is.null,retry_at.lte.{now_iso}")
             .order("created_at", desc=False)
             .limit(batch_size)
             .execute()
         )
 
-        fresh_jobs = fresh_resp.data or []
-
-        # Jobs where retry_at has passed (backoff window expired)
-        if len(fresh_jobs) < batch_size:
-            retry_resp = (
-                supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
-                .select("id,creator_id,source,retry_count,job_type,input_query")
-                .eq("status", JobStatus.PENDING.value)
-                .not_.is_("retry_at", "null")
-                .lte("retry_at", now_iso)
-                .order("retry_at", desc=False)
-                .limit(batch_size - len(fresh_jobs))
-                .execute()
-            )
-            retry_jobs = retry_resp.data or []
-        else:
-            retry_jobs = []
-
-        all_jobs = fresh_jobs + retry_jobs
+        all_jobs = resp.data or []
 
         if all_jobs:
-            logger.info(
-                f"  Pending jobs ready: {len(all_jobs)} total "
-                f"({len(fresh_jobs)} fresh, {len(retry_jobs)} retry-ready)"
-            )
+            logger.info(f"  Pending jobs ready: {len(all_jobs)}")
         else:
             logger.debug("  No pending jobs ready for processing right now")
 


### PR DESCRIPTION
routes/admin.py:
- Fix oldest-pending query: remove retry_at IS NULL filter — correct column is retry_at (not next_retry_at), and all 48,979 in-backoff jobs have retry_at <= now() anyway; show absolute oldest (Mar 22)
- Fix recent_jobs + fragment: order by created_at DESC, not completed_at — 1,349/1,455 failed rows have completed_at=NULL, causing PostgreSQL NULLS FIRST to bury completed jobs
- Fix rescue endpoint: replace fetch-IDs-then-.in_() with a single filter-based .update().ilike() — .in_(952 UUIDs) would exceed PostgREST URL length limits
- Add failed job breakdown (failed_quota/failed_invalid/failed_other) populated by classifying error_message strings in Python
- Add admin_rescue_quota_jobs() endpoint + register in main.py

views/admin.py:
- _QueueSection: expand failed card with quota/invalid/other breakdown and HTMX "Rescue N quota jobs" button with confirm dialog
- _JobRow duration: show "started" (orange italic) when started_at is set but completed_at is NULL — affects 1,349 aborted failed jobs

worker/creator_worker.py:
- Fix _fetch_pending_jobs: replace two-query split with single .or_(retry_at.is.null,retry_at.lte.now) — previous design made the retry branch dead code with batch_size=1, leaving 48,979 overdue retry jobs stranded for ~154 days
- Remove input_query from both select() calls (column doesn't exist; was silently causing 400s swallowed by the except clause)

db.py:
- mark_creator_sync_failed: append "(permanent — max retries reached)" to error_message when retry_count >= MAX_RETRIES, so permanently failed jobs don't show "will retry" in the admin table

## Summary by Sourcery

Correct admin job monitoring and recovery logic for creator sync jobs and ensure overdue retries are processed.

New Features:
- Add admin metrics for failed job breakdown by quota, invalid, and other error categories.
- Expose an admin endpoint and UI control to reset quota-failed jobs back to pending.

Bug Fixes:
- Fix oldest pending job query to consider all pending jobs regardless of retry state.
- Fix recent jobs queries to sort by creation time so failed jobs with NULL completion times are visible and ordered correctly.
- Ensure pending job fetching includes overdue retry jobs instead of starving them behind fresh jobs.
- Display an explicit 'started' state in the admin job row for jobs that began but never completed.
- Mark max-retry creator sync failures as permanently failed in their error messages.

Enhancements:
- Simplify pending job fetching into a single FIFO query based on retry_at state.
- Add a detailed failed-jobs card in the admin queue view with counts and a rescue action for quota failures.