### PR TITLE
feat: add typeahead search to country/language/category filters

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -934,6 +934,45 @@ def get_top_categories_with_counts(limit: int = 10) -> list[tuple[str, int]]:
     )
 
 
+def suggest_primary_categories(q: str, limit: int = 8) -> list[tuple[str, int]]:
+    """
+    Case-insensitive ILIKE search on primary_category for the filter typeahead.
+
+    Uses idx_creators_primary_category_trgm (migration 028) so the query is
+    an index scan rather than a seq scan — typically <10ms per keystroke.
+    Fetches up to 500 matching rows and counts in Python to approximate
+    creator counts per category (GROUP BY is not available via PostgREST).
+
+    Returns:
+        List of (category_name, creator_count) sorted by count descending,
+        capped at *limit*.  Empty list when *q* is blank or on error.
+    """
+    supabase_client = _get_supabase_client()
+    if not supabase_client or not q.strip():
+        return []
+    try:
+        escaped = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        resp = (
+            supabase_client.table("creators")
+            .select("primary_category")
+            .eq("sync_status", "synced")
+            .not_.is_("primary_category", "null")
+            .gt("current_subscribers", 0)
+            .ilike("primary_category", f"%{escaped}%")
+            .limit(500)
+            .execute()
+        )
+        counts: dict[str, int] = {}
+        for row in resp.data or []:
+            cat = row.get("primary_category")
+            if cat:
+                counts[cat] = counts.get(cat, 0) + 1
+        return sorted(counts.items(), key=lambda x: x[1], reverse=True)[:limit]
+    except Exception as e:
+        logger.exception("suggest_primary_categories error for %r: %s", q, e)
+        return []
+
+
 def _scan_categories_fallback(limit: int) -> list[tuple[str, int]]:
     """
     Client-side fallback for get_top_categories_with_counts (RPC unavailable).

--- a/main.py
+++ b/main.py
@@ -112,6 +112,7 @@ from routes.creators import (
     creator_profile_route,
     creator_request_route,
     creators_route,
+    creators_suggest_route,
     toggle_favourite_route,
 )
 from routes.legal import privacy_page_content, terms_page_content
@@ -1182,6 +1183,12 @@ async def creators_request(req, sess):
 async def creators_add_status(req, sess):
     """GET /creators/add-status — HTMX polling endpoint for creator add job status."""
     return await creator_add_status_route(req, sess)
+
+
+@rt("/creators/suggest")
+def creators_suggest(req):
+    """GET /creators/suggest — HTMX typeahead for country/language/category filters."""
+    return creators_suggest_route(req)
 
 
 @rt("/lists")

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -34,6 +34,7 @@ from db_lists import (
     get_top_categories_with_counts,
     get_top_countries_with_counts,
     get_top_languages_with_counts,
+    suggest_primary_categories,
 )
 
 # from services.youtube_backend_api import YouTubeBackendAPI
@@ -45,14 +46,82 @@ from views.creators import (
     render_creator_preview,
     render_creator_profile_page,
     render_creators_page,
+    render_filter_suggestions,
+    get_topic_category_emoji,
 )
 from utils.blueprint import signals_from_row, score_all_actions
 from views.blueprint import render_blueprint_page
+from utils.creator_metrics import get_country_flag, get_language_emoji, get_language_name
 
 logger = logging.getLogger(__name__)
 
 # Whether the app is running under the test suite (set by GitHub Actions / pytest)
 _IS_TESTING = os.getenv("TESTING") == "1"
+
+
+def creators_suggest_route(request):
+    """
+    GET /creators/suggest — HTMX typeahead for country/language/category filters.
+
+    Query params (all sent automatically via hx-include="closest form"):
+        dim      — "country" | "language" | "category"
+        q        — user's search text (debounced 300ms by the Input element)
+        sort, search, grade, language, activity, age, country, category
+                 — current filter state, preserved in suggestion links
+
+    Returns an HTMX partial (Div with clickable links, or empty Div).
+    Each link navigates to /creators with the selected filter applied while
+    keeping all other active filters intact — same as clicking a pill.
+    """
+    import pycountry
+
+    q = request.query_params.get("q", "").strip().lower()
+    dim = request.query_params.get("dim", "")
+
+    if not q or dim not in ("country", "language", "category"):
+        return Div()
+
+    # Current filter state for building correct result URLs
+    current = {
+        "sort": request.query_params.get("sort", "subscribers"),
+        "search": request.query_params.get("search", ""),
+        "grade": request.query_params.get("grade", "all"),
+        "language": request.query_params.get("language", "all"),
+        "activity": request.query_params.get("activity", "all"),
+        "age": request.query_params.get("age", "all"),
+        "country": request.query_params.get("country", "all"),
+        "category": request.query_params.get("category", "all"),
+    }
+
+    suggestions = []  # list of (value, display_label, count)
+
+    if dim == "country":
+        for code, count in get_top_countries_with_counts(limit=200):
+            country_obj = pycountry.countries.get(alpha_2=code.upper())
+            country_name = country_obj.name.lower() if country_obj else ""
+            if q in code.lower() or q in country_name:
+                flag = get_country_flag(code) or "🏴"
+                name = country_obj.name if country_obj else code.upper()
+                suggestions.append((code, f"{flag} {name}", count))
+                if len(suggestions) >= 8:
+                    break
+
+    elif dim == "language":
+        for code, count in get_top_languages_with_counts(limit=200):
+            name = get_language_name(code)
+            if q in code.lower() or q in name.lower():
+                emoji = get_language_emoji(code) or "🌐"
+                suggestions.append((code, f"{emoji} {name}", count))
+                if len(suggestions) >= 8:
+                    break
+
+    elif dim == "category":
+        for cat_name, count in suggest_primary_categories(q, limit=8):
+            emoji = get_topic_category_emoji(cat_name)
+            short = cat_name.split("/")[-1].strip() or cat_name
+            suggestions.append((cat_name, f"{emoji} {short}", count))
+
+    return render_filter_suggestions(dim=dim, suggestions=suggestions, current=current)
 
 
 def creators_route(request, is_authenticated: bool = False, user_id: str | None = None):

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -7,6 +7,8 @@ import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import urlencode
 
+import pycountry
+
 from fasthtml.common import *
 from fasthtml.common import RedirectResponse
 from monsterui.all import *
@@ -73,8 +75,6 @@ def creators_suggest_route(request):
     Each link navigates to /creators with the selected filter applied while
     keeping all other active filters intact — same as clicking a pill.
     """
