### PR TITLE
search: drop description column, strip @ on handle fall-through, hone…

### DIFF
--- a/db.py
+++ b/db.py
@@ -3030,17 +3030,20 @@ def get_creators(
 
             # Multi-column ILIKE search — only columns with pg_trgm GIN indexes are safe;
             # unindexed ILIKE on long text causes full seq scans and 57014 stmt timeouts.
-            # To add a column: create a GIN index with gin_trgm_ops first (see migrations 028, 033).
+            # To add a column: create a GIN index with gin_trgm_ops first (see migration 028).
             #
             # Excluded columns:
-            #   topic_categories — GIN is jsonb_path_ops (containment only, not text search)
-            #   country_code     — stores "JP" not "japan"; use country_filter param instead
+            #   topic_categories     — GIN is jsonb_path_ops (containment only, not text search)
+            #   country_code         — stores "JP" not "japan"; use country_filter param instead
+            #   channel_description  — high noise, low signal: bio mentions of a creator's name
+            #                          (e.g. shoutouts) drowned out exact name matches. Removed
+            #                          to improve precision; legit name matches are well covered
+            #                          by the four columns below.
             _search_cols = [
                 "channel_name",  # short text
                 "custom_url",  # short text
-                "keywords",  # medium text
                 "primary_category",  # idx_creators_primary_category_trgm (migration 028)
-                "channel_description",  # idx_creators_channel_description_trgm (migration 033)
+                "keywords",  # medium text
             ]
             or_filter = ",".join(f"{col}.ilike.{search_pattern}" for col in _search_cols)
             query = query.or_(or_filter)

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -239,6 +239,15 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
     # NORMAL SEARCH MODE
     # ═══════════════════════════════════════════════════════════════
     search = request.query_params.get("search", "")
+    # When the user typed an @handle, strip the leading @ before passing the
+    # term to the SQL search.  custom_url is stored without the @, so leaving
+    # it in causes ILIKE "%@mrbeast%" to match only on `keywords` (where some
+    # creators SEO-stuff @mentions of larger channels) instead of the actual
+    # name/URL columns. Stripping it surfaces real matches (mrbeast2,
+    # mrbeastgaming) and drops the keyword-spam noise.
+    # The original @handle is preserved in the banner via `handle_not_found`.
+    if search.startswith("@"):
+        search = search.lstrip("@").strip()
     sort = request.query_params.get("sort", "subscribers")
     grade_filter = request.query_params.get("grade", "all")
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -2790,8 +2790,12 @@ def _render_handle_not_found_banner(search: str, is_authenticated: bool) -> Div:
             Div(
                 UkIcon("info", cls="size-4 text-blue-500 shrink-0 mt-0.5"),
                 P(
-                    Span(search, cls="font-semibold"),
-                    " isn't in our database yet. " "Related results are shown below.",
+                    "We don’t have ",
+                    Span(
+                        search if search.startswith("@") else f"@{search}",
+                        cls="font-semibold",
+                    ),
+                    " exactly. Closest matches below — or add it to the database.",
                     cls="text-sm text-foreground",
                 ),
                 cls="flex items-start gap-2 flex-1",


### PR DESCRIPTION
…st banner

Three small UX fixes that make the /creators search feel less noisy without touching the schema.

* db.py: remove `channel_description` from the multi-column ILIKE OR-filter. Bio-text matches were drowning out exact name hits (e.g. any channel that shouts out "MKBHD" in their description ranked alongside MKBHD itself). The pg_trgm GIN index from migration 033 is left in place; it just goes unused for now. Search now spans channel_name, custom_url, primary_category, keywords.

* routes/creators.py: strip the leading "@" from the search term in the normal-search block. Previously "@mrbeast" only matched the `keywords` column (where smaller channels SEO-stuff @-mentions of larger ones), so the real MrBeast variants were buried under spam. Stripping the @ lets the term hit channel_name / custom_url and surfaces the right results.

* views/creators.py: rewrite the "@handle not found" banner. It used to say "@x isn't in our database yet. Related results are shown below." while displaying obvious matches like MrBeast 2 and MrBeast Gaming. New copy: "We don't have @x exactly. Closest matches below — or add it to the database." The Span re-prefixes "@" since `search` now arrives stripped.

## Summary by Sourcery

Refine creator search to reduce noisy matches from descriptions, improve @handle matching, and clarify the handle-not-found banner text.

Bug Fixes:
- Ensure @handle queries match underlying channel name and custom URL fields instead of being drowned out by keyword-only matches.

Enhancements:
- Narrow creator search to exclude channel descriptions from the multi-column text search to improve result precision.
- Update the handle-not-found banner copy to reflect fuzzy handle matching and encourage adding missing creators.