### PR TITLE
feat: add trgm index on channel_description and re-enable it in creat…

### DIFF
--- a/db.py
+++ b/db.py
@@ -3015,28 +3015,21 @@ def get_creators(
             )
             search_pattern = f"%{escaped_search}%"
 
-            # Multi-column lexical search across indexed columns only.
-            # PostgREST OR syntax: col.op.val,col.op.val,...
+            # Multi-column ILIKE search — only columns with pg_trgm GIN indexes are safe;
+            # unindexed ILIKE on long text causes full seq scans and 57014 stmt timeouts.
+            # To add a column: create a GIN index with gin_trgm_ops first (see migrations 028, 033).
             #
-            # Safe columns (indexed, no timeout risk):
-            #   channel_name    — short text
-            #   custom_url      — short text
-            #   keywords        — medium text
-            #   primary_category — has idx_creators_primary_category_trgm (migration 028)
-            #
-            # NOT included until migration 032 adds pg_trgm indexes:
-            #   channel_description  — long text, seq scan → timeout (same issue as migration 028)
-            #   topic_categories     — GIN index is jsonb_path_ops (only helps @> containment, not ilike)
-            #   country_code         — stores "JP" not "japan", so substring match is broken anyway;
-            #                          use the country_filter param for country-based filtering instead
-            or_filter = ",".join(
-                [
-                    f"channel_name.ilike.{search_pattern}",
-                    f"custom_url.ilike.{search_pattern}",
-                    f"keywords.ilike.{search_pattern}",
-                    f"primary_category.ilike.{search_pattern}",
-                ]
-            )
+            # Excluded columns:
+            #   topic_categories — GIN is jsonb_path_ops (containment only, not text search)
+            #   country_code     — stores "JP" not "japan"; use country_filter param instead
+            _search_cols = [
+                "channel_name",  # short text
+                "custom_url",  # short text
+                "keywords",  # medium text
+                "primary_category",  # idx_creators_primary_category_trgm (migration 028)
+                "channel_description",  # idx_creators_channel_description_trgm (migration 033)
+            ]
+            or_filter = ",".join(f"{col}.ilike.{search_pattern}" for col in _search_cols)
             query = query.or_(or_filter)
 
         # Apply grade filter

--- a/db/migrations/033_creator_description_search_trgm.sql
+++ b/db/migrations/033_creator_description_search_trgm.sql
@@ -1,0 +1,16 @@
+-- Migration 033: Add pg_trgm GIN index on channel_description for safe ILIKE search
+--
+-- context: channel_description was excluded from the creator search OR filter because
+-- a full sequential ILIKE scan on the long-text column caused 57014 statement timeouts
+-- (same root cause as primary_category before migration 028).
+--
+-- After this index is created, re-add channel_description.ilike.{pattern} to the
+-- OR filter in get_creators() in db.py.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_creators_channel_description_trgm
+    ON public.creators USING GIN (channel_description gin_trgm_ops)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;


### PR DESCRIPTION
…or search

Migration 033 creates idx_creators_channel_description_trgm (partial GIN, synced creators only) so ILIKE on channel_description is index-backed and safe from statement timeouts.

db.py: re-adds channel_description to the search OR filter using a named list (_search_cols) per code review — future column additions are a one-line list edit with a migration reference.

topic_categories and country_code remain excluded (jsonb_path_ops GIN and ISO code mismatch respectively).

## Summary by Sourcery

Add a pg_trgm-backed search index for creator channel descriptions and re-enable channel_description in the indexed ILIKE search filter.

New Features:
- Support ILIKE-based search over channel_description via a new pg_trgm GIN index and inclusion in the multi-column search filter.

Enhancements:
- Refactor the creator search OR filter to build ILIKE clauses from a shared list of indexed text columns, improving maintainability of search fields.