### PR TITLE
feat(discovery): Editors' Shortlist rail on /creators and /lists

### DIFF
--- a/components/editors_shortlist.py
+++ b/components/editors_shortlist.py
@@ -1,0 +1,177 @@
+"""Editors' Shortlist rail — curated entry point into ``/creators/top``.
+
+A horizontal card rail surfacing the five A+ category landing pages plus
+the global A+ shortlist. Designed to live near the top of the two main
+discovery surfaces (``/creators`` and ``/lists``) so anonymous visitors
+and returning users alike have a one-click path into the editorial cut.
+
+Design notes
+------------
+* Single accent treatment (no per-card colour) — restraint over noise.
+* Mono numerals for counts so they read as data, not marketing.
+* Horizontal scroll on mobile via ``overflow-x-auto`` so the rail never
+  reflows into a tall column on small screens.
+* Counts are optional. When omitted the cards still render with a
+  generic CTA, which lets pages that don't want to take the small count
+  query opt out cleanly.
+"""
+
+from __future__ import annotations
+
+from fasthtml.common import A, Div, H3, P, Span
+
+from utils import format_number
+
+__all__ = ["EditorsShortlistRail"]
+
+# Card order: "All A+" first as the broadest entry point, then categories
+# in descending A+ population (matches what users will see in counts).
+_RAIL_ITEMS: list[tuple[str | None, str, str]] = [
+    # (slug, label, href)
+    (None, "All A+ Tier", "/creators/top"),
+    ("gaming", "Gaming", "/creators/top/gaming"),
+    ("entertainment", "Entertainment", "/creators/top/entertainment"),
+    ("music", "Music", "/creators/top/music"),
+    ("education", "Education", "/creators/top/education"),
+    ("howto-style", "Howto & Style", "/creators/top/howto-style"),
+]
+
+
+def _rail_card(
+    *,
+    label: str,
+    href: str,
+    count: int | None,
+    is_all: bool,
+) -> A:
+    """Single card in the rail. Anchor element so the entire surface is clickable."""
+    count_block = (
+        Div(
+            Span(
+                format_number(count),
+                cls="block text-3xl font-mono font-semibold text-foreground tabular-nums",
+            ),
+            P(
+                "A+ rated creators",
+                cls="text-xs text-muted-foreground mt-1",
+            ),
+            cls="mt-4",
+        )
+        if count is not None
+        else Div(
+            P(
+                "View top creators",
+                cls="text-sm text-foreground/80 mt-4",
+            ),
+        )
+    )
+
+    eyebrow = "Editors' Pick" if is_all else "Category"
+
+    return A(
+        Div(
+            Span(
+                eyebrow.upper(),
+                cls=(
+                    "text-[10px] font-mono tracking-[0.2em] "
+                    "text-muted-foreground/70"
+                ),
+            ),
+            H3(
+                label,
+                cls="text-lg font-semibold text-foreground mt-2 leading-tight",
+            ),
+            count_block,
+            Div(
+                Span(
+                    "Browse →",
+                    cls=(
+                        "text-xs font-medium text-muted-foreground "
+                        "group-hover:text-primary transition-colors"
+                    ),
+                ),
+                cls="mt-6 pt-4 border-t border-border/60",
+            ),
+            cls="h-full flex flex-col",
+        ),
+        href=href,
+        cls=(
+            "group block snap-start shrink-0 "
+            "w-[220px] sm:w-[240px] "
+            "rounded-xl border border-border bg-card "
+            "p-5 no-underline "
+            "transition-all duration-200 "
+            "hover:border-primary/40 hover:bg-primary/[0.03] "
+            "hover:-translate-y-0.5 hover:shadow-sm"
+        ),
+    )
+
+
+def EditorsShortlistRail(
+    counts: dict[str, int] | None = None,
+    *,
+    headline: str = "Editors' Shortlist",
+    subhead: str | None = "The A+ engagement tier — hand-graded, ranked by reach.",
+    see_all_label: str = "See all A+ creators →",
+    see_all_href: str = "/creators/top",
+) -> Div:
+    """Render the rail. Pass ``counts`` from ``get_aplus_category_counts()``.
+
+    The rail intentionally returns a plain ``Div`` (no Container) so callers
+    control the surrounding padding and section rhythm.
+    """
+    if counts is None:
+        counts = {}
+
+    cards = [
+        _rail_card(
+            label=label,
+            href=href,
+            count=counts.get(slug or "all"),
+            is_all=slug is None,
+        )
+        for slug, label, href in _RAIL_ITEMS
+    ]
+
+    return Div(
+        # Header strip — H2-equivalent + optional see-all CTA on one row.
+        Div(
+            Div(
+                Span(
+                    "EDITORIAL",
+                    cls=(
+                        "block text-[10px] font-mono tracking-[0.22em] "
+                        "text-muted-foreground/70 mb-2"
+                    ),
+                ),
+                H3(
+                    headline,
+                    cls="text-xl sm:text-2xl font-bold text-foreground tracking-tight",
+                ),
+                (
+                    P(subhead, cls="text-sm text-muted-foreground mt-1")
+                    if subhead
+                    else None
+                ),
+            ),
+            A(
+                see_all_label,
+                href=see_all_href,
+                cls=(
+                    "hidden sm:inline-flex items-center text-sm font-medium "
+                    "text-muted-foreground hover:text-primary transition-colors "
+                    "no-underline whitespace-nowrap"
+                ),
+            ),
+            cls="flex items-end justify-between gap-4 mb-5",
+        ),
+        # Rail itself — horizontal scroll with snap.
+        Div(
+            *cards,
+            cls=(
+                "flex gap-4 overflow-x-auto snap-x snap-mandatory "
+                "-mx-4 px-4 sm:mx-0 sm:px-0 pb-2"
+            ),
+        ),
+        cls="my-10 sm:my-12",
+    )

