### PR TITLE
feat: admin dashboard, rescue-quota-jobs, favourites CSV export

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ Modernized with Tailwind-inspired design and MonsterUI components.
 Includes Google OAuth with token revocation support.
 """
 
+import csv
+import io
 import json
 import logging
 import mimetypes
@@ -20,7 +22,7 @@ from fasthtml.common import *
 from fasthtml.common import RedirectResponse, Response
 from fasthtml.core import HtmxHeaders
 from monsterui.all import *
-from starlette.responses import StreamingResponse
+from starlette.responses import Response as StarletteResponse, StreamingResponse
 
 from auth.auth_service import (
     AUTH_SKIP_ROUTE_PATTERNS,
@@ -1554,6 +1556,67 @@ def toggle_favourite_list(req, sess, list_key: str = "", list_label: str = "", l
         new_fav = ok  # False if validation failed
 
     return _list_heart_btn(list_key, list_label, list_url, new_fav, authenticated=True)
+
+
+@rt("/me/favourites/export.csv")
+def me_favourites_export(req, sess):
+    """Export the user's saved creators as a CSV file."""
+    user_id = sess.get("user_id") if sess else None
+    if not user_id:
+        return RedirectResponse("/login", status_code=303)
+
+    creators = get_user_favourite_creators(user_id)
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "channel_name",
+            "channel_id",
+            "channel_url",
+            "custom_url",
+            "current_subscribers",
+            "current_view_count",
+            "current_video_count",
+            "primary_category",
+            "country_code",
+            "language",
+            "quality_grade",
+            "engagement_score",
+            "sub_growth_30d",
+            "view_growth_30d",
+            "last_synced_at",
+        ]
+    )
+    for c in creators:
+        channel_url = c.get("channel_url") or (
+            f"https://www.youtube.com/channel/{c.get('channel_id', '')}"
+        )
+        writer.writerow(
+            [
+                c.get("channel_name") or "",
+                c.get("channel_id") or "",
+                channel_url,
+                c.get("custom_url") or "",
+                c.get("current_subscribers") or 0,
+                c.get("current_view_count") or 0,
+                c.get("current_video_count") or 0,
+                c.get("primary_category") or "",
+                c.get("country_code") or "",
+                c.get("language") or "",
+                c.get("quality_grade") or "",
+                c.get("engagement_score") or "",
+                c.get("sub_growth_30d") or "",
+                c.get("view_growth_30d") or "",
+                c.get("last_synced_at") or "",
+            ]
+        )
+
+    return StarletteResponse(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="saved-creators.csv"'},
+    )
 
 
 @rt("/me/favourites")

--- a/main.py
+++ b/main.py
@@ -1589,13 +1589,14 @@ def me_favourites_export(req, sess):
         ]
     )
     for c in creators:
+        channel_id = c.get("channel_id") or ""
         channel_url = c.get("channel_url") or (
-            f"https://www.youtube.com/channel/{c.get('channel_id', '')}"
+            f"https://www.youtube.com/channel/{channel_id}" if channel_id else ""
         )
         writer.writerow(
             [
                 c.get("channel_name") or "",
-                c.get("channel_id") or "",
+                channel_id,
                 channel_url,
                 c.get("custom_url") or "",
                 c.get("current_subscribers") or 0,
@@ -1614,7 +1615,7 @@ def me_favourites_export(req, sess):
 
     return StarletteResponse(
         content=buf.getvalue(),
-        media_type="text/csv",
+        media_type="text/csv; charset=utf-8",
         headers={"Content-Disposition": 'attachment; filename="saved-creators.csv"'},
     )
 

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -46,6 +46,8 @@ from views.creators import (
     render_creator_profile_page,
     render_creators_page,
 )
+from utils.blueprint import signals_from_row, score_all_actions
+from views.blueprint import render_blueprint_page
 
 logger = logging.getLogger(__name__)
 
@@ -491,9 +493,6 @@ def blueprint_route(request, creator_id: str):
 
     Returns a Div (page fragment) — wrapped in a full Titled page by main.py.
     """
-    from utils.blueprint import signals_from_row, score_all_actions
-    from views.blueprint import render_blueprint_page
-
     creator = get_creator_stats(creator_id)
     if not creator:
         logger.warning("[Blueprint] Creator not found: %s", creator_id)

--- a/views/favourites.py
+++ b/views/favourites.py
@@ -153,11 +153,26 @@ def render_favourites_page(creators: list[dict], user_name: str) -> Div:
                 ),
                 cls="",
             ),
-            A(
-                UkIcon("search", cls="w-4 h-4 mr-2"),
-                "Browse Creators",
-                href="/creators",
-                cls="inline-flex items-center px-4 py-2 bg-accent hover:bg-accent/80 text-foreground text-sm font-semibold rounded-lg no-underline transition-colors",
+            Div(
+                *(
+                    [
+                        A(
+                            UkIcon("download", cls="w-4 h-4 mr-2"),
+                            "Export CSV",
+                            href="/me/favourites/export.csv",
+                            cls="inline-flex items-center px-4 py-2 bg-green-600 hover:bg-green-700 text-white text-sm font-semibold rounded-lg no-underline transition-colors mr-2",
+                        )
+                    ]
+                    if count
+                    else []
+                ),
+                A(
+                    UkIcon("search", cls="w-4 h-4 mr-2"),
+                    "Browse Creators",
+                    href="/creators",
+                    cls="inline-flex items-center px-4 py-2 bg-accent hover:bg-accent/80 text-foreground text-sm font-semibold rounded-lg no-underline transition-colors",
+                ),
+                cls="flex items-center",
             ),
             cls="flex items-start justify-between mt-8 mb-6",
         ),


### PR DESCRIPTION
- Rewrite admin dashboard with live operational metrics (queue health, worker throughput, drain estimate, failed job breakdown)
- Fix worker _fetch_pending_jobs: unified .or_() query replaces dead retry branch; remove input_query from selects (caused silent 400s)
- Add POST /admin/rescue-quota-jobs: resets quota-failed jobs to pending via single filter-based update (no ID list / URL overflow risk)
- Add GET /me/favourites/export.csv: streams 15-column CSV of saved creators
- Fix mark_creator_sync_failed: appends "(permanent)" label on exhaustion
- Move inline imports to module level (csv, io, StarletteResponse, blueprint utils in routes/creators.py)

## Summary by Sourcery

Add CSV export for a user's saved creators and surface it from the favourites page, while cleaning up blueprint route imports.

New Features:
- Expose a /me/favourites/export.csv endpoint that streams a CSV export of the authenticated user's saved creators.
- Add an Export CSV button to the favourites page header when the user has saved creators.

Enhancements:
- Move blueprint-related imports in routes/creators.py from inline to module-level for clearer structure.