### PR TITLE
Add lookalike landing pages and CSV export for creators

### DIFF
--- a/db.py
+++ b/db.py
@@ -2503,17 +2503,45 @@ _PEER_CREATOR_FIELDS = (
     "current_subscribers, quality_grade, primary_category, country_code"
 )
 
+# Extended fields for the /creators/like/{handle} lookalike page — adds the
+# columns ContactExtractorService.build_creator_contact_row needs (channel_id,
+# custom_url, growth deltas, the persisted extracted_* contact columns from
+# migration 040). Kept separate from the rail tiles so the cheap rail query
+# stays cheap.
+_PEER_CREATOR_FIELDS_WITH_CONTACT = (
+    "id, channel_id, channel_name, channel_url, custom_url, "
+    "channel_thumbnail_url, channel_description, keywords, "
+    "current_subscribers, current_view_count, current_video_count, "
+    "subscribers_change_30d, views_change_30d, "
+    "engagement_score, quality_grade, primary_category, category, "
+    "country_code, default_language, "
+    "has_contact_info, contact_signals_extracted_at, "
+    "extracted_email, extracted_website, extracted_instagram, "
+    "extracted_x, extracted_tiktok, extracted_linkedin"
+)
+
 
 def get_embedding_peers(
     creator_id: str,
     peer_type: str = "embedding_v1",
     limit: int = 20,
+    *,
+    include_contacts: bool = False,
 ) -> Optional[List[Dict[str, Any]]]:
     """Return hydrated creator dicts for the embedding-based peer list.
 
     Two-query pattern:
       1. Fetch the peer_list (ordered UUID array) from creator_peers.
       2. Fetch the matching creator rows, then re-order to match the ranked list.
+
+    Args:
+        creator_id: Seed creator UUID.
+        peer_type: Which embedding bucket to look up (default ``embedding_v1``).
+        limit: Maximum peers to return.
+        include_contacts: When True, fetches the wider field set that
+            ``ContactExtractorService.build_creator_contact_row`` needs
+            (extracted_* contact columns + growth deltas). Used by
+            ``/creators/like/{handle}``. Default keeps the cheap rail query.
 
     Returns:
         list[dict]  — peer creator rows in similarity order (best first)
@@ -2541,11 +2569,9 @@ def get_embedding_peers(
             return None
 
         # Step 2: hydrate creator rows for those IDs
+        fields = _PEER_CREATOR_FIELDS_WITH_CONTACT if include_contacts else _PEER_CREATOR_FIELDS
         creators_resp = (
-            supabase_client.table(CREATOR_TABLE)
-            .select(_PEER_CREATOR_FIELDS)
-            .in_("id", peer_ids)
-            .execute()
+            supabase_client.table(CREATOR_TABLE).select(fields).in_("id", peer_ids).execute()
         )
         creators_by_id = {c["id"]: c for c in (creators_resp.data or [])}
 

--- a/main.py
+++ b/main.py
@@ -111,6 +111,8 @@ from routes.creators import (
     creator_add_status_route,
     creator_profile_route,
     creator_request_route,
+    creators_like_export_route,
+    creators_like_route,
     creators_route,
     creators_suggest_route,
     creators_top_route,
@@ -128,11 +130,7 @@ from routes.stripe_checkout import (
     billing_portal,
 )
 from services.plan_gate import gate_plan
-from services.sitemap import (
-    build_sitemap_xml as _sitemap_build_xml,
-    STATIC_ROUTES as _SITEMAP_STATIC_ROUTES,
-    BASE_URL as _SITEMAP_BASE_URL,
-)
+from services.sitemap import build_sitemap_xml
 from routes.lists import (
     categories_explorer_route,
     countries_explorer_route,
@@ -1251,6 +1249,52 @@ def creators_top_category(req, sess, slug: str):
     return _render_creators_top(req, sess, category_slug=slug)
 
 
+# ---------------------------------------------------------------------------
+# /creators/like/{handle} — Lookalike (embedding-peer) landing pages
+# ---------------------------------------------------------------------------
+# Programmatic SEO surface. One indexable page per creator with peers,
+# anonymous-friendly, with a free CSV export of any extracted contacts.
+# Slug = creator handle (custom_url). Extensionless /export to dodge
+# FastHTML's static-route precedence (same bug we hit on /admin/outreach).
+
+
+@rt("/creators/like/{handle}")
+def creators_like(req, sess, handle: str):
+    """GET /creators/like/{handle} — 20 most-similar creators + contacts."""
+    from starlette.responses import Response as _Response
+
+    from routes.creators import CreatorsLikeResult
+    from views.creators import creators_like_head, creators_like_page_title
+
+    result = creators_like_route(req, handle=handle)
+    if isinstance(result, _Response):
+        return result  # 404 for unknown handle or missing peer list
+    if not isinstance(result, CreatorsLikeResult):
+        return result  # defensive passthrough for future redirect shapes
+
+    head_tags = creators_like_head(
+        seed=result.seed,
+        peer_count=result.peer_count,
+        contact_count=result.contact_count,
+    )
+    return Titled(
+        creators_like_page_title(result.seed),
+        Container(
+            NavComponent(oauth, req, sess),
+            result.body,
+            cls=ContainerT.xl,
+        ),
+        *head_tags,
+    )
+
+
+@rt("/creators/like/{handle}/export")
+def creators_like_export(req, sess, handle: str):
+    """GET /creators/like/{handle}/export — CSV download. Extensionless on
+    purpose; Content-Disposition supplies the .csv filename."""
+    return creators_like_export_route(req, handle=handle)
+
+
 @rt("/lists")
 def lists(req, sess):
     """Creator Lists page - curated, pre-filtered creator rankings"""
@@ -1933,19 +1977,12 @@ _SITEMAP_CACHE_TTL = 86_400  # 24 hours
 
 
 def _build_sitemap_xml() -> str:
-    """Query Supabase for synced creators and return a sitemap XML string."""
-    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    urlset = _ET.Element("urlset", xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
+    """Fetch sitemap cohorts from Supabase and delegate to services.sitemap.
 
