### PR TITLE
Add recent performance section to stats

### DIFF
--- a/db/migrations/031_tier1_recent_performance.sql
+++ b/db/migrations/031_tier1_recent_performance.sql
@@ -1,0 +1,24 @@
+-- Migration 031: Tier 1 recent performance & brand safety columns
+-- Zero additional API quota cost — all data is derived from calls already made:
+--   avg_views_10 / avg_likes_10 / avg_comments_10 / avg_days_between_uploads
+--     ← from playlistItems.list + videos.list (already fetched for engagement_score)
+--   is_made_for_kids / has_long_upload_status
+--     ← from channels.list status part (added to existing channels.list call)
+
+ALTER TABLE creators
+  ADD COLUMN IF NOT EXISTS avg_views_10          INTEGER,
+  ADD COLUMN IF NOT EXISTS avg_likes_10          INTEGER,
+  ADD COLUMN IF NOT EXISTS avg_comments_10       INTEGER,
+  ADD COLUMN IF NOT EXISTS avg_days_between_uploads NUMERIC(6,2),
+  ADD COLUMN IF NOT EXISTS is_made_for_kids      BOOLEAN,
+  ADD COLUMN IF NOT EXISTS has_long_upload_status BOOLEAN;
+
+-- Index for reach-based sorting (avg_views_10 / current_subscribers)
+CREATE INDEX IF NOT EXISTS idx_creators_avg_views_10
+  ON creators (avg_views_10)
+  WHERE avg_views_10 IS NOT NULL;
+
+-- Index for brand safety filtering
+CREATE INDEX IF NOT EXISTS idx_creators_is_made_for_kids
+  ON creators (is_made_for_kids)
+  WHERE is_made_for_kids = TRUE;

--- a/services/channel_utils.py
+++ b/services/channel_utils.py
@@ -315,7 +315,7 @@ class YouTubeResolver:
 
         try:
             request = youtube.channels().list(
-                part="id,snippet,statistics,brandingSettings,topicDetails",
+                part="id,snippet,statistics,brandingSettings,topicDetails,status",
                 id=channel_id,
             )
             response = await self._execute_async(request)
