### PR TITLE
fix: prevent multiple calls to UserSecretsClient by flagging secrets …

### DIFF
--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -171,7 +171,7 @@ def _bootstrap_kaggle_secrets() -> None:
     # when creator_worker.py is imported — the env is already populated.
     import secrets_loader
 
-    secrets_loader._secrets_loaded = True
+    secrets_loader.mark_secrets_loaded()
 
 
 # Run immediately at import — before worker module is imported below

--- a/kaggle_worker.py
+++ b/kaggle_worker.py
@@ -167,6 +167,12 @@ def _bootstrap_kaggle_secrets() -> None:
     keys_found = [k for k in YOUTUBE_API_KEY_NAMES if os.environ.get(k)]
     logger.info("✅ Secrets loaded. YouTube API keys available: %d", len(keys_found))
 
+    # Prevent secrets_loader from calling UserSecretsClient a second time
+    # when creator_worker.py is imported — the env is already populated.
+    import secrets_loader
+
+    secrets_loader._secrets_loaded = True
+
 
 # Run immediately at import — before worker module is imported below
 logging.basicConfig(

--- a/secrets_loader.py
+++ b/secrets_loader.py
@@ -202,3 +202,13 @@ def load_secrets() -> str:
 
     _secrets_loaded = True
     return loader_used
+
+
+def mark_secrets_loaded() -> None:
+    """Mark that secrets have already been loaded (idempotency flag).
+
+    Used by alternative secret-loading entry points (e.g., kaggle_worker.py)
+    to signal that secrets are already in os.environ and don't need reloading.
+    """
+    global _secrets_loaded
+    _secrets_loaded = True


### PR DESCRIPTION
…as loaded

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate UserSecretsClient invocations by flagging secrets as loaded in the shared secrets_loader module.