-    # Static routes
-    for path, changefreq, priority in _SITEMAP_STATIC_ROUTES:
-        url_el = _ET.SubElement(urlset, "url")
-        _ET.SubElement(url_el, "loc").text = _urljoin(_SITEMAP_BASE_URL, path)
-        _ET.SubElement(url_el, "lastmod").text = today
-        _ET.SubElement(url_el, "changefreq").text = changefreq
-        _ET.SubElement(url_el, "priority").text = priority
-
-    # Dynamic creator pages
+    Single source of truth for XML construction lives in
+    ``services.sitemap.build_sitemap_xml`` so the live route and the CI-
+    generated ``public/sitemap.xml`` stay in lockstep.
+    """
     try:
         resp = (
             supabase_client.table("creators")
@@ -1958,21 +1995,24 @@ def _build_sitemap_xml() -> str:
         logger.warning("sitemap: could not fetch creators from Supabase", exc_info=True)
         creators = []
 
-    for creator in creators:
-        creator_id = creator.get("id")
-        if not creator_id:
-            continue
-        raw_lastmod = creator.get("last_updated_at") or ""
-        lastmod = raw_lastmod[:10] if len(raw_lastmod) >= 10 else today
+    # Lookalike landing pages are scoped to A+ tier to stay well under the
+    # 50k URL ceiling and focus Google's crawl budget on the highest-quality
+    # cohort. Requires custom_url because the URL is /creators/like/{handle}.
+    try:
+        aplus_resp = (
+            supabase_client.table("creators")
+            .select("custom_url, last_updated_at")
+            .eq("sync_status", "synced")
+            .eq("quality_grade", "A+")
+            .not_.is_("custom_url", "null")
+            .execute()
+        )
+        aplus_creators = aplus_resp.data or []
+    except Exception:
+        logger.warning("sitemap: could not fetch A+ creators for lookalikes", exc_info=True)
+        aplus_creators = []
 
-        url_el = _ET.SubElement(urlset, "url")
-        _ET.SubElement(url_el, "loc").text = _urljoin(_SITEMAP_BASE_URL, f"/creator/{creator_id}")
-        _ET.SubElement(url_el, "lastmod").text = lastmod
-        _ET.SubElement(url_el, "changefreq").text = "weekly"
-        _ET.SubElement(url_el, "priority").text = "0.7"
-
-    rough = _ET.tostring(urlset, "utf-8")
-    return _minidom.parseString(rough).toprettyxml(indent="  ")
+    return build_sitemap_xml(creators, aplus_creators=aplus_creators)
 
 
 @rt("/sitemap.xml")

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -937,3 +937,144 @@ def creators_top_route(request, *, category_slug: str | None = None):
         total_count=total_count,
         page=page,
     )
+
+
+# ---------------------------------------------------------------------------
+# /creators/like/{handle} — Lookalike (embedding-peer) landing pages
+# ---------------------------------------------------------------------------
+# Programmatic SEO + bulk-contact wedge:
+#   * 344k potential URLs (one per creator with peers in `creator_peers`)
+#   * Anonymous CSV download — no auth required, no plan-gate
+#   * Reuses ContactExtractorService for the export so the CSV shape stays
+#     identical to /me/outreach/export and the admin bulk export.
+
+LOOKALIKE_LIMIT = 20  # peers shown on /creators/like/{handle}
+
+
+@dataclass(frozen=True)
+class CreatorsLikeResult:
+    """Bundle returned to main.py so the route can wrap with <head> + Titled.
+
+    Same pattern as ``CreatorsTopResult`` — keeps the route the single owner
+    of the data fetch so main.py never has to re-query.
+    """
+
+    body: object  # FT tree from render_creators_like_page()
+    seed: dict  # full creator row for the seed handle
+    peer_count: int  # how many peers we actually rendered
+    contact_count: int  # subset of peers with at least one contact
+
+
+def _resolve_seed_creator(handle: str) -> dict | None:
+    """Lookalike-side handle resolver. Thin wrapper kept for symmetry with
+    the route below so tests/refactors don't have to monkey-patch the DB
+    function directly."""
+    if not handle:
+        return None
+    return find_creator_by_handle(handle)
+
+
+def creators_like_route(request, *, handle: str):
+    """GET /creators/like/{handle}
+
+    Resolves ``handle`` to a creator id, fetches up to ``LOOKALIKE_LIMIT``
+    embedding peers (with the contact-bearing field set), and hands the
+    result to the view. Anonymous-friendly — no auth gate, no plan gate.
+
+    Returns:
+        * ``CreatorsLikeResult`` on success.
+        * ``Response`` 404 when the handle is unknown or has no peers
+          (the latter prevents indexable empty pages).
+    """
+    from starlette.responses import Response
+
+    from views.creators import render_creators_like_page
+
+    seed = _resolve_seed_creator(handle)
+    if not seed:
+        return Response("Creator not found", status_code=404)
+
+    seed_id = seed.get("id")
+    if not seed_id:
+        return Response("Creator not found", status_code=404)
+
+    peers = get_embedding_peers(
+        seed_id,
+        limit=LOOKALIKE_LIMIT,
+        include_contacts=True,
+    )
+    if not peers:
+        # No peer row → don't render an empty SEO page Google can crawl.
+        return Response("No lookalikes available for this creator", status_code=404)
+
+    contact_count = sum(1 for p in peers if p.get("has_contact_info") or p.get("extracted_email"))
+
+    body = render_creators_like_page(
+        seed=seed,
+        peers=peers,
+        contact_count=contact_count,
+    )
+    return CreatorsLikeResult(
+        body=body,
+        seed=seed,
+        peer_count=len(peers),
+        contact_count=contact_count,
+    )
+
+
+def creators_like_export_route(request, *, handle: str):
+    """GET /creators/like/{handle}/export  — CSV download (no extension).
+
+    Returns the same CSV shape as ``/me/outreach/export`` so downstream
+    email tools (Lemlist, Apollo, Instantly, etc.) accept it directly.
+    Extensionless path + ``Content-Disposition`` preserves the .csv
+    filename without tripping FastHTML's static-route precedence
+    (the bug we fixed for ``/admin/outreach/export``).
+    """
+    import csv
+    import io
+
+    from starlette.responses import Response as _Response
+    from starlette.responses import Response as StarletteResponse
+
+    from services.contact_extractor import ContactExtractorService
+
+    seed = _resolve_seed_creator(handle)
+    if not seed or not seed.get("id"):
+        return _Response("Creator not found", status_code=404)
+
+    peers = get_embedding_peers(
+        seed["id"],
+        limit=LOOKALIKE_LIMIT,
+        include_contacts=True,
+    )
+    if not peers:
+        return _Response("No lookalikes available for this creator", status_code=404)
+
+    # Build email-tool-friendly rows and filter to those with an email.
+    # Pulling base_url from the live request keeps profile URLs portable
+    # across staging / production without hard-coding the domain.
+    base_url = str(request.base_url).rstrip("/") if hasattr(request, "base_url") else ""
+    rows = [ContactExtractorService.build_creator_contact_row(p, base_url=base_url) for p in peers]
+    rows = ContactExtractorService.filter_email_ready_rows(rows)
+
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf,
+        fieldnames=ContactExtractorService.EMAIL_EXPORT_HEADERS,
+        extrasaction="ignore",
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+
+    # Filename is sanitised lower-case handle so downloads don't collide
+    # when a user exports several lookalike lists in one session.
+    safe_handle = (seed.get("custom_url") or handle or "creator").lstrip("@").lower()
+    safe_handle = re.sub(r"[^a-z0-9_-]", "", safe_handle) or "creator"
+    filename = f"lookalikes-{safe_handle}.csv"
+
+    return StarletteResponse(
+        content=buf.getvalue(),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -1034,14 +1034,13 @@ def creators_like_export_route(request, *, handle: str):
     import csv
     import io
 
-    from starlette.responses import Response as _Response
-    from starlette.responses import Response as StarletteResponse
+    from starlette.responses import Response
 
     from services.contact_extractor import ContactExtractorService
 
     seed = _resolve_seed_creator(handle)
     if not seed or not seed.get("id"):
-        return _Response("Creator not found", status_code=404)
+        return Response("Creator not found", status_code=404)
 
     peers = get_embedding_peers(
         seed["id"],
@@ -1049,7 +1048,7 @@ def creators_like_export_route(request, *, handle: str):
         include_contacts=True,
     )
     if not peers:
-        return _Response("No lookalikes available for this creator", status_code=404)
+        return Response("No lookalikes available for this creator", status_code=404)
 
     # Build email-tool-friendly rows and filter to those with an email.
     # Pulling base_url from the live request keeps profile URLs portable
@@ -1073,7 +1072,7 @@ def creators_like_export_route(request, *, handle: str):
     safe_handle = re.sub(r"[^a-z0-9_-]", "", safe_handle) or "creator"
     filename = f"lookalikes-{safe_handle}.csv"
 
-    return StarletteResponse(
+    return Response(
         content=buf.getvalue(),
         media_type="text/csv; charset=utf-8",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -45,6 +45,28 @@ def _fetch_synced_creators(client) -> list:
         return []
 
 
+def _fetch_aplus_creators(client) -> list:
+    """Return {custom_url, last_updated_at} for synced A+ creators with a handle.
+
+    Used to emit /creators/like/{handle} lookalike landing pages. Scoped to
+    A+ tier so the sitemap stays well under the 50k URL ceiling and focuses
+    crawl budget on the highest-quality cohort.
+    """
+    try:
+        resp = (
+            client.table("creators")
+            .select("custom_url, last_updated_at")
+            .eq("sync_status", "synced")
+            .eq("quality_grade", "A+")
+            .not_.is_("custom_url", "null")
+            .execute()
+        )
+        return resp.data or []
+    except Exception as e:
+        print(f"Warning: could not fetch A+ creators from Supabase: {e}")
+        return []
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -59,11 +81,14 @@ def generate_sitemap() -> bool:
             "Ensure NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_KEY are set for full output."
         )
         creators = []
+        aplus_creators = []
     else:
         creators = _fetch_synced_creators(client)
         print(f"Found {len(creators)} synced creators.")
+        aplus_creators = _fetch_aplus_creators(client)
+        print(f"Found {len(aplus_creators)} A+ creators for lookalike pages.")
 
-    xml_content = build_sitemap_xml(creators)
+    xml_content = build_sitemap_xml(creators, aplus_creators=aplus_creators)
 
     public_dir = os.path.join(_PROJECT_ROOT, "public")
     sitemap_path = os.path.join(public_dir, "sitemap.xml")
@@ -74,7 +99,8 @@ def generate_sitemap() -> bool:
             f.write(xml_content)
         print(
             f"Sitemap written to {sitemap_path} "
-            f"({len(STATIC_ROUTES)} static + {len(creators)} creator URLs)"
+            f"({len(STATIC_ROUTES)} static + {len(creators)} creator "
+            f"+ {len(aplus_creators)} lookalike URLs)"
         )
     except IOError as e:
         print(f"Error writing sitemap: {e}")

--- a/services/sitemap.py
+++ b/services/sitemap.py
@@ -42,12 +42,29 @@ def _prettify(elem: ET.Element) -> str:
     return minidom.parseString(rough).toprettyxml(indent="  ")
 
 
-def build_sitemap_xml(creators: list) -> str:
+def _lastmod_or_today(row: dict, today: str) -> str:
+    """Pull a 10-char (YYYY-MM-DD) lastmod off a row, falling back to today."""
+    raw = row.get("last_updated_at") or ""
+    return raw[:10] if len(raw) >= 10 else today
+
+
+def build_sitemap_xml(
+    creators: list,
+    *,
+    aplus_creators: list | None = None,
+) -> str:
     """Build and return the complete sitemap XML string.
 
     Args:
         creators: List of ``{id, last_updated_at}`` dicts for synced creators.