@@ -492,6 +492,7 @@ class YouTubeResolver:
         """
         snippet = item.get("snippet", {})
         statistics = item.get("statistics", {})
+        status = item.get("status", {})
         branding = item.get("brandingSettings", {})
         channel_branding = branding.get("channel", {})
         topic_details = item.get("topicDetails", {})
@@ -579,6 +580,11 @@ class YouTubeResolver:
                 int(statistics.get("videoCount", 0) or 0),
                 snippet.get("publishedAt"),
             ),  # NEW: Estimated videos/month
+            # ═══════════════════════════════════════════════════════════
+            # BRAND SAFETY (from channels.list status part)
+            # ═══════════════════════════════════════════════════════════
+            "is_made_for_kids": status.get("madeForKids", False),
+            "has_long_upload_status": status.get("longUploadsStatus") == "longUploadsEnabled",
         }
 
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -2047,6 +2047,124 @@ def _build_info_strip(
     )
 
 
+def _build_recent_performance(
+    avg_views_10: int | None,
+    current_subs: int,
+    avg_days_between_uploads: float | None,
+    is_made_for_kids: bool,
+    has_long_upload_status: bool,
+) -> Div | None:
+    """
+    Tier 1 — "Recent Performance" microcard section (Tufte / Economist style).
+
+    Shows a reach microbar (avg views of last 10 videos as % of subscribers)
+    and upload cadence pill.  Brand safety badges only shown when relevant.
+
+    Hidden entirely when avg_views_10 is not yet populated (pre-migration data).
+    """
+    if avg_views_10 is None:
+        return None
+
+    # ── Reach % bar ──────────────────────────────────────────────────────────
+    # Reach = avg_views_10 / current_subscribers.  Reference ceiling = 10% of subs.
+    # Below 2% → red (ghost channel); 2–7% → amber; ≥7% → green (highly engaged).
+    reach_pct: float = (avg_views_10 / current_subs * 100) if current_subs > 0 else 0.0
+    bar_pct = min(reach_pct / 10 * 100, 100)  # scale to a 10%-of-subs ceiling
+
+    if reach_pct >= 7:
+        bar_fill = "bg-emerald-500"
+        reach_color = "text-emerald-600 dark:text-emerald-400"
+        reach_label_cls = "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800"
+    elif reach_pct >= 2:
+        bar_fill = "bg-amber-400"
+        reach_color = "text-amber-600 dark:text-amber-400"
+        reach_label_cls = "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800"
+    else:
+        bar_fill = "bg-red-400"
+        reach_color = "text-red-500 dark:text-red-400"
+        reach_label_cls = "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border-red-200 dark:border-red-800"
+
+    reach_row = Div(
+        # Label + value — left column
+        Div(
+            Span(
+                "REACH",
+                cls="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide",
+            ),
+            Span(
+                f"{reach_pct:.1f}% of subs",
+                cls=f"text-xs font-bold {reach_color}",
+            ),
+            cls="flex flex-col gap-0.5 min-w-[90px]",
+        ),
+        # Microbar — right column, Tufte-style: one thin rule, no grid
+        Div(
+            Div(
+                cls=f"h-[5px] rounded-sm {bar_fill} transition-all",
+                style=f"width:{bar_pct:.1f}%",
+            ),
+            cls="flex-1 h-[5px] bg-border rounded-sm overflow-hidden self-center",
+            title=f"{format_number(avg_views_10)} avg views on last 10 videos",
+        ),
+        # Avg views absolute — right label
+        Span(
+            format_number(avg_views_10),
+            cls="text-xs font-semibold text-muted-foreground text-right min-w-[44px]",
+        ),
+        cls="flex items-center gap-2",
+    )
+
+    # ── Cadence pill + brand-safety badges ───────────────────────────────────
+    badges: list = []
+
+    if avg_days_between_uploads is not None:
+        if avg_days_between_uploads < 1:
+            cadence_str = "multiple/day"
+        elif avg_days_between_uploads < 7:
+            cadence_str = f"every {avg_days_between_uploads:.0f}d"
+        else:
+            weeks = avg_days_between_uploads / 7
+            cadence_str = f"every {weeks:.1f}w"
+        badges.append(
+            Span(
+                f"⏱ {cadence_str}",
+                cls="text-[10px] font-medium px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700",
+                title="Average days between uploads (last 10 videos)",
+            )
+        )
+
+    if is_made_for_kids:
+        badges.append(
+            Span(
+                "🧸 Kids",
+                cls="text-[10px] font-medium px-2 py-0.5 rounded-full bg-yellow-50 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-700",
+                title="This channel is made for children (COPPA)",
+            )
+        )
+
+    if has_long_upload_status:
+        badges.append(
+            Span(
+                "⬆ Long video",
+                cls="text-[10px] font-medium px-2 py-0.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700",
+                title="Eligible to upload videos longer than 15 minutes",
+            )
+        )
+
+    badge_row = Div(*badges, cls="flex flex-wrap gap-1.5") if badges else None
+
+    return Div(
+        # Section label — Tufte-style: flush left, text only, no borders
+        P(
+            "RECENT · last 10",
+            cls="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest mb-2",
+        ),
+        reach_row,
+        badge_row,
+        cls="px-3 py-2.5 rounded-lg bg-accent/50 border border-border/60",
+    )
+
+
 def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
     """
     Creator card - clean, data-driven design.
@@ -2057,6 +2175,8 @@ def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
     SUBSCRIBERS | VIEWS (large 2-col metrics)
     ────────────────────────────────────
     AVG/VID | VIDEOS | ENGAGEMENT | REVENUE (small 4-col metrics)
+    ────────────────────────────────────
+    RECENT · last 10  (reach microbar + cadence + brand safety)
     ────────────────────────────────────
     30-Day Trend bar
     ────────────────────────────────────
@@ -2110,6 +2230,14 @@ def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
     country_code = safe_get_value(creator, "country_code", "")
     primary_category = safe_get_value(creator, "primary_category", "general") or "general"
     monthly_uploads = safe_get_value(creator, "monthly_uploads", 0)
