### PR TITLE
feat(peers): add embedding-based creator peers functionality

### DIFF
--- a/db.py
+++ b/db.py
@@ -2465,6 +2465,72 @@ def get_favourite_creators_with_stats(user_id: str, limit: int = 50) -> List[Dic
 
 
 # ============================================================================
+# 🤝  Creator Peers  (embedding-based similarity)
+# ============================================================================
+
+_CREATOR_PEERS_TABLE = "creator_peers"
+
+# Fields fetched for each peer creator — same subset used by the similar-rail tiles
+_PEER_CREATOR_FIELDS = (
+    "id, channel_name, channel_thumbnail_url, "
+    "current_subscribers, quality_grade, primary_category, country_code"
+)
+
+
+def get_embedding_peers(
+    creator_id: str,
+    peer_type: str = "embedding_v1",
+    limit: int = 20,
+) -> Optional[List[Dict[str, Any]]]:
+    """Return hydrated creator dicts for the embedding-based peer list.
+
+    Two-query pattern:
+      1. Fetch the peer_list (ordered UUID array) from creator_peers.
+      2. Fetch the matching creator rows, then re-order to match the ranked list.
+
+    Returns:
+        list[dict]  — peer creator rows in similarity order (best first)
+        None        — creator_id not present in creator_peers for this peer_type,
+                      so callers should suppress the "Similar creators" section.
+    """
+    if not supabase_client or not creator_id:
+        return None
+    try:
+        # Step 1: look up peer list
+        resp = (
+            supabase_client.table(_CREATOR_PEERS_TABLE)
+            .select("peer_list")
+            .eq("creator_id", creator_id)
+            .eq("peer_type", peer_type)
+            .limit(1)
+            .execute()
+        )
+        rows = resp.data or []
+        if not rows:
+            return None  # ← caller must hide the section
+
+        peer_ids: list[str] = (rows[0].get("peer_list") or [])[:limit]
+        if not peer_ids:
+            return None
+
+        # Step 2: hydrate creator rows for those IDs
+        creators_resp = (
+            supabase_client.table(CREATOR_TABLE)
+            .select(_PEER_CREATOR_FIELDS)
+            .in_("id", peer_ids)
+            .execute()
+        )
+        creators_by_id = {c["id"]: c for c in (creators_resp.data or [])}
+
+        # Re-order to preserve similarity ranking from peer_list
+        return [creators_by_id[pid] for pid in peer_ids if pid in creators_by_id]
+
+    except Exception as exc:
+        logger.exception("[EmbeddingPeers] get_embedding_peers failed for %s: %s", creator_id, exc)
+        return None
+
+
+# ============================================================================
 # 🔖  User Favourite Lists
 # ============================================================================
 

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -27,6 +27,7 @@ from db import (
     get_creator_rank,
     get_creator_stats,
     get_creators,
+    get_embedding_peers,
     get_user_favourite_creator_ids,
     is_creator_favourited,
     queue_creator_add_request,
@@ -527,6 +528,7 @@ def creator_profile_route(request, creator_id: str, user_id: str | None = None):
     niche_leaderboard = get_category_leaderboard(creator.get("primary_category", ""), limit=5)
     is_fav = is_creator_favourited(user_id, creator_id) if user_id else False
     similar_creators = _get_similar_creators(creator)
+    embedding_peers = get_embedding_peers(creator_id)
 
     return render_creator_profile_page(
         creator,
@@ -537,6 +539,7 @@ def creator_profile_route(request, creator_id: str, user_id: str | None = None):
         niche_leaderboard=niche_leaderboard,
         is_favourited=is_fav,
         similar_creators=similar_creators,
+        embedding_peers=embedding_peers,
     )
 
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -2997,6 +2997,7 @@ def _render_similar_creators(
     category: str,
     country_code: str,
     current_creator_id: str = "",
+    title: str = "You may also like",
 ) -> Div | None:
     """
     Horizontal Apple-Music-style scroll rail of similar creators.
@@ -3004,6 +3005,10 @@ def _render_similar_creators(
     Each tile is a fixed-width card with a square avatar, channel name,
     subscriber count, and quality grade. The rail uses scroll-snap so
     swiping feels native on mobile.
+
+    ``title`` controls the section heading so the same component can serve
+    both the category-based "You may also like" and the embedding-based
+    "Similar creators" rails.
 
     Returns None when the list is empty so callers can safely omit it.
     """
@@ -3104,7 +3109,7 @@ def _render_similar_creators(
     rail_id = f"similar-rail-{current_creator_id or 'x'}"
     return Card(
         Div(
-            H2("You may also like", cls="text-base font-bold text-foreground"),
+            H2(title, cls="text-base font-bold text-foreground"),
             A(
                 see_all_label + " →",
                 href=see_all_href,
@@ -3137,6 +3142,7 @@ def render_creator_profile_page(
     peer_engagement_p75: float = 0.0,
     niche_leaderboard: list[dict] | None = None,
     recent_upload: dict | None = None,
+    embedding_peers: list[dict] | None = None,
 ) -> Div:
     """
     Full-page creator profile — award-showcase design.
@@ -4200,6 +4206,23 @@ def render_creator_profile_page(
     )
 
     # ═══════════════════════════════════════════════════════════════════════════
+    # SECTION 4b — Embedding-based peers rail ("Similar creators")
+    # Only rendered when embedding_peers is a non-empty list.
+    # Passing None means the caller found no row in creator_peers → hide section.
+    # ═══════════════════════════════════════════════════════════════════════════
+    embedding_peers_section = (
+        _render_similar_creators(
+            embedding_peers,
+            primary_category,
+            country_code,
+            current_creator_id=creator_id,
+            title="Similar creators",
+        )
+        if embedding_peers  # None or [] → section is suppressed
+        else None
+    )
+
+    # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 5 — Sync / freshness footer
     # ═══════════════════════════════════════════════════════════════════════════
     sync_colour = {
@@ -4242,6 +4265,7 @@ def render_creator_profile_page(
         stats_row,
         body_cols,
         similar_section,
+        embedding_peers_section,
         box_plot_section,
         footer_section,
         cls="max-w-5xl mx-auto px-4 pb-16 pt-6",


### PR DESCRIPTION
## Summary by Sourcery

Add embedding-based creator peers data to the creator profile page and support customizable titles for similar-creator rails.

New Features:
- Introduce an embedding-based creator peers lookup that returns ranked similar creators from the creator_peers table.
- Render a new "Similar creators" rail on the creator profile page powered by embedding-based peers, distinct from the category-based recommendations.

Enhancements:
- Allow the similar-creators rail component to accept a configurable section title so it can be reused for different recommendation types.