### PR TITLE
fix: eliminate sitemap route duplication and correct /analyze→/analysis

### DIFF
--- a/main.py
+++ b/main.py
@@ -124,7 +124,11 @@ from routes.stripe_checkout import (
     billing_portal,
 )
 from services.plan_gate import gate_plan
-from services.sitemap import build_sitemap_xml as _sitemap_build_xml
+from services.sitemap import (
+    build_sitemap_xml as _sitemap_build_xml,
+    STATIC_ROUTES as _SITEMAP_STATIC_ROUTES,
+    BASE_URL as _SITEMAP_BASE_URL,
+)
 from routes.lists import (
     categories_explorer_route,
     countries_explorer_route,
@@ -1769,24 +1773,12 @@ def admin_rescue_quota(req, sess):
 
 # ============================================================================
 # Sitemap — live route with 24-hour in-process cache
+# Static routes are imported from services.sitemap (single source of truth shared
+# with scripts/generate_sitemap.py and verified by scripts/verify_sitemap.py).
 # ============================================================================
 
-_SITEMAP_BASE_URL = "https://viralvibes.fyi"
 _SITEMAP_CACHE: dict = {"xml": None, "generated_at": None}
 _SITEMAP_CACHE_TTL = 86_400  # 24 hours
-
-_SITEMAP_STATIC_ROUTES = [
-    ("/", "daily", "1.0"),
-    ("/analyze", "weekly", "0.8"),
-    ("/creators", "daily", "0.8"),
-    ("/lists", "weekly", "0.7"),
-    ("/lists/categories", "weekly", "0.6"),
-    ("/lists/countries", "weekly", "0.6"),
-    ("/lists/languages", "weekly", "0.6"),
-    ("/pricing", "monthly", "0.5"),
-    ("/terms", "monthly", "0.3"),
-    ("/privacy", "monthly", "0.3"),
-]
 
 
 def _build_sitemap_xml() -> str:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,27 +1,31 @@
 # Allow all crawlers
 User-agent: *
 Allow: /
-Allow: /analyze
-Allow: /fetch-content
 
-# Disallow endpoints
+# Crawlable content — explicit for clarity
+Allow: /creators
+Allow: /creator/
+Allow: /lists
+Allow: /analysis
+Allow: /pricing
+Allow: /terms
+Allow: /privacy
+
+# Disallow app endpoints that should not be indexed
+Disallow: /admin/
+Disallow: /api/
 Disallow: /validate
 Disallow: /newsletter
 Disallow: /update-steps
+Disallow: /submit-job
+Disallow: /check-job-status
+Disallow: /job-progress
 Disallow: /static/
-
-# Disallow admin and API endpoints
-Disallow: /admin/
-Disallow: /api/
-Disallow: /private/
-
-# Disallow temporary files and logs
-Disallow: /*.tmp$
-Disallow: /*.log$
-Disallow: /*.json$
-
-# Crawl delay to prevent server overload
-Crawl-delay: 10
+Disallow: /me/
+Disallow: /billing/
+Disallow: /webhook
+Disallow: /login
+Disallow: /logout
 
 # Sitemap location
 Sitemap: https://viralvibes.fyi/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,14 +2,62 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://viralvibes.fyi/</loc>
-    <lastmod>2025-06-14</lastmod>
+    <lastmod>2026-05-06</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://viralvibes.fyi/analysis</loc>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://viralvibes.fyi/analyze</loc>
-    <lastmod>2025-06-14</lastmod>
+    <loc>https://viralvibes.fyi/creators</loc>
+    <lastmod>2026-05-06</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://viralvibes.fyi/lists</loc>
+    <lastmod>2026-05-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://viralvibes.fyi/lists/categories</loc>
+    <lastmod>2026-05-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://viralvibes.fyi/lists/countries</loc>
+    <lastmod>2026-05-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://viralvibes.fyi/lists/languages</loc>
+    <lastmod>2026-05-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://viralvibes.fyi/pricing</loc>
+    <lastmod>2026-05-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://viralvibes.fyi/terms</loc>
+    <lastmod>2026-05-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://viralvibes.fyi/privacy</loc>
+    <lastmod>2026-05-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
   </url>
 </urlset>

--- a/services/sitemap.py
+++ b/services/sitemap.py
@@ -17,8 +17,8 @@ BASE_URL = "https://viralvibes.fyi"
 # (path, changefreq, priority)
 STATIC_ROUTES: list[tuple[str, str, str]] = [
     ("/", "daily", "1.0"),
-    ("/analyze", "weekly", "0.8"),
-    ("/creators", "daily", "0.8"),
+    ("/analysis", "weekly", "0.8"),
+    ("/creators", "daily", "0.9"),
     ("/lists", "weekly", "0.7"),
     ("/lists/categories", "weekly", "0.6"),
     ("/lists/countries", "weekly", "0.6"),


### PR DESCRIPTION
- services/sitemap.py is now the single source of truth for STATIC_ROUTES and BASE_URL, shared by generate_sitemap.py, verify_sitemap.py, and the live /sitemap.xml route in main.py

- main.py: import STATIC_ROUTES and BASE_URL from services.sitemap instead of maintaining a separate _SITEMAP_STATIC_ROUTES list and _SITEMAP_BASE_URL constant that could silently diverge (as they did)

- Fix /analyze → /analysis in services/sitemap.py (route is @rt("/analysis"); /analyze was a 404 being submitted to Google on every CI run and deploy)

- robots.txt: remove broken /*.json$ / /*.log$ regex patterns (robots.txt uses path prefixes, not regex), remove Crawl-delay, add explicit Allow: /creator/ and Disallow for /me/ /billing/ /login /logout

## Summary by Sourcery

Consolidate sitemap route definitions into a single shared source and correct sitemap URLs and metadata for static pages.

New Features:
- Add richer metadata entries for static pages in the public sitemap, including change frequency and priority values.

Bug Fixes:
- Correct the static analysis route in the sitemap from /analyze to /analysis to match the live route and avoid 404s being submitted to search engines.

Enhancements:
- Centralize static sitemap routes and base URL in services.sitemap for reuse by the live sitemap route and related scripts.
- Adjust sitemap priorities, including increasing the creators page priority, to better reflect page importance.