### PR TITLE
feat(creators): add freshness indicator and momentum badge to growth …

### DIFF
--- a/views/creators.py
+++ b/views/creators.py
@@ -2013,11 +2013,58 @@ def _build_performance_metrics(
     )
 
 
+def _freshness_dot(last_updated: str) -> Span:
+    """Return a coloured dot encoding data freshness.
+
+    Replaces the clock icon in the footer so staleness is scannable at a
+    glance without reading the timestamp text.
+
+    Thresholds (mirrors the daily-refresh cadence):
+      green  — < 2 days  (fresh, within one worker cycle)
+      amber  — 2–7 days  (aging, due for a refresh)
+      gray   — > 7 days  (stale)
+    """
+    from utils.dates import format_date_relative as _fdr  # local to avoid circular at module level
+
+    try:
+        from datetime import datetime, timezone
+
+        clean = (last_updated or "").replace("Z", "+00:00")
+        dt = datetime.fromisoformat(clean)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        age_days = (datetime.now(timezone.utc) - dt).days
+    except Exception:
+        age_days = 999  # unknown → stale
+
+    if age_days < 2:
+        color = "#10b981"  # emerald-500
+        title = "Fresh data"
+    elif age_days < 7:
+        color = "#f59e0b"  # amber-400
+        title = "Data aging — refresh due soon"
+    else:
+        color = "#9ca3af"  # gray-400
+        title = "Stale data — pending worker refresh"
+
+    return Span(
+        style=(
+            f"display:inline-block;width:7px;height:7px;"
+            f"border-radius:50%;background:{color};margin-right:4px;"
+            f"flex-shrink:0;"
+        ),
+        title=title,
+        aria_label=title,
+    )
+
+
 def _build_growth_trend(
     growth_rate: float,
     growth_label: str,
     growth_style: str,
     subs_change: int | None = None,
+    views_change: int | None = None,
+    current_subs: int = 0,
 ) -> Div:
     """
     Build growth trend indicator section.
@@ -2029,6 +2076,18 @@ def _build_growth_trend(
     """
     # Check if growth data is available (not None/NULL from DB)
     has_growth_data = subs_change is not None
+
+    # Momentum badge — computed from both sub + view velocity (0–100 composite)
+    momentum_score = calculate_momentum_score(views_change, subs_change, current_subs)
+    if momentum_score is not None:
+        mom_label, mom_cls = get_momentum_label(momentum_score)
+        momentum_badge = Span(
+            f"{mom_label} · {format_float(momentum_score, 0)}",
+            cls=f"px-2 py-0.5 text-xs font-semibold rounded-full border {mom_cls}",
+            title=f"Momentum score {format_float(momentum_score, 0)}/100 — combines subscriber and view velocity over 30 days",
+        )
+    else:
+        momentum_badge = None
 
     if not has_growth_data:
         return Div(
@@ -2061,18 +2120,19 @@ def _build_growth_trend(
                 "30-DAY TREND",
                 cls="text-xs font-semibold text-muted-foreground",
             ),
-            Div(
-                P(
-                    f"{growth_rate:+.1f}%",
-                    cls="text-sm font-bold text-foreground",
-                ),
-                Span(
-                    growth_label,
-                    cls=f"px-2 py-1 text-xs font-semibold rounded-full border {growth_style}",
-                ),
-                cls="flex items-center gap-2",
-            ),
+            *([momentum_badge] if momentum_badge else []),
             cls="flex justify-between items-center mb-3",
+        ),
+        Div(
+            P(
+                f"{growth_rate:+.1f}%",
+                cls="text-sm font-bold text-foreground",
+            ),
+            Span(
+                growth_label,
+                cls=f"px-2 py-1 text-xs font-semibold rounded-full border {growth_style}",
+            ),
+            cls="flex items-center gap-2",
         ),
         # Growth bar
         Div(
@@ -2235,7 +2295,7 @@ def _build_card_footer(
 
     return Div(
         Div(
-            UkIcon("clock", cls="w-3 h-3 mr-1 opacity-50"),
+            _freshness_dot(last_updated),
             Span(
                 format_date_relative(last_updated),
                 cls=_CLS_MUTED_XS,
@@ -2581,7 +2641,14 @@ def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
             has_long_upload_status=has_long_upload_status,
         ),
         # Growth trend (pass subs_change to determine if tracking is initializing)
-        _build_growth_trend(growth_rate, growth_label, growth_style, subs_change),
+        _build_growth_trend(
+            growth_rate,
+            growth_label,
+            growth_style,
+            subs_change,
+            views_change=views_change,
+            current_subs=current_subs,
+        ),
         # Keywords if available, rendered as a single line of small italic text (not a full tag cloud)
         (
             P(


### PR DESCRIPTION
…trend

## Summary by Sourcery

Add a visual freshness indicator for creator data and introduce a momentum badge to the growth trend section.

New Features:
- Display a coloured freshness dot in creator cards to indicate how up-to-date the data is at a glance.
- Show a momentum badge in the growth trend section based on a combined subscriber and view velocity score.

Enhancements:
- Refine the growth trend header layout to accommodate the new momentum badge while keeping growth metrics readable.