### PR TITLE
fix: update query logic in _fetch_pending_jobs to use next_retry_at f…

### DIFF
--- a/db/migrations/032_fix_pending_jobs_or_query_timeout.sql
+++ b/db/migrations/032_fix_pending_jobs_or_query_timeout.sql
@@ -1,0 +1,33 @@
+-- Migration 032: Fix timeout in creator_sync_jobs polling with OR query
+--
+-- Problem: _fetch_pending_jobs() uses a single OR query:
+--   WHERE status='pending' AND (next_retry_at IS NULL OR next_retry_at <= now())
+--   ORDER BY created_at ASC
+--
+-- The partial indexes from migration 026 (designed for separate queries) don't
+-- cover this OR predicate efficiently. PostgreSQL must consider both branches,
+-- leading to full table scans and timeouts when the table has 800K+ rows.
+--
+-- Solution: Create a covering index that satisfies the entire query without
+-- accessing the base table. This index includes all SELECT columns so
+-- PostgreSQL can do an "index-only scan" (very fast).
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_creator_sync_jobs_pending_or_query
+    ON public.creator_sync_jobs (created_at ASC)
+    INCLUDE (id, creator_id, source, retry_count, job_type, next_retry_at)
+    WHERE status = 'pending';
+
+-- This index:
+-- 1. Is partial (only includes rows where status='pending') → small and fast
+-- 2. Orders by created_at to support ORDER BY created_at ASC
+-- 3. Includes all SELECT columns for index-only scans (no heap lookup needed)
+-- 4. Covers both OR branches: next_retry_at IS NULL and next_retry_at <= now()
+--
+-- Expected query plan:
+--   Index Only Scan using idx_creator_sync_jobs_pending_or_query
+--     Index Cond: (created_at > now() - interval '...')  [if needed]
+--     Heap Fetches: 0
+--
+-- Verification:
+-- SELECT indexname, indexdef FROM pg_indexes
+-- WHERE indexname = 'idx_creator_sync_jobs_pending_or_query';

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -466,8 +466,8 @@ def _fetch_pending_jobs(batch_size: int) -> List[Dict]:
     now_iso = datetime.now(timezone.utc).isoformat()
 
     try:
-        # Single query: fresh jobs (retry_at IS NULL) OR overdue retry jobs
-        # (retry_at IS NOT NULL AND retry_at <= now()), ordered by created_at FIFO.
+        # Single query: fresh jobs (next_retry_at IS NULL) OR overdue retry jobs
+        # (next_retry_at IS NOT NULL AND next_retry_at <= now()), ordered by created_at FIFO.
         #
         # The previous two-query approach had a critical flaw: with batch_size=1,
         # the retry branch was dead code — `if len(fresh_jobs) < 1` is always False
@@ -477,7 +477,7 @@ def _fetch_pending_jobs(batch_size: int) -> List[Dict]:
             supabase_client.table(CREATOR_SYNC_JOBS_TABLE)
             .select("id,creator_id,source,retry_count,job_type")
             .eq("status", JobStatus.PENDING.value)
-            .or_(f"retry_at.is.null,retry_at.lte.{now_iso}")
+            .or_(f"next_retry_at.is.null,next_retry_at.lte.{now_iso}")
             .order("created_at", desc=False)
             .limit(batch_size)
             .execute()


### PR DESCRIPTION
…or better performance

## Summary by Sourcery

Update pending creator sync job polling to use the correct retry timestamp field and add an index to optimize the OR-based pending-jobs query.

Bug Fixes:
- Correct pending job selection to filter on next_retry_at instead of retry_at in the creator worker.

Enhancements:
- Add a covering partial index on creator_sync_jobs to support efficient index-only scans for the pending-jobs OR query.