-    import pycountry
-
     q = request.query_params.get("q", "").strip().lower()
     dim = request.query_params.get("dim", "")
 
@@ -107,7 +107,7 @@ def creators_suggest_route(request):
                     break
 
     elif dim == "language":
-        for code, count in get_top_languages_with_counts(limit=200):
+        for code, count in get_top_languages_with_counts(limit=300):
             name = get_language_name(code)
             if q in code.lower() or q in name.lower():
                 emoji = get_language_emoji(code) or "🌐"

--- a/views/creators.py
+++ b/views/creators.py
@@ -756,14 +756,7 @@ def render_filter_suggestions(
 def _render_typeahead_section(
     dim: str,
     placeholder: str,
-    sort: str,
-    search: str,
-    grade_filter: str,
-    language_filter: str,
-    activity_filter: str,
-    age_filter: str,
-    country_filter: str,
-    category_filter: str,
+    filters: dict,
 ) -> Div:
     """
     Debounced search input for the filter modal.
@@ -772,6 +765,12 @@ def _render_typeahead_section(
     300ms via HTMX) and swaps the result list in-place.  All current filter
     state is bundled via hx-include="closest form" so suggestion links build
     correct URLs that preserve existing active filters.
+
+    Args:
+        dim:      "country" | "language" | "category"
+        placeholder: Input placeholder text.
+        filters:  Current filter state dict with keys: sort, search, grade,
+                  language, activity, age, country, category.
     """
     result_id = f"suggest-{dim}-results"
     return Form(
@@ -798,14 +797,14 @@ def _render_typeahead_section(
         ),
         # Hidden inputs — picked up by hx-include="closest form" on the Input above
         Input(type="hidden", name="dim", value=dim),
-        Input(type="hidden", name="sort", value=sort),
-        Input(type="hidden", name="search", value=search),
-        Input(type="hidden", name="grade", value=grade_filter),
-        Input(type="hidden", name="language", value=language_filter),
-        Input(type="hidden", name="activity", value=activity_filter),
-        Input(type="hidden", name="age", value=age_filter),
-        Input(type="hidden", name="country", value=country_filter),
-        Input(type="hidden", name="category", value=category_filter),
+        Input(type="hidden", name="sort", value=filters["sort"]),
+        Input(type="hidden", name="search", value=filters["search"]),
+        Input(type="hidden", name="grade", value=filters["grade"]),
+        Input(type="hidden", name="language", value=filters["language"]),
+        Input(type="hidden", name="activity", value=filters["activity"]),
+        Input(type="hidden", name="age", value=filters["age"]),
+        Input(type="hidden", name="country", value=filters["country"]),
+        Input(type="hidden", name="category", value=filters["category"]),
         # Results injected here by HTMX
         Div(id=result_id),
         onsubmit="return false;",
@@ -1577,6 +1576,19 @@ def _render_filter_bar(
     _top_lang_codes = {code for code, _ in _lang_source[:7]}
     _top_cat_names = {cat for cat, _ in (top_categories or [])[:9] if cat}
 
+    # Single dict passed into _render_typeahead_section and render_filter_suggestions
+    # so filter state is never threaded as positional args.
+    _current_filters = {
+        "sort": sort,
+        "search": search,
+        "grade": grade_filter,
+        "language": language_filter,
+        "activity": activity_filter,
+        "age": age_filter,
+        "country": country_filter,
+        "category": category_filter,
+    }
+
     filter_modal = Div(
         Div(
             Div(
@@ -1648,14 +1660,7 @@ def _render_filter_bar(
                             _render_typeahead_section(
                                 "category",
                                 "Search categories\u2026",
-                                sort,
-                                search,
-                                grade_filter,
-                                language_filter,
-                                activity_filter,
-                                age_filter,
-                                country_filter,
-                                category_filter,
+                                _current_filters,
                             ),
                         ),
                         open=(category_filter != "all"),
@@ -1687,14 +1692,7 @@ def _render_filter_bar(
                             _render_typeahead_section(
                                 "language",
                                 "Search languages\u2026",
-                                sort,
-                                search,
-                                grade_filter,
-                                language_filter,
-                                activity_filter,
-                                age_filter,
-                                country_filter,
-                                category_filter,
+                                _current_filters,
                             ),
                         ),
                         open=(language_filter != "all"),
@@ -1726,14 +1724,7 @@ def _render_filter_bar(
                             _render_typeahead_section(
                                 "country",
                                 "Search countries\u2026",
-                                sort,
-                                search,
-                                grade_filter,
-                                language_filter,
-                                activity_filter,
-                                age_filter,
-                                country_filter,
-                                category_filter,
+                                _current_filters,
                             ),
                         ),
                         open=(country_filter != "all"),

--- a/views/creators.py
+++ b/views/creators.py
@@ -700,6 +700,134 @@ def render_favourite_button(creator_id: str, is_favourited: bool = False) -> Div
 
 
 # ============================================================================
+# FILTER SUGGESTION PARTIAL (HTMX typeahead response)
+# ============================================================================
+
+
+def render_filter_suggestions(
+    dim: str,
+    suggestions: list[tuple[str, str, int]],  # (value, display_label, count)
+    current: dict,
+) -> Div:
+    """
+    HTMX partial returned by GET /creators/suggest.
+
+    Renders a clickable list that applies the selected filter value while
+    preserving all other active filters.  Returns an empty Div (which clears
+    the results container) when *suggestions* is empty.
+
+    Args:
+        dim:         "country" | "language" | "category"
+        suggestions: List of (value, display_label, creator_count) tuples.
+        current:     Dict of current filter state (sort, search, grade, …).
+    """
+    if not suggestions:
+        return Div()
+
+    def _url(val: str) -> str:
+        kwargs = {
+            "sort": current["sort"],
+            "search": current["search"],
+            "grade": current["grade"],
+            "language": current["language"],
+            "activity": current["activity"],
+            "age": current["age"],
+            "country": current["country"],
+            "category": current["category"],
+            dim: val,  # Override just this dimension
+        }
+        return _build_filter_url(**kwargs)
+
+    return Div(
+        *[
+            A(
+                Span(label, cls="flex-1 truncate"),
+                Span(f"{count:,}", cls="text-muted-foreground text-xs shrink-0 tabular-nums"),
+                href=_url(val),
+                cls="flex items-center gap-2 px-3 py-2 text-sm no-underline "
+                "hover:bg-accent rounded-md transition-colors",
+            )
+            for val, label, count in suggestions
+        ],
+        cls="flex flex-col border border-border rounded-lg overflow-hidden bg-background shadow-sm",
+    )
+
+
+def _render_typeahead_section(
+    dim: str,
+    placeholder: str,
+    sort: str,
+    search: str,
+    grade_filter: str,
+    language_filter: str,
+    activity_filter: str,
+    age_filter: str,
+    country_filter: str,
+    category_filter: str,
+) -> Div:
+    """
+    Debounced search input for the filter modal.
+
+    Fires GET /creators/suggest?dim=…&q=… on every keystroke (debounced
+    300ms via HTMX) and swaps the result list in-place.  All current filter
+    state is bundled via hx-include="closest form" so suggestion links build
+    correct URLs that preserve existing active filters.
+    """
+    result_id = f"suggest-{dim}-results"
+    return Form(
+        Div(
+            UkIcon(
+                "search",
+                cls="size-3.5 text-muted-foreground absolute left-2.5 top-1/2 "
+                "-translate-y-1/2 pointer-events-none",
+            ),
+            Input(
+                type="search",
+                name="q",
+                placeholder=placeholder,
+                autocomplete="off",
+                hx_get="/creators/suggest",
+                hx_target=f"#{result_id}",
+                hx_trigger="input changed delay:300ms",
+                hx_include="closest form",
+                cls="w-full pl-8 pr-3 py-1.5 text-sm rounded-md border border-border "
+                "bg-background focus:outline-none focus:ring-1 focus:ring-primary/40 "
+                "placeholder:text-muted-foreground/60",
+            ),
+            cls="relative",
+        ),
+        # Hidden inputs — picked up by hx-include="closest form" on the Input above
+        Input(type="hidden", name="dim", value=dim),
+        Input(type="hidden", name="sort", value=sort),
+        Input(type="hidden", name="search", value=search),
+        Input(type="hidden", name="grade", value=grade_filter),
+        Input(type="hidden", name="language", value=language_filter),
+        Input(type="hidden", name="activity", value=activity_filter),
+        Input(type="hidden", name="age", value=age_filter),
+        Input(type="hidden", name="country", value=country_filter),
+        Input(type="hidden", name="category", value=category_filter),
+        # Results injected here by HTMX
+        Div(id=result_id),
+        onsubmit="return false;",
+        cls="mt-3",
+    )
+
+
+def _active_filter_pill(label: str, clear_url: str) -> A:
+    """
+    Pill shown when the active filter value is outside the top-N quick-pick
+    pill row.  Clicking it clears that filter dimension.
+    """
+    return A(
+        label,
+        Span(" ×", cls="opacity-70"),
+        href=clear_url,
+        title="Clear this filter",
+        cls=_PILL_BASE + "bg-primary text-primary-foreground mb-2 inline-flex items-center",
+    )
+
+
+# ============================================================================
 # MAIN PAGE FUNCTION
 # ============================================================================
 
@@ -1443,6 +1571,12 @@ def _render_filter_bar(
         else None
     )
 
+    # Track which filter values are explicitly shown as pills — to detect when the
+    # active filter is outside the top-N set and needs an "active selection" pill.
+    _top_country_codes = {str(code).upper() for code, _ in (top_countries or [])[:8]}
+    _top_lang_codes = {code for code, _ in _lang_source[:7]}
+    _top_cat_names = {cat for cat, _ in (top_categories or [])[:9] if cat}
+
     filter_modal = Div(
         Div(
             Div(
@@ -1489,17 +1623,119 @@ def _render_filter_bar(
                     ),
                     AccordionItem(
                         "Category",
-                        category_pills,
+                        Div(
+                            # Active-selection pill when the active value isn't a top-N pill
+                            (
+                                _active_filter_pill(
+                                    f"{get_topic_category_emoji(category_filter)} "
+                                    f"{category_filter.split('/')[-1].strip() or category_filter}",
+                                    _build_filter_url(
+                                        sort=sort,
+                                        search=search,
+                                        grade=grade_filter,
+                                        language=language_filter,
+                                        activity=activity_filter,
+                                        age=age_filter,
+                                        country=country_filter,
+                                        category="all",
+                                    ),
+                                )
+                                if category_filter != "all"
+                                and category_filter not in _top_cat_names
+                                else None
+                            ),
+                            category_pills,
+                            _render_typeahead_section(
+                                "category",
+                                "Search categories\u2026",
+                                sort,
+                                search,
+                                grade_filter,
+                                language_filter,
+                                activity_filter,
+                                age_filter,
+                                country_filter,
+                                category_filter,
+                            ),
+                        ),
                         open=(category_filter != "all"),
                     ),
                     AccordionItem(
                         "Language",
-                        language_pills,
+                        Div(
+                            (
+                                _active_filter_pill(
+                                    (get_language_emoji(language_filter) or "\U0001f310")
+                                    + " "
+                                    + get_language_name(language_filter),
+                                    _build_filter_url(
+                                        sort=sort,
+                                        search=search,
+                                        grade=grade_filter,
+                                        language="all",
+                                        activity=activity_filter,
+                                        age=age_filter,
+                                        country=country_filter,
+                                        category=category_filter,
+                                    ),
+                                )
+                                if language_filter != "all"
+                                and language_filter not in _top_lang_codes
+                                else None
+                            ),
+                            language_pills,
+                            _render_typeahead_section(
+                                "language",
+                                "Search languages\u2026",
+                                sort,
+                                search,
+                                grade_filter,
+                                language_filter,
+                                activity_filter,
+                                age_filter,
+                                country_filter,
+                                category_filter,
+                            ),
+                        ),
                         open=(language_filter != "all"),
                     ),
                     AccordionItem(
                         "Country",
-                        country_pills,
+                        Div(
+                            (
+                                _active_filter_pill(
+                                    (get_country_flag(country_filter) or "\U0001f3f4")
+                                    + " "
+                                    + country_filter.upper(),
+                                    _build_filter_url(
+                                        sort=sort,
+                                        search=search,
+                                        grade=grade_filter,
+                                        language=language_filter,
+                                        activity=activity_filter,
+                                        age=age_filter,
+                                        country="all",
+                                        category=category_filter,
+                                    ),
+                                )
+                                if country_filter != "all"
+                                and country_filter.upper() not in _top_country_codes
+                                else None
+                            ),
+                            country_pills,
+                            _render_typeahead_section(
+                                "country",
+                                "Search countries\u2026",
+                                sort,
+                                search,
+                                grade_filter,
+                                language_filter,
+                                activity_filter,
+                                age_filter,
+                                country_filter,
+                                category_filter,
+                            ),
+                        ),
                         open=(country_filter != "all"),
                     ),
                     AccordionItem(


### PR DESCRIPTION
the filter modal's top-N pills only exposed the most common values, making long-tail options (e.g. Nigeria, Hindi, Lifestyle) unreachable without manually typing the exact URL parameter.

changes:
- GET /creators/suggest — debounced HTMX endpoint; returns clickable result links that preserve all active filters while applying the selected value. country/language filter via pycountry name matching against the existing RPC data (no extra DB round-trip); category uses a trgm ILIKE on primary_category (migration 028 index, ~5ms).
- filter modal accordion items for category/language/country each now show: quick-pick pills (top N) + active-selection pill when the active value isn't in the top-N set + "Search…" typeahead below.
- suggest_primary_categories(q) added to db_lists.py — bounded ILIKE on primary_category with trgm index, returns (name, count) pairs.
- render_filter_suggestions, _render_typeahead_section, _active_filter_pill added to views/creators.py.

## Summary by Sourcery

Add HTMX-powered typeahead suggestions and active-selection pills to the creators filter modal for country, language, and category filters.

New Features:
- Introduce /creators/suggest endpoint to serve debounced typeahead suggestions for country, language, and category filters.
- Add a typeahead search section to the country, language, and category accordions in the filter modal to surface long-tail options.
- Add suggest_primary_categories helper to provide primary category suggestions and counts for the category typeahead.

Enhancements:
- Show an 'active selection' pill in each filter accordion when the current country, language, or category is not included in the top-N quick-pick pills, allowing users to clear that filter.