### PR TITLE
feat(dashboard): add pagination support to user dashboards retrieval

### DIFF
--- a/db.py
+++ b/db.py
@@ -2196,7 +2196,13 @@ def resolve_playlist_url_from_dashboard_id(
         return None
 
 
-def get_user_dashboards(user_id: str, search: str = "", sort: str = "recent") -> list[dict]:
+def get_user_dashboards(
+    user_id: str,
+    search: str = "",
+    sort: str = "recent",
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> list[dict]:
     """
     Get all dashboards owned by a user with optional filtering and sorting.
 
@@ -2204,6 +2210,8 @@ def get_user_dashboards(user_id: str, search: str = "", sort: str = "recent") ->
         user_id: User ID from session
         search: Optional search query for title/channel (sanitized)
         sort: Sort option ('recent', 'views', 'videos', 'title')
+        limit: Optional maximum number of rows to return
+        offset: Optional number of rows to skip when paginating
 
     Returns:
         List of dashboard metadata dicts sorted according to sort parameter
@@ -2246,6 +2254,9 @@ def get_user_dashboards(user_id: str, search: str = "", sort: str = "recent") ->
             query = query.order("title", desc=False)
         else:  # recent
             query = query.order("processed_on", desc=True)
+
+        if limit is not None:
+            query = query.limit(limit).offset(max(offset, 0))
 
         # Execute query
         response = query.execute()

--- a/db.py
+++ b/db.py
@@ -2255,8 +2255,10 @@ def get_user_dashboards(
         else:  # recent
             query = query.order("processed_on", desc=True)
 
+        if offset:
+            query = query.offset(max(offset, 0))
         if limit is not None:
-            query = query.limit(limit).offset(max(offset, 0))
+            query = query.limit(limit)
 
         # Execute query
         response = query.execute()
@@ -3547,6 +3549,14 @@ def refresh_total_categories() -> int:
             data = data[0] if data else 0
         count = int(data or 0)
         logger.info("refresh_total_categories: %d distinct categories", count)
+        try:
+            from db_lists import clear_lists_meta_cache
+
+            clear_lists_meta_cache()
+        except Exception:
+            logger.debug(
+                "refresh_total_categories: failed to clear lists meta cache", exc_info=True
+            )
         return count
     except Exception:
         logger.exception("refresh_total_categories: RPC failed")
@@ -3620,6 +3630,16 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
                 )
             else:
                 logger.warning("[Hero Stats Cache] ⚠️ %s RPC returned no rows", view_label)
+            if view_label == "mv_lists_meta":
+                try:
+                    from db_lists import clear_lists_meta_cache
+
+                    clear_lists_meta_cache()
+                except Exception:
+                    logger.debug(
+                        "[Hero Stats Cache] failed to clear lists meta cache",
+                        exc_info=True,
+                    )
         except Exception as e:
             logger.error("[Hero Stats Cache] ❌ %s failed: %s", view_label, e)
             errors.append({"view": view_label, "error": str(e)})

--- a/db_lists.py
+++ b/db_lists.py
@@ -5,6 +5,7 @@ Specialized functions for the /lists page tab content.
 
 import json
 import logging
+import time
 from typing import Callable
 
 from utils import normalize_category_name, safe_get_value
@@ -19,6 +20,9 @@ _MAX_FALLBACK_FETCH = 1_000
 
 # Channels created within this many days are considered "new".
 NEW_CHANNEL_MAX_AGE_DAYS = 365
+
+_LISTS_META_TTL_SECONDS = 60
+_lists_meta_cache: tuple[float, dict[str, int]] | None = None
 
 
 def _get_supabase_client():
@@ -840,17 +844,26 @@ def get_lists_meta() -> dict:
     if not supabase_client:
         return _EMPTY_META.copy()
 
+    global _lists_meta_cache
+    if _lists_meta_cache:
+        expires_at, cached_meta = _lists_meta_cache
+        if expires_at > time.monotonic():
+            return cached_meta.copy()
+        _lists_meta_cache = None
+
     try:
         resp = supabase_client.rpc("get_lists_meta").execute()
         if resp.data:
             row = resp.data[0]
-            return {
+            meta = {
                 "total_creators": int(row.get("total_creators") or 0),
                 "total_countries": int(row.get("total_countries") or 0),
                 "total_categories": int(row.get("total_categories") or 0),
                 # total_languages added in migration 003; defaults to 0 on older DBs
                 "total_languages": int(row.get("total_languages") or 0),
             }
+            _lists_meta_cache = (time.monotonic() + _LISTS_META_TTL_SECONDS, meta)
+            return meta.copy()
         logger.warning("[Lists] get_lists_meta RPC returned no data")
         return _EMPTY_META.copy()
 

--- a/db_lists.py
+++ b/db_lists.py
@@ -25,6 +25,12 @@ _LISTS_META_TTL_SECONDS = 60
 _lists_meta_cache: tuple[float, dict[str, int]] | None = None
 
 
+def clear_lists_meta_cache() -> None:
+    """Clear this process's short-lived lists metadata cache."""
+    global _lists_meta_cache
+    _lists_meta_cache = None
+
+
 def _get_supabase_client():
     """Access the Supabase client (initialized at app startup via db.init_supabase())."""
     from db import supabase_client
@@ -836,6 +842,10 @@ def get_lists_meta() -> dict:
     everything in a single server-side pass with zero row transfer.  Falls
     back to a combined client-side scan (approximate) if the RPC is
     unavailable.
+
+    The 60-second cache is intentionally process-local. It avoids duplicate
+    requests during a single page render and is cleared by local metadata
+    refresh helpers; other workers may briefly diverge until their TTL expires.
 
     Note: if the DB RPC predates the ``total_languages`` column (migration
     003), the key defaults to 0 gracefully via ``row.get(...) or 0``.

--- a/main.py
+++ b/main.py
@@ -235,30 +235,31 @@ hdrs = Theme.red.headers(apex_charts=True)
 # Add custom CSS and JS to headers
 hdrs += (
     Link(rel="stylesheet", href="/css/main.css"),
-    Script(src="/js/index.js"),
-    Script(src="/js/reveal.js"),
+    Script(src="/js/index.js", defer=True),
+    Script(src="/js/reveal.js", defer=True),
 )
 
-# Add Vercel Web Analytics
-# Script initializes the analytics queue before the main script loads
-hdrs += (
-    Script(
-        "window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };"
-    ),
-    Script(src="https://cdn.vercel-insights.com/v1/script.js", defer=True),
-)
+if os.getenv("VERCEL") == "1" or os.getenv("ENABLE_VERCEL_INSIGHTS") == "1":
+    # Add Vercel Web Analytics
+    # Script initializes the analytics queue before the main script loads.
+    hdrs += (
+        Script(
+            "window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };"
+        ),
+        Script(src="https://cdn.vercel-insights.com/v1/script.js", defer=True),
+    )
 
-# Add Vercel Speed Insights
-# Using ES module to inject Speed Insights tracking
-hdrs += (
-    Script(
-        """
-        import { injectSpeedInsights } from 'https://cdn.jsdelivr.net/npm/@vercel/speed-insights@1/+esm';
-        injectSpeedInsights();
-        """,
-        type="module",
-    ),
-)
+    # Add Vercel Speed Insights
+    # Using ES module to inject Speed Insights tracking.
+    hdrs += (
+        Script(
+            """
+            import { injectSpeedInsights } from 'https://cdn.jsdelivr.net/npm/@vercel/speed-insights@1/+esm';
+            injectSpeedInsights();
+            """,
+            type="module",
+        ),
+    )
 
 # Auth beforeware — canonical FastHTML pattern (adv_app.py, quickstart docs).
 # skip uses re.search(), so regex patterns like r'/static/.*' cover all children.
@@ -1501,10 +1502,16 @@ def my_dashboards(
         return RedirectResponse(f"/d/{dashboard_id}", status_code=303)
 
     # Fetch all matching dashboards (search/sort applied in DB), paginate in Python
-    all_dashboards = get_user_dashboards(user_id, search=search, sort=sort)
     offset = (page - 1) * _PAGE_SIZE
-    page_items = all_dashboards[offset : offset + _PAGE_SIZE]
-    has_more = len(all_dashboards) > offset + _PAGE_SIZE
+    dashboards_page = get_user_dashboards(
+        user_id,
+        search=search,
+        sort=sort,
+        limit=_PAGE_SIZE + 1,
+        offset=offset,
+    )
+    page_items = dashboards_page[:_PAGE_SIZE]
+    has_more = len(dashboards_page) > _PAGE_SIZE
 
     # HTMX load-more: return only new rows + OOB button replacement
     if htmx and page > 1:


### PR DESCRIPTION
feat(lists): implement caching for lists metadata with TTL
fix(main): defer loading of scripts for improved performance

## Summary by Sourcery

Add server-side pagination to user dashboard retrieval and introduce caching for lists metadata while refining analytics script loading for performance and configurability.

New Features:
- Support limit/offset-based pagination when fetching user dashboards and integrate it into the dashboards page handler.
- Add in-memory, time-limited caching for lists metadata retrieved from Supabase.

Bug Fixes:
- Defer loading of main frontend scripts to improve initial page performance and interactivity timing.
- Load Vercel analytics and speed insights scripts only when explicitly enabled via deployment environment flags.