### PR TITLE
fix: show "add creator" CTA for @handle searches that return partial …

### DIFF
--- a/routes/creators.py
+++ b/routes/creators.py
@@ -67,7 +67,7 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
     # Set when user searched a @handle that isn't in the DB — passed to the
     # view so it can show the "add this creator" banner even when other
     # creators appear in search results.
-    handle_not_found_in_db: bool = False
+    handle_not_found: bool = False
 
     if search.strip().startswith("@"):
         handle = search.strip()
@@ -84,7 +84,7 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
             # Fall through to normal search (will match by custom_url)
         else:
             # Creator not in DB — flag it so the view shows the add CTA
-            handle_not_found_in_db = True
+            handle_not_found = True
             logger.info(f"[HandleSearch] Creator not found in DB: {handle}")
 
             try:
@@ -241,7 +241,7 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
         total_pages=total_pages,
         is_authenticated=is_authenticated,
         favourite_ids=favourite_ids,
-        handle_not_found=handle_not_found_in_db,
+        handle_not_found=handle_not_found,
     )
 
 

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -64,6 +64,11 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
     # ═══════════════════════════════════════════════════════════════
     # HANDLE SEARCH MODE (@username)
     # ═══════════════════════════════════════════════════════════════
+    # Set when user searched a @handle that isn't in the DB — passed to the
+    # view so it can show the "add this creator" banner even when other
+    # creators appear in search results.
+    handle_not_found_in_db: bool = False
+
     if search.strip().startswith("@"):
         handle = search.strip()
         logger.info(f"[HandleSearch] Detected handle search: {handle}")
@@ -78,8 +83,9 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
             )
             # Fall through to normal search (will match by custom_url)
         else:
-            # Creator not in DB - fetch from YouTube and show preview
-            logger.info(f"[HandleSearch] Creator not found, fetching from YouTube...")
+            # Creator not in DB — flag it so the view shows the add CTA
+            handle_not_found_in_db = True
+            logger.info(f"[HandleSearch] Creator not found in DB: {handle}")
 
             try:
                 youtube_api = None  # YouTubeBackendAPI()
@@ -92,10 +98,7 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
                         channel_info=channel_info,
                         search=search,
                     )
-                else:
-                    # Handle not found on YouTube
-                    logger.warning(f"[HandleSearch] Handle not found on YouTube: {handle}")
-                    # Fall through to show empty results with helpful message
+                # else: fall through to normal search with banner
 
             except Exception as e:
                 logger.exception(f"[HandleSearch] Error fetching handle {handle}: {e}")
@@ -238,6 +241,7 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
         total_pages=total_pages,
         is_authenticated=is_authenticated,
         favourite_ids=favourite_ids,
+        handle_not_found=handle_not_found_in_db,
     )
 
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -721,6 +721,7 @@ def render_creators_page(
     total_pages: int = 1,
     is_authenticated: bool = False,
     favourite_ids: set[str] | None = None,
+    handle_not_found: bool = False,
 ) -> Div:
     """
     Analytics-first creator discovery dashboard.
@@ -791,6 +792,9 @@ def render_creators_page(
             total_count=total_count,
             per_page=per_page,
         ),
+        # "@handle not in DB" banner — shown above results even when other
+        # creators appear, so the add-creator CTA is never lost.
+        (_render_handle_not_found_banner(search, is_authenticated) if handle_not_found else None),
         # Creators grid or empty state
         (
             Div(
@@ -2316,6 +2320,58 @@ def _render_pagination(
             cls="flex items-center justify-center gap-4 flex-wrap",
         ),
         cls="py-8",
+    )
+
+
+def _render_handle_not_found_banner(search: str, is_authenticated: bool) -> Div:
+    """
+    Compact banner shown above the results grid when a @handle search
+    returned no exact DB match — even if related creators are shown below.
+    Reuses the same HTMX endpoint as the empty-state Flow 1.
+    """
+    result_slot = Div(id="creator-add-result", cls="mt-2")
+
+    if is_authenticated:
+        action = Form(
+            Input(type="hidden", name="q", value=search),
+            Button(
+                UkIcon("plus-circle", cls="size-4 mr-1.5"),
+                f"Add {search}",
+                type="submit",
+                cls="flex items-center px-4 py-1.5 text-sm font-semibold rounded-lg "
+                "bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shrink-0",
+            ),
+            result_slot,
+            hx_post="/creators/request",
+            hx_target="#creator-add-result",
+            hx_swap="innerHTML",
+            cls="flex flex-col items-start gap-0",
+        )
+    else:
+        action = A(
+            UkIcon("log-in", cls="size-4 mr-1.5"),
+            "Log in to add",
+            href="/login",
+            cls="inline-flex items-center px-4 py-1.5 text-sm font-semibold rounded-lg "
+            "border border-border hover:bg-accent transition-colors shrink-0",
+        )
+
+    return Div(
+        Div(
+            Div(
+                UkIcon("info", cls="size-4 text-blue-500 shrink-0 mt-0.5"),
+                P(
+                    Span(search, cls="font-semibold"),
+                    " isn't in our database yet. " "Related results are shown below.",
+                    cls="text-sm text-foreground",
+                ),
+                cls="flex items-start gap-2 flex-1",
+            ),
+            action,
+            cls="flex items-start justify-between gap-4 flex-wrap",
+        ),
+        cls="mb-4 px-4 py-3 rounded-xl border border-blue-200 bg-blue-50 "
+        "dark:bg-blue-950/30 dark:border-blue-800",
     )
 
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -792,9 +792,14 @@ def render_creators_page(
             total_count=total_count,
             per_page=per_page,
         ),
-        # "@handle not in DB" banner — shown above results even when other
-        # creators appear, so the add-creator CTA is never lost.
-        (_render_handle_not_found_banner(search, is_authenticated) if handle_not_found else None),
+        # "@handle not in DB" banner — only shown alongside a real results grid.
+        # When creators is empty, _render_empty_state Flow 1 handles the CTA,
+        # avoiding duplicate id="creator-add-result" in the same page.
+        (
+            _render_handle_not_found_banner(search, is_authenticated)
+            if handle_not_found and creators
+            else None
+        ),
         # Creators grid or empty state
         (
             Div(


### PR DESCRIPTION
…results

When searching @mrbeast and the exact handle isn't in the DB, the normal search still returns related creators (e.g. "MrBeast Gaming"), so the empty-state card (and its add CTA) was never shown — regression from the progressive-disclosure refactor.

Fix:
- Route tracks handle_not_found_in_db flag when @handle falls through to normal search without an exact DB match
- Passes handle_not_found=True to render_creators_page
- New _render_handle_not_found_banner() renders a compact blue info strip above the results grid: "@x isn't in our database yet. Related results shown below." + one-click Add / Log in button
- Empty-state Flow 1 (full card) still fires when no results at all

## Summary by Sourcery

Ensure @handle searches that lack an exact database match still prompt users to add the creator while showing related results.

New Features:
- Display a compact banner above creator search results when an @handle is not found in the database, offering an add-creator or log-in call to action.

Bug Fixes:
- Preserve the add-creator call to action for @handle searches that fall back to normal search results instead of showing an empty state.

Enhancements:
- Plumb a handle-not-found flag from the creators route into the creators page view to control display of the handle-not-found banner.