-                  Pass an empty list to emit static routes only (e.g. in CI).
+                  Each becomes a ``/creator/{id}`` entry. Pass an empty list
+                  to emit static routes only (e.g. in CI when DB is offline).
+        aplus_creators: Optional list of ``{custom_url, last_updated_at}``
+                  dicts for A+ creators with a usable handle. Each becomes a
+                  ``/creators/like/{handle}`` lookalike-page entry. Scoped to
+                  A+ by the caller so the sitemap stays well under Google's
+                  50k-URL ceiling and crawl budget focuses on the most
+                  rankable creators.
     """
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     urlset = ET.Element("urlset", xmlns="http://www.sitemaps.org/schemas/sitemap/0.9")
@@ -63,13 +80,20 @@ def build_sitemap_xml(creators: list) -> str:
         creator_id = creator.get("id")
         if not creator_id:
             continue
-        raw_lastmod = creator.get("last_updated_at") or ""
-        lastmod = raw_lastmod[:10] if len(raw_lastmod) >= 10 else today
-
         url_el = ET.SubElement(urlset, "url")
         ET.SubElement(url_el, "loc").text = urljoin(BASE_URL, f"/creator/{creator_id}")
-        ET.SubElement(url_el, "lastmod").text = lastmod
+        ET.SubElement(url_el, "lastmod").text = _lastmod_or_today(creator, today)
         ET.SubElement(url_el, "changefreq").text = "weekly"
         ET.SubElement(url_el, "priority").text = "0.7"
+
+    for creator in aplus_creators or []:
+        handle = (creator.get("custom_url") or "").lstrip("@").lower()
+        if not handle:
+            continue
+        url_el = ET.SubElement(urlset, "url")
+        ET.SubElement(url_el, "loc").text = urljoin(BASE_URL, f"/creators/like/{handle}")
+        ET.SubElement(url_el, "lastmod").text = _lastmod_or_today(creator, today)
+        ET.SubElement(url_el, "changefreq").text = "weekly"
+        ET.SubElement(url_el, "priority").text = "0.6"
 
     return _prettify(urlset)

--- a/views/creators.py
+++ b/views/creators.py
@@ -4248,13 +4248,40 @@ def render_creator_profile_page(
     # Only rendered when embedding_peers is a non-empty list.
     # Passing None means the caller found no row in creator_peers → hide section.
     # ═══════════════════════════════════════════════════════════════════════════
+    # When embedding peers exist we also offer a one-click jump to the full
+    # /creators/like/{handle} landing page (20 peers + CSV export). Handle
+    # slug is sourced from custom_url so it matches the public URL shape.
+    _peer_handle_slug = (custom_url or "").lstrip("@").lower()
+    _lookalike_cta = (
+        Div(
+            A(
+                Span(
+                    f"See all {len(embedding_peers)} lookalikes for " f"{channel_name} ",
+                    cls="font-medium",
+                ),
+                Span("with verified contacts →", cls="text-muted-foreground"),
+                href=f"/creators/like/{_peer_handle_slug}",
+                cls=(
+                    "inline-flex items-center gap-1 text-sm "
+                    "text-primary hover:underline no-underline"
+                ),
+            ),
+            cls="mt-3 px-1",
+        )
+        if embedding_peers and _peer_handle_slug
+        else None
+    )
+
     embedding_peers_section = (
-        _render_similar_creators(
-            embedding_peers,
-            primary_category,
-            country_code,
-            current_creator_id=creator_id,
-            title="Similar creators",
+        Div(
+            _render_similar_creators(
+                embedding_peers,
+                primary_category,
+                country_code,
+                current_creator_id=creator_id,
+                title="Similar creators",
+            ),
+            _lookalike_cta,
         )
         if embedding_peers  # None or [] → section is suppressed
         else None
@@ -4704,3 +4731,285 @@ def creators_top_head(
         *OgTags(title=page_title, description=meta_desc, path=base_path),
     ]
     return tuple(tags)
+
+
+# =============================================================================
+# /creators/like/{handle} — embedding-based lookalike landing pages
+# =============================================================================
+# Programmatic SEO surface backed by the `creator_peers` table. Each page is
+# anonymous-friendly, shows ≤20 similar creators (in similarity order), and
+# offers a free CSV download with verified business contacts inline.
+
+
+def _lookalike_seed_handle(seed: dict) -> str:
+    """Best-effort @handle for display ("MrBeast" → "@mrbeast")."""
+    raw = (seed.get("custom_url") or "").strip().lstrip("@")
+    return f"@{raw}" if raw else (seed.get("channel_name") or "this creator")
+
+
+def _format_contact_summary(contact_count: int, peer_count: int) -> str:
+    """Numeric badge copy for the hero — "12 of 20 with verified contacts"."""
+    if not peer_count:
+        return ""
+    if not contact_count:
+        return "Contacts being extracted — check back soon."
+    if contact_count == peer_count:
+        return f"All {peer_count} have verified business contacts."
+    return f"{contact_count} of {peer_count} have verified business contacts."
+
+
+def _render_lookalike_contact_strip(peer: dict) -> Div | None:
+    """Thin contact bar shown under each peer card.
+
+    Only renders when the peer actually has at least one extractable signal.
+    Designed to be visually subordinate to the card itself — the card is the
+    creator, the strip is the data attached to them.
+    """
+    email = peer.get("extracted_email")
+    website = peer.get("extracted_website")
+    instagram = peer.get("extracted_instagram")
+    x_url = peer.get("extracted_x")
+
+    if not any((email, website, instagram, x_url)):
+        return None
+
+    chips: list = []
+    if email:
+        chips.append(
+            A(
+                "📩 ",
+                Span(email, cls="font-mono text-xs"),
+                href=f"mailto:{email}",
+                cls=(
+                    "inline-flex items-center gap-1 px-2 py-1 rounded-md "
+                    "bg-primary/[0.06] text-primary text-xs font-medium "
+                    "hover:bg-primary/10 transition-colors no-underline truncate max-w-full"
+                ),
+            )
+        )
+    if website:
+        chips.append(
+            A(
+                "🔗 Website",
+                href=website,
+                target="_blank",
+                rel="nofollow noopener",
+                cls=(
+                    "inline-flex items-center gap-1 px-2 py-1 rounded-md "
+                    "bg-accent/40 text-foreground/80 text-xs font-medium "
+                    "hover:bg-accent transition-colors no-underline"
+                ),
+            )
+        )
+    if instagram:
+        chips.append(
+            A(
+                "Instagram",
+                href=instagram,
+                target="_blank",
+                rel="nofollow noopener",
+                cls=(
+                    "inline-flex items-center px-2 py-1 rounded-md "
+                    "bg-accent/40 text-foreground/80 text-xs font-medium "
+                    "hover:bg-accent transition-colors no-underline"
+                ),
+            )
+        )
+    if x_url:
+        chips.append(
+            A(
+                "X",
+                href=x_url,
+                target="_blank",
+                rel="nofollow noopener",
+                cls=(
+                    "inline-flex items-center px-2 py-1 rounded-md "
+                    "bg-accent/40 text-foreground/80 text-xs font-medium "
+                    "hover:bg-accent transition-colors no-underline"
+                ),
+            )
+        )
+
+    return Div(
+        *chips,
+        cls="flex flex-wrap gap-1.5 mt-2 px-1",
+    )
+
+
+def _render_lookalike_grid(peers: list[dict]) -> Div:
+    """3-up grid: each cell wraps the standard creator card + contact strip.
+
+    Re-uses ``_render_creator_card`` so spacing, hover, and dark-mode tokens
+    match the rest of the discovery surfaces. The strip is a sibling, never
+    nested inside the card's anchor.
+    """
+    # Inject _rank so the standard card shows a sane "#N" badge per peer
+    # (peer order is similarity-ranked; rank 1 = closest).
+    cells = []
+    for i, p in enumerate(peers, start=1):
+        peer_with_rank = {**p, "_rank": str(i)}
+        cells.append(
+            Div(
+                _render_creator_card(peer_with_rank, is_favourited=False),
+                _render_lookalike_contact_strip(p),
+                cls="flex flex-col",
+            )
+        )
+    return Div(
+        *cells,
+        cls="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5",
+    )
+
+
+def render_creators_like_page(
+    *,
+    seed: dict,
+    peers: list[dict],
+    contact_count: int,
+) -> Div:
+    """Editorial layout for ``/creators/like/{handle}``.
+
+    Layout
+    ------
+    * Hero — gradient H1 ("Creators like @handle"), eyebrow, lede with
+      contact-count badge, accent rule.
+    * Action bar — CSV download (anonymous-friendly) + breadcrumb back
+      to the seed creator's profile.
+    * 3-up grid of similarity-ordered peers, each with a contact strip.
+    * Footer CTA — link into ``/creators`` filter UI for deeper research.
+    """
+    handle = _lookalike_seed_handle(seed)
+    seed_name = seed.get("channel_name") or handle
+    seed_id = seed.get("id") or ""
+    peer_count = len(peers)
+    summary = _format_contact_summary(contact_count, peer_count)
+
+    hero = Div(
+        Div(
+            Span(
+                "LOOKALIKE LIST",
+                cls=(
+                    "inline-block text-xs font-mono font-medium tracking-[0.18em] "
+                    "text-muted-foreground mb-4"
+                ),
+            ),
+            H1(
+                Span("Creators like ", cls="text-foreground/70"),
+                Span(
+                    seed_name,
+                    cls=(
+                        "bg-gradient-to-r from-foreground to-foreground/70 "
+                        "bg-clip-text text-transparent"
+                    ),
+                ),
+                cls="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight mb-6",
+            ),
+            P(
+                f"{peer_count} channels ranked by audience-overlap similarity to " f"{handle}. ",
+                Span(summary, cls="font-medium text-foreground") if summary else None,
+                cls="text-lg sm:text-xl text-muted-foreground leading-relaxed max-w-3xl",
+            ),
+            Div(cls="h-px w-24 bg-primary/40 mt-10"),
+            cls="max-w-4xl",
+        ),
+        cls="py-16 sm:py-20 lg:py-24",
+    )
+
+    action_bar = Div(
+        A(
+            "← Back to ",
+            Span(handle, cls="font-medium"),
+            href=f"/creator/{seed_id}",
+            cls=(
+                "inline-flex items-center text-sm text-muted-foreground "
+                "hover:text-foreground transition-colors no-underline"
+            ),
+        ),
+        (
+            A(
+                "⬇ Export contacts (CSV)",
+                href=f"/creators/like/{seed.get('custom_url', '').lstrip('@').lower() or handle.lstrip('@')}/export",
+                cls=(
+                    "inline-flex items-center px-4 py-2 rounded-md text-sm font-medium "
+                    "bg-primary text-primary-foreground hover:bg-primary/90 "
+                    "transition-colors no-underline shadow-sm"
+                ),
+            )
+            if contact_count > 0
+            else Span(
+                "CSV export will be available once contacts are extracted",
+                cls="text-sm text-muted-foreground italic",
+            )
+        ),
+        cls="flex items-center justify-between gap-4 mb-8 flex-wrap",
+    )
+
+    grid = _render_lookalike_grid(peers)
+
+    footer_cta = Div(
+        Div(
+            Span(
+                "OR DIG DEEPER",
+                cls=(
+                    "block text-[10px] font-mono tracking-[0.22em] " "text-muted-foreground/70 mb-2"
+                ),
+            ),
+            P(
+                f"Want to filter {handle}-style creators by country, growth, "
+                "or category? Open the full search to combine signals.",
+                cls="text-sm text-muted-foreground leading-relaxed",
+            ),
+            A(
+                "Open the creator search →",
+                href="/creators",
+                cls=(
+                    "inline-flex items-center mt-4 text-sm font-medium "
+                    "text-primary hover:underline no-underline"
+                ),
+            ),
+            cls="max-w-2xl",
+        ),
+        cls="mt-16 pt-10 border-t border-border/60",
+    )
+
+    return Container(
+        hero,
+        action_bar,
+        grid,
+        footer_cta,
+        cls=ContainerT.xl,
+    )
+
+
+def creators_like_page_title(seed: dict) -> str:
+    """Single source for the ``<title>`` and visible chrome title."""
+    name = seed.get("channel_name") or _lookalike_seed_handle(seed)
+    return f"Creators like {name} — ViralVibes"
+
+
+def creators_like_head(*, seed: dict, peer_count: int, contact_count: int) -> tuple:
+    """Return ``<head>`` tags for the lookalike landing page."""
+    from components.seo import Canonical, MetaDescription, OgTags
+
+    handle = (seed.get("custom_url") or "").lstrip("@").lower()
+    path = f"/creators/like/{handle}" if handle else "/creators"
+    title = creators_like_page_title(seed)
+    name = seed.get("channel_name") or _lookalike_seed_handle(seed)
+
+    if contact_count:
+        desc = (
+            f"{peer_count} creators similar to {name} on YouTube — ranked by "
+            f"audience overlap. {contact_count} include verified business "
+            "contacts. Free CSV download."
+        )
+    else:
+        desc = (
+            f"{peer_count} YouTube channels similar to {name}, ranked by "
+            "audience overlap. Updated as new creators are discovered."
+        )
+
+    return (
+        Canonical(path),
+        MetaDescription(desc),
+        *OgTags(title=title, description=desc, path=path),
+    )


### PR DESCRIPTION
- Implemented /creators/like/{handle} route to display similar creators with contact information.
- Added CSV export functionality for lookalike creators.
- Updated sitemap generation to include lookalike URLs for A+ creators.
- Enhanced database queries to fetch necessary fields for lookalike functionality.

## Summary by Sourcery

Introduce lookalike creator landing pages with contact info and CSV export, and surface them via the sitemap and creator detail page.

New Features:
- Add /creators/like/{handle} landing page showing embedding-based similar creators with inline contact information.
- Expose anonymous CSV export of lookalike creators’ contact-ready records at /creators/like/{handle}/export.
- Add inline call-to-action on creator profile pages linking to the full lookalike list when embedding peers exist.

Enhancements:
- Extend embedding peer queries to optionally include contact and growth fields required for contact exports.
- Refactor sitemap generation to delegate XML construction to services.sitemap and include A+ creators’ lookalike URLs.
- Update sitemap generation script to fetch A+ creators and report lookalike URL counts in output.