### PR TITLE
feat(contact, legal): add centralized contact email for inquiries and…

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -336,6 +336,8 @@ FAQS = [
 # =============================================================================
 # DATABASE TABLE CONSTANTS
 # =============================================================================
+CONTACT_EMAIL = "viralvibes.fyi@proton.me"
+
 PLAYLIST_STATS_TABLE = "playlist_stats"
 PLAYLIST_JOBS_TABLE = "playlist_jobs"
 SIGNUPS_TABLE = "signups"

--- a/routes/contact.py
+++ b/routes/contact.py
@@ -5,6 +5,8 @@ Contact page — inquiry form, support channels, and FAQ.
 from fasthtml.common import *
 from monsterui.all import *
 
+from constants import CONTACT_EMAIL
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -131,6 +133,7 @@ def contact_form() -> Form:
 
 
 def contact_page_content() -> Div:
+    mailto = f"mailto:{CONTACT_EMAIL}"
     return _contact_page(
         "Get In Touch",
         _section(
@@ -142,19 +145,19 @@ def contact_page_content() -> Div:
                 "Sales & Pricing",
                 "Questions about plans, features, or pricing? Our sales team can help.",
                 "Contact Sales →",
-                "mailto:sales@viralvibes.app",
+                mailto,
             ),
             _contact_method(
                 "Support",
                 "Need help using ViralVibes? Have a bug to report? We're here to help.",
                 "Contact Support →",
-                "mailto:support@viralvibes.app",
+                mailto,
             ),
             _contact_method(
                 "Privacy & Legal",
                 "Questions about our privacy policy, data handling, or legal matters?",
                 "Contact Legal →",
-                "mailto:privacy@viralvibes.app",
+                mailto,
             ),
             cls="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8",
         ),
@@ -188,7 +191,7 @@ def contact_page_content() -> Div:
             Div(
                 H3("Can I schedule a demo?", cls="text-lg font-semibold text-foreground mb-2"),
                 P(
-                    "Yes! Contact our sales team at sales@viralvibes.app and mention 'DEMO REQUEST'. "
+                    f"Yes! Contact us at {CONTACT_EMAIL} and mention 'DEMO REQUEST'. "
                     "We offer custom walkthroughs for teams evaluating ViralVibes.",
                     cls="text-muted-foreground leading-relaxed",
                 ),
@@ -198,7 +201,7 @@ def contact_page_content() -> Div:
                 H3("What about partnerships?", cls="text-lg font-semibold text-foreground mb-2"),
                 P(
                     "We're always interested in partnership opportunities — integrations, reselling, or co-marketing. "
-                    "Email partnerships@viralvibes.app to discuss collaboration ideas.",
+                    f"Email {CONTACT_EMAIL} to discuss collaboration ideas.",
                     cls="text-muted-foreground leading-relaxed",
                 ),
                 cls="p-4 border border-border rounded-lg",

--- a/routes/legal.py
+++ b/routes/legal.py
@@ -5,6 +5,8 @@ Legal pages: Terms of Service and Privacy Policy.
 from fasthtml.common import *
 from monsterui.all import *
 
+from constants import CONTACT_EMAIL
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -123,8 +125,7 @@ def terms_page_content() -> Div:
         ),
         _section(
             "9. Contact",
-            "For questions about these Terms of Service, please contact us at "
-            "legal@viralvibes.app.",
+            "For questions about these Terms of Service, please contact us at " f"{CONTACT_EMAIL}.",
         ),
     )
 
@@ -219,7 +220,7 @@ def privacy_page_content() -> Div:
         ),
         _section(
             "",
-            "To exercise any of these rights, please contact us at privacy@viralvibes.app. "
+            f"To exercise any of these rights, please contact us at {CONTACT_EMAIL}. "
             "We will respond within 30 days.",
         ),
         _section(
@@ -242,7 +243,6 @@ def privacy_page_content() -> Div:
         ),
         _section(
             "11. Contact",
-            "For privacy-related questions or requests, please contact us at "
-            "privacy@viralvibes.app.",
+            "For privacy-related questions or requests, please contact us at " f"{CONTACT_EMAIL}.",
         ),
     )

--- a/tests/test_creator_profile.py
+++ b/tests/test_creator_profile.py
@@ -219,3 +219,10 @@ class TestCreatorProfile:
         self._patch_profile_db(monkeypatch)
         r = client.get(f"/creator/{FAKE_CREATOR_UUID}?from=/creators%3Fsort%3Dengagement")
         assert r.status_code == 200
+
+    def test_profile_shows_safe_for_kids_badge(self, client, monkeypatch):
+        """Worker-collected is_made_for_kids should render a profile badge."""
+        self._patch_profile_db(monkeypatch, creator={**FAKE_CREATOR, "is_made_for_kids": True})
+        r = client.get(f"/creator/{FAKE_CREATOR_UUID}")
+        assert r.status_code == 200
+        assert "Safe for Kids" in r.text

--- a/views/creators.py
+++ b/views/creators.py
@@ -3359,6 +3359,19 @@ def render_creator_profile_page(
             cls="text-xs font-semibold px-2 py-0.5 rounded-full bg-accent text-foreground hover:bg-accent/80 no-underline transition-colors",
         )
 
+    def _safe_for_kids_badge():
+        """Badge backed by the worker-collected YouTube status.madeForKids field."""
+        return Span(
+            UkIcon("shield-check", cls="w-3.5 h-3.5 mr-1 inline"),
+            "Safe for Kids",
+            title="YouTube marks this channel as Made for Kids. This signal comes from the worker sync.",
+            cls=(
+                "inline-flex items-center text-xs font-semibold "
+                "bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-300 "
+                "px-2 py-0.5 rounded-full shrink-0"
+            ),
+        )
+
     def _stat_card(label, value, delta_val, number_cls, bg_cls, *, delta_pct=None, rank_line=None):
         return Card(
             Div(
@@ -3465,15 +3478,7 @@ def render_creator_profile_page(
                     if official
                     else None
                 ),
-                (
-                    Span(
-                        "🧒 Made for Kids",
-                        title="This channel is designated as content made for children. AdSense rates are significantly lower and brand deals are not available.",
-                        cls="inline-flex items-center text-xs font-semibold bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300 px-2 py-0.5 rounded-full shrink-0",
-                    )
-                    if is_made_for_kids
-                    else None
-                ),
+                (_safe_for_kids_badge() if is_made_for_kids else None),
                 cls="flex items-center gap-2 flex-wrap",
             ),
             # Rank chips — grade + subscriber rank badges, links to list pages


### PR DESCRIPTION
… update references

## Summary by Sourcery

Centralize public contact email usage across contact and legal pages and add a worker-backed “Safe for Kids” badge to creator profiles.

New Features:
- Display a Safe for Kids badge on creator profiles when the worker data marks a channel as made for kids.

Enhancements:
- Introduce a single CONTACT_EMAIL constant and update contact, sales, support, partnership, and legal/privacy copy to reference it instead of hard-coded addresses.

Tests:
- Add a creator profile test to assert that the Safe for Kids badge renders when is_made_for_kids is true.