--- a/components/editors_shortlist.py
+++ b/components/editors_shortlist.py
@@ -24,17 +24,29 @@ from utils import format_number
 
 __all__ = ["EditorsShortlistRail"]
 
-# Card order: "All A+" first as the broadest entry point, then categories
-# in descending A+ population (matches what users will see in counts).
-_RAIL_ITEMS: list[tuple[str | None, str, str]] = [
-    # (slug, label, href)
-    (None, "All A+ Tier", "/creators/top"),
-    ("gaming", "Gaming", "/creators/top/gaming"),
-    ("entertainment", "Entertainment", "/creators/top/entertainment"),
-    ("music", "Music", "/creators/top/music"),
-    ("education", "Education", "/creators/top/education"),
-    ("howto-style", "Howto & Style", "/creators/top/howto-style"),
-]
+# The "All A+" card is always first as the broadest entry point. The
+# category cards are derived from ``routes.creators.TOP_CATEGORY_SLUGS``
+# at call time (see ``_build_rail_items``) so the rail and the
+# ``/creators/top`` landing pages can never silently drift apart. The
+# import is deferred to avoid a components → routes → views → components
+# import cycle at module load.
+_ALL_AP_ITEM: tuple[None, str, str] = (None, "All A+ Tier", "/creators/top")
+
+
+def _build_rail_items() -> list[tuple[str | None, str, str]]:
+    """Return ``[(slug_or_None, label, href), ...]`` for the rail.
+
+    Order: the synthetic "All A+" card first, then category cards in the
+    order ``TOP_CATEGORY_SLUGS`` defines them (which we keep sorted by A+
+    population at the source).
+    """
+    from routes.creators import TOP_CATEGORY_SLUGS  # local: avoid circular import
+
+    items: list[tuple[str | None, str, str]] = [_ALL_AP_ITEM]
+    items.extend(
+        (slug, label, f"/creators/top/{slug}") for slug, label in TOP_CATEGORY_SLUGS.items()
+    )
+    return items
 
 
 def _rail_card(
@@ -72,10 +84,7 @@ def _rail_card(
         Div(
             Span(
                 eyebrow.upper(),
-                cls=(
-                    "text-[10px] font-mono tracking-[0.2em] "
-                    "text-muted-foreground/70"
-                ),
+                cls=("text-[10px] font-mono tracking-[0.2em] " "text-muted-foreground/70"),
             ),
             H3(
                 label,
@@ -130,7 +139,7 @@ def EditorsShortlistRail(
             count=counts.get(slug or "all"),
             is_all=slug is None,
         )
-        for slug, label, href in _RAIL_ITEMS
+        for slug, label, href in _build_rail_items()
     ]
 
     return Div(
@@ -148,11 +157,7 @@ def EditorsShortlistRail(
                     headline,
                     cls="text-xl sm:text-2xl font-bold text-foreground tracking-tight",
                 ),
-                (
-                    P(subhead, cls="text-sm text-muted-foreground mt-1")
-                    if subhead
-                    else None
-                ),
+                (P(subhead, cls="text-sm text-muted-foreground mt-1") if subhead else None),
             ),
             A(
                 see_all_label,

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -778,6 +778,66 @@ TOP_CATEGORY_SLUGS: dict[str, str] = {
 
 TOP_PAGE_SIZE = 50  # creators per page — one screen on a laptop
 
+# ----- A+ category counts cache (powers the Editors' Shortlist rail) -------
+# These counts change slowly (only after backfill runs) so a coarse in-process
+# cache is plenty. We deliberately keep the TTL short enough that a fresh
+# deploy reflects new data within an hour, but long enough that the rail
+# never bottlenecks the homepage.
+_APLUS_COUNTS_TTL_S = 60 * 60  # 1 hour
+_aplus_counts_cache: dict = {"data": None, "expires_at": 0.0}
+
+
+def get_aplus_category_counts() -> dict[str, int]:
+    """Return ``{slug: count}`` for each rail slug plus a synthetic ``"all"`` total.
+
+    Issues six parallel count-only queries against ``get_creators`` (which is
+    the same path the landing pages use, so any indexes already cover it).
+    Cached in-process for ``_APLUS_COUNTS_TTL_S`` seconds. Returns the last
+    successful payload on transient failure, or zeros on cold-start failure
+    so the rail still renders gracefully.
+    """
+    import time
+
+    now = time.monotonic()
+    cached = _aplus_counts_cache.get("data")
+    if cached is not None and now < _aplus_counts_cache["expires_at"]:
+        return cached
+
+    def _probe(slug: str | None, label: str | None) -> tuple[str, int]:
+        try:
+            res = get_creators(
+                sort="subscribers",
+                grade_filter="A+",
+                category_filter=label or "all",
+                limit=1,
+                offset=0,
+                return_count=True,
+            )
+            return (slug or "all"), int(res.total_count or 0)
+        except Exception:
+            logger.exception("get_aplus_category_counts: probe failed for %s", slug)
+            return (slug or "all"), 0
+
+    probes: list[tuple[str | None, str | None]] = [(None, None)]
+    probes.extend((slug, label) for slug, label in TOP_CATEGORY_SLUGS.items())
+
+    counts: dict[str, int] = {}
+    try:
+        with ThreadPoolExecutor(max_workers=len(probes)) as pool:
+            futures = [pool.submit(_probe, slug, label) for slug, label in probes]
+            for fut in as_completed(futures):
+                key, n = fut.result()
+                counts[key] = n
+    except Exception:
+        logger.exception("get_aplus_category_counts: pool failed")
+        if cached is not None:
+            return cached  # serve stale rather than break the rail
+        return {key: 0 for key in ("all", *TOP_CATEGORY_SLUGS.keys())}
+
+    _aplus_counts_cache["data"] = counts
+    _aplus_counts_cache["expires_at"] = now + _APLUS_COUNTS_TTL_S
+    return counts
+
 
 @dataclass(frozen=True)
 class CreatorsTopResult:

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -5,8 +5,9 @@ Creators routes - browse and filter discovered YouTube creators.
 import logging
 import os
 import re
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from urllib.parse import urlencode
 
 import pycountry
@@ -782,9 +783,26 @@ TOP_PAGE_SIZE = 50  # creators per page — one screen on a laptop
 # These counts change slowly (only after backfill runs) so a coarse in-process
 # cache is plenty. We deliberately keep the TTL short enough that a fresh
 # deploy reflects new data within an hour, but long enough that the rail
-# never bottlenecks the homepage.
+# never bottlenecks the discovery pages.
 _APLUS_COUNTS_TTL_S = 60 * 60  # 1 hour
-_aplus_counts_cache: dict = {"data": None, "expires_at": 0.0}
+
+
+@dataclass
+class _CountsCacheEntry:
+    """Thread-safe TTL cache for A+ rail counts.
+
+    Wraps the cached payload, expiry, and a ``Lock`` so concurrent requests
+    can't both miss-and-refill (which would fan 6 DB probes out into 12+).
+    The lock is only held around the cache read/write; the actual probe
+    fan-out happens outside it so a slow refresh never blocks readers.
+    """
+
+    data: dict[str, int] | None = None
+    expires_at: float = 0.0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_aplus_counts_cache = _CountsCacheEntry()
 
 
 def get_aplus_category_counts() -> dict[str, int]:
@@ -799,9 +817,10 @@ def get_aplus_category_counts() -> dict[str, int]:
     import time
 
     now = time.monotonic()
-    cached = _aplus_counts_cache.get("data")
-    if cached is not None and now < _aplus_counts_cache["expires_at"]:
-        return cached
+    with _aplus_counts_cache.lock:
+        if _aplus_counts_cache.data is not None and now < _aplus_counts_cache.expires_at:
+            return _aplus_counts_cache.data
+        prev_payload = _aplus_counts_cache.data  # snapshot for failure fallback
 
     def _probe(slug: str | None, label: str | None) -> tuple[str, int]:
         try:
@@ -830,12 +849,13 @@ def get_aplus_category_counts() -> dict[str, int]:
                 counts[key] = n
     except Exception:
         logger.exception("get_aplus_category_counts: pool failed")
-        if cached is not None:
-            return cached  # serve stale rather than break the rail
+        if prev_payload is not None:
+            return prev_payload  # serve stale rather than break the rail
         return {key: 0 for key in ("all", *TOP_CATEGORY_SLUGS.keys())}
 
-    _aplus_counts_cache["data"] = counts
-    _aplus_counts_cache["expires_at"] = now + _APLUS_COUNTS_TTL_S
+    with _aplus_counts_cache.lock:
+        _aplus_counts_cache.data = counts
+        _aplus_counts_cache.expires_at = now + _APLUS_COUNTS_TTL_S
     return counts
 
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -754,6 +754,10 @@ def render_creators_page(
             filtered_count=total_count,
             has_filters=has_active_filters,
         ),
+        # Editors' Shortlist rail — curated entry points into /creators/top.
+        # Lazy-imported to keep this module's import surface lean and to avoid
+        # a circular components ⇄ routes graph when routes/creators imports views.
+        _render_editors_shortlist_rail(),
         # Filter controls (sticky bar)
         _render_filter_bar(
             search=search,
@@ -804,6 +808,23 @@ def render_creators_page(
         ),
         cls=ContainerT.xl,
     )
+
+
+def _render_editors_shortlist_rail() -> Div:
+    """Mount point for the EditorsShortlistRail on /creators.
+
+    Wrapped in a helper so the rail's import (and its associated 6-probe
+    DB call for live counts) stays out of the module-level scope. Failure
+    here must never break the page — falls back to a no-op div.
+    """
+    try:
+        from components.editors_shortlist import EditorsShortlistRail
+        from routes.creators import get_aplus_category_counts
+
+        return EditorsShortlistRail(counts=get_aplus_category_counts())
+    except Exception:  # pragma: no cover — never block /creators
+        logger.exception("Editors' Shortlist rail failed to render")
+        return Div()
 
 
 def _render_hero(stats: dict, filtered_count: int = 0, has_filters: bool = False) -> Div:
@@ -4591,12 +4612,61 @@ def render_creators_top_page(
                 total_pages=total_pages,
                 base_path=base_path,
             ),
+            _render_top_drill_in_cta(category_label=category_label),
         )
 
     return Container(
         hero,
         body,
         cls=ContainerT.xl,
+    )
+
+
+def _render_top_drill_in_cta(*, category_label: str | None) -> Div:
+    """Reciprocal link back into the /creators research tool.
+
+    Closes the discovery → research loop: a user who's browsed the curated
+    A+ cut can drill into the full filter UI with the same constraints
+    pre-applied. Encoded with ``quote`` because ``A+`` contains a reserved
+    character.
+    """
+    from urllib.parse import urlencode
+
+    params = {"grade": "A+"}
+    if category_label is not None:
+        params["category"] = category_label
+    href = f"/creators?{urlencode(params)}"
+
+    label = (
+        "Open the full A+ filter on /creators"
+        if category_label is None
+        else f"Open all {category_label} A+ creators on /creators"
+    )
+
+    return Div(
+        Div(
+            Span(
+                "OR DIG DEEPER",
+                cls=(
+                    "block text-[10px] font-mono tracking-[0.22em] " "text-muted-foreground/70 mb-2"
+                ),
+            ),
+            P(
+                "Want to combine A+ with country, language, or growth filters? "
+                "Open the same set in the search tool — sortable, paginated, exportable.",
+                cls="text-sm text-muted-foreground leading-relaxed",
+            ),
+            A(
+                label + " →",
+                href=href,
+                cls=(
+                    "inline-flex items-center mt-4 text-sm font-medium "
+                    "text-primary hover:underline no-underline"
+                ),
+            ),
+            cls="max-w-2xl",
+        ),
+        cls="mt-16 pt-10 border-t border-border/60",
     )
 
 

--- a/views/lists.py
+++ b/views/lists.py
@@ -3,6 +3,7 @@ Creator Lists view — curated, pre-filtered creator rankings.
 Each tab is a different lens on the creators database.
 """
 
+import logging
 import pycountry
 from fasthtml.common import *
 from monsterui.all import *
@@ -18,6 +19,28 @@ from utils.creator_metrics import (
     format_channel_age,
 )
 from views.creators import get_topic_category_emoji
+
+logger = logging.getLogger(__name__)
+
+
+def _render_lists_editors_rail() -> "Div":
+    """Mount point for EditorsShortlistRail on /lists.
+
+    Lazy-imported + defensively wrapped so a rail-side failure (or a slow
+    counts probe during a Supabase blip) can never take down the page.
+    """
+    try:
+        from components.editors_shortlist import EditorsShortlistRail
+        from routes.creators import get_aplus_category_counts
+
+        return EditorsShortlistRail(
+            counts=get_aplus_category_counts(),
+            headline="Start with the Shortlist",
+            subhead="Hand-graded A+ creators — the curated cut behind every list below.",
+        )
+    except Exception:  # pragma: no cover — never block /lists
+        logger.exception("Editors' Shortlist rail failed to render on /lists")
+        return Div()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1383,6 +1406,11 @@ def render_lists_page(
             ),
             cls="mb-6 pt-6",
         ),
+        # ── Editors' Shortlist rail ────────────────────────────────────────────
+        # Surfaces the A+ tier landing pages so curated lists remain one click
+        # away from the broader directory below. Lazy-imported + try/except so
+        # a rail-side failure can never take down /lists.
+        _render_lists_editors_rail(),
         # ── Tab bar (horizontally scrollable on mobile) ────────────────────────
         Div(
             TabContainer(


### PR DESCRIPTION
Surfaces /creators/top as a curated entry point from both main discovery surfaces, plus a reciprocal drill-in CTA from each landing page back into the /creators filter UI. Closes the discovery → research loop and gives the new SEO pages real internal-link weight.

- components/editors_shortlist.py: EditorsShortlistRail(counts) Six-card horizontal rail (All A+ + 5 categories), mono numerals, snap-scroll on mobile, hover-lift on desktop.
- routes/creators.py: get_aplus_category_counts() 6 parallel count probes, 1h in-process TTL, serves stale on failure.
- views/creators.py: rail mounted above the filter bar; _render_top_drill_in_cta() at the foot of every /creators/top page.
- views/lists.py: rail mounted between page header and tab bar ("Start with the Shortlist" variant copy).

## Summary by Sourcery

Add an Editors' Shortlist rail highlighting A+ creators to the main discovery pages and connect curated A+ landing pages back into the creators search UI.

New Features:
- Introduce an EditorsShortlistRail component to surface the global A+ shortlist and key A+ categories as a horizontal card rail.
- Expose cached A+ category counts via a new get_aplus_category_counts helper for powering the shortlist rail.
- Add a drill-in call-to-action on /creators/top pages linking back into the creators filter UI with A+ (and optional category) pre-applied.
- Embed the Editors' Shortlist rail on /creators and /lists as a curated entry point into /creators/top.

Enhancements:
- Guard shortlist rail rendering on /creators and /lists with lazy imports and exception handling so failures never break the pages.