+
+    # Tier 1 recent performance fields
+    avg_views_10_raw = safe_get_value(creator, "avg_views_10", None)
+    avg_views_10 = int(avg_views_10_raw) if avg_views_10_raw is not None else None
+    avg_days_raw = safe_get_value(creator, "avg_days_between_uploads", None)
+    avg_days_between_uploads = float(avg_days_raw) if avg_days_raw is not None else None
+    is_made_for_kids = bool(safe_get_value(creator, "is_made_for_kids", False))
+    has_long_upload_status = bool(safe_get_value(creator, "has_long_upload_status", False))
 
     # v4 revenue model — uses country + niche for accurate CPM, Shorts split, sponsorships
     _rev = estimate_monthly_revenue_v4(
@@ -2172,6 +2300,14 @@ def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
         # Performance metrics grid: avg views/video, total videos, views/sub, est. revenue
         _build_performance_metrics(
             avg_views_per_video, current_videos, estimated_revenue, views_per_sub
+        ),
+        # Tier 1 — Recent Performance microcard (reach bar, cadence, brand safety)
+        _build_recent_performance(
+            avg_views_10=avg_views_10,
+            current_subs=current_subs,
+            avg_days_between_uploads=avg_days_between_uploads,
+            is_made_for_kids=is_made_for_kids,
+            has_long_upload_status=has_long_upload_status,
         ),
         # Growth trend (pass subs_change to determine if tracking is initializing)
         _build_growth_trend(growth_rate, growth_label, growth_style, subs_change),

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -555,33 +555,35 @@ async def _fetch_channel_data(channel_id: str) -> Dict:
         raise
 
 
-_EMPTY_ENGAGEMENT: dict = {
-    "engagement_score": 0.0,
-    "avg_views_10": None,
-    "avg_likes_10": None,
-    "avg_comments_10": None,
-    "avg_days_between_uploads": None,
-}
+def _empty_engagement() -> dict:
+    """Return a fresh empty engagement payload to prevent shared-mutation bugs."""
+    return {
+        "engagement_score": 0.0,
+        "avg_views_10": None,
+        "avg_likes_10": None,
+        "avg_comments_10": None,
+        "avg_days_between_uploads": None,
+    }
 
 
-async def _calculate_engagement_score(channel_id: str) -> dict:
+async def _fetch_recent_performance_stats(channel_id: str) -> dict:
     """
     Fetch recent video stats and derive engagement + performance metrics.
 
-    Returns a dict (never raises) — all keys are always present:
+    Returns a fresh dict on every call (never raises) — all keys always present:
       engagement_score          float   — avg (likes + comments) / views * 100
       avg_views_10              int     — mean view count across last ≤10 videos
       avg_likes_10              int     — mean like count
       avg_comments_10           int     — mean comment count
       avg_days_between_uploads  float   — mean gap in days between uploads (None < 2 videos)
 
-    Zero additional quota cost versus the previous implementation:
+    Zero additional quota cost versus the previous single-float implementation:
       - playlistItems.list already fetched contentDetails (videoPublishedAt is included)
       - videos.list statistics batch is unchanged
     """
     try:
         if not youtube_resolver:
-            return _EMPTY_ENGAGEMENT
+            return _empty_engagement()
 
         # Thread-safety is handled internally by YouTubeResolver._execute_async
         youtube = youtube_resolver._get_youtube_client()
@@ -609,11 +611,11 @@ async def _calculate_engagement_score(channel_id: str) -> dict:
             )
         except Exception as e:
             logger.debug(f"  Could not fetch uploads playlist for {channel_id}: {e}")
-            return _EMPTY_ENGAGEMENT
+            return _empty_engagement()
 
         items = playlist_response.get("items", [])
         if not items:
-            return _EMPTY_ENGAGEMENT
+            return _empty_engagement()
 
         video_ids = [item["contentDetails"]["videoId"] for item in items]
 
@@ -640,7 +642,7 @@ async def _calculate_engagement_score(channel_id: str) -> dict:
             )
         except Exception as e:
             logger.debug(f"  Could not fetch video stats for {channel_id}: {e}")
-            return _EMPTY_ENGAGEMENT
+            return _empty_engagement()
 
         # Accumulate per-video stats
         engagement_scores: list[float] = []
@@ -663,7 +665,7 @@ async def _calculate_engagement_score(channel_id: str) -> dict:
                 engagement_scores.append(rate)
 
         if not engagement_scores:
-            return _EMPTY_ENGAGEMENT
+            return _empty_engagement()
 
         avg_engagement = sum(engagement_scores) / len(engagement_scores)
 
@@ -696,7 +698,7 @@ async def _calculate_engagement_score(channel_id: str) -> dict:
     except Exception as e:
         # Silently return defaults — engagement is optional
         logger.debug(f"Engagement calculation failed for {channel_id}: {e}")
-        return _EMPTY_ENGAGEMENT
+        return _empty_engagement()
 
 
 async def _fetch_recent_upload(channel_id: str) -> dict | None:
@@ -1182,7 +1184,7 @@ async def handle_sync_job(
         # If EXIT_AFTER_JOB is ever disabled, consider a per-call YouTube client
         # instance to restore safe concurrency.
         should_fetch_categories = _needs_category_fetch(creator.get("primary_category"))
-        engagement_data = await _calculate_engagement_score(channel_id)
+        engagement_data = await _fetch_recent_performance_stats(channel_id)
         engagement = engagement_data["engagement_score"]
         if should_fetch_categories:
             cat_data = await _fetch_channel_category_distribution(channel_id)

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -555,24 +555,33 @@ async def _fetch_channel_data(channel_id: str) -> Dict:
         raise
 
 
-async def _calculate_engagement_score(channel_id: str) -> float:
+_EMPTY_ENGAGEMENT: dict = {
+    "engagement_score": 0.0,
+    "avg_views_10": None,
+    "avg_likes_10": None,
+    "avg_comments_10": None,
+    "avg_days_between_uploads": None,
+}
+
+
+async def _calculate_engagement_score(channel_id: str) -> dict:
     """
-    Calculate engagement score from recent videos (optional).
+    Fetch recent video stats and derive engagement + performance metrics.
 
-    Returns 0.0 gracefully on any error - engagement is informational only.
-    Doesn't fail the sync if engagement can't be calculated.
+    Returns a dict (never raises) — all keys are always present:
+      engagement_score          float   — avg (likes + comments) / views * 100
+      avg_views_10              int     — mean view count across last ≤10 videos
+      avg_likes_10              int     — mean like count
+      avg_comments_10           int     — mean comment count
+      avg_days_between_uploads  float   — mean gap in days between uploads (None < 2 videos)
 
-    Uses lock to serialize YouTube API calls (googleapiclient is not thread-safe).
-
-    Args:
-        channel_id: YouTube channel ID
-
-    Returns:
-        Engagement percentage (0-100+), or 0.0 on error
+    Zero additional quota cost versus the previous implementation:
+      - playlistItems.list already fetched contentDetails (videoPublishedAt is included)
+      - videos.list statistics batch is unchanged
     """
     try:
         if not youtube_resolver:
-            return 0.0
+            return _EMPTY_ENGAGEMENT
 
         # Thread-safety is handled internally by YouTubeResolver._execute_async
         youtube = youtube_resolver._get_youtube_client()
@@ -581,7 +590,7 @@ async def _calculate_engagement_score(channel_id: str) -> float:
 
         logger.debug(f"Calculating engagement for {channel_id}")
 
-        # Fetch last 10 videos
+        # Fetch last 10 videos — contentDetails includes videoPublishedAt
         try:
             playlist_response = await asyncio.wait_for(
                 asyncio.get_event_loop().run_in_executor(
@@ -600,13 +609,23 @@ async def _calculate_engagement_score(channel_id: str) -> float:
             )
         except Exception as e:
             logger.debug(f"  Could not fetch uploads playlist for {channel_id}: {e}")
-            return 0.0
+            return _EMPTY_ENGAGEMENT
 
         items = playlist_response.get("items", [])
         if not items:
-            return 0.0
+            return _EMPTY_ENGAGEMENT
 
         video_ids = [item["contentDetails"]["videoId"] for item in items]
+
+        # Collect publish dates for cadence calculation (already in contentDetails)
+        published_dates: list[datetime] = []
+        for item in items:
+            raw_date = item.get("contentDetails", {}).get("videoPublishedAt")
+            if raw_date:
+                try:
+                    published_dates.append(datetime.fromisoformat(raw_date.replace("Z", "+00:00")))
+                except ValueError:
+                    pass
 
         # Fetch video stats
         try:
@@ -621,35 +640,63 @@ async def _calculate_engagement_score(channel_id: str) -> float:
             )
         except Exception as e:
             logger.debug(f"  Could not fetch video stats for {channel_id}: {e}")
-            return 0.0
+            return _EMPTY_ENGAGEMENT
 
-        # Calculate engagement
-        engagement_scores = []
+        # Accumulate per-video stats
+        engagement_scores: list[float] = []
+        all_views: list[int] = []
+        all_likes: list[int] = []
+        all_comments: list[int] = []
+
         for video in stats_response.get("items", []):
             stats = video.get("statistics", {})
             views = int(stats.get("viewCount", 0) or 0)
             likes = int(stats.get("likeCount", 0) or 0)
             comments = int(stats.get("commentCount", 0) or 0)
 
+            all_views.append(views)
+            all_likes.append(likes)
+            all_comments.append(comments)
+
             if views > 0:
                 rate = (likes + comments) / views * 100
                 engagement_scores.append(rate)
 
         if not engagement_scores:
-            return 0.0
+            return _EMPTY_ENGAGEMENT
 
         avg_engagement = sum(engagement_scores) / len(engagement_scores)
+
+        # Compute average days between uploads from publish dates (most-recent first)
+        avg_days: float | None = None
+        if len(published_dates) >= 2:
+            sorted_dates = sorted(published_dates, reverse=True)
+            gaps = [
+                (sorted_dates[i] - sorted_dates[i + 1]).total_seconds() / 86400
+                for i in range(len(sorted_dates) - 1)
+            ]
+            avg_days = round(sum(gaps) / len(gaps), 2)
+
+        n = len(all_views)
+        result = {
+            "engagement_score": avg_engagement,
+            "avg_views_10": round(sum(all_views) / n) if n else None,
+            "avg_likes_10": round(sum(all_likes) / n) if n else None,
+            "avg_comments_10": round(sum(all_comments) / n) if n else None,
+            "avg_days_between_uploads": avg_days,
+        }
         logger.debug(
             f"[Engagement] {channel_id}: {avg_engagement:.2f}% "
+            f"avg_views={result['avg_views_10']:,} "
+            f"cadence={avg_days}d "
             f"(from {len(engagement_scores)} videos)"
         )
-
-        return avg_engagement
+        return result
 
     except Exception as e:
-        # Silently return 0 - engagement is optional
+        # Silently return defaults — engagement is optional
         logger.debug(f"Engagement calculation failed for {channel_id}: {e}")
-        return 0.0
+        return _EMPTY_ENGAGEMENT
 
 
 async def _fetch_recent_upload(channel_id: str) -> dict | None:
@@ -1135,7 +1182,8 @@ async def handle_sync_job(
         # If EXIT_AFTER_JOB is ever disabled, consider a per-call YouTube client
         # instance to restore safe concurrency.
         should_fetch_categories = _needs_category_fetch(creator.get("primary_category"))
-        engagement = await _calculate_engagement_score(channel_id)
+        engagement_data = await _calculate_engagement_score(channel_id)
+        engagement = engagement_data["engagement_score"]
         if should_fetch_categories:
             cat_data = await _fetch_channel_category_distribution(channel_id)
         else:
@@ -1163,7 +1211,9 @@ async def handle_sync_job(
 
         logger.info(
             f"{job_tag} Stats: subs={subs:,}, views={views:,}, videos={videos:,}, "
-            f"engagement={engagement:.2f}%, quality={quality}"
+            f"engagement={engagement:.2f}%, quality={quality}, "
+            f"avg_views_10={engagement_data['avg_views_10']}, "
+            f"cadence={engagement_data['avg_days_between_uploads']}d"
         )
         if primary_category and category_distribution:
             dist_str = ", ".join(
@@ -1336,6 +1386,14 @@ async def handle_sync_job(
                 "engagement_score": round(engagement, 4),
                 # ── Recent upload (latest video snapshot) ─────────────────
                 "recent_upload": recent_upload,
+                # ── Tier 1 recent performance ─────────────────────────────
+                "avg_views_10": engagement_data["avg_views_10"],
+                "avg_likes_10": engagement_data["avg_likes_10"],
+                "avg_comments_10": engagement_data["avg_comments_10"],
+                "avg_days_between_uploads": engagement_data["avg_days_between_uploads"],
+                # ── Tier 1 brand safety (from channels.list status part) ───
+                "is_made_for_kids": channel_data.get("is_made_for_kids", False),
+                "has_long_upload_status": channel_data.get("has_long_upload_status", False),
                 # ──────────────────────────────────────────────────────────
                 "sync_status": sync_status,
                 "sync_error_message": sync_error,


### PR DESCRIPTION
## Summary by Sourcery

Add a recent performance microcard to creator stats using new engagement-derived metrics and brand safety flags.

New Features:
- Display a "Recent · last 10" section on creator cards showing reach as a microbar, recent upload cadence, and brand safety badges.
- Persist recent performance metrics (avg views/likes/comments on last 10 videos and average days between uploads) and brand safety flags on creators.

Enhancements:
- Extend engagement calculation to return structured recent performance data without extra YouTube quota usage.
- Include channel status data (made for kids and long uploads eligibility) in normalized channel records and sync logging for debugging.
- Log recent performance metrics alongside engagement and quality during creator syncs.