### PR TITLE
contact: roll back SMTP forward; add inquiries schema + db helpers

### DIFF
--- a/db.py
+++ b/db.py
@@ -3947,3 +3947,148 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
         "materialized_views": results,
         "error": partial_errors,  # non-null when one view failed but the other succeeded
     }
+
+
+# ============================================================================
+# 📨 Contact form inquiries  (migration 041)
+# ============================================================================
+# System of record for /contact submissions. Transactional-email forwarding
+# (Resend / Postmark) is layered on top in a subsequent change — keeping the
+# DB write authoritative means an outbound send failure never loses an
+# inquiry, and an admin retry view can drain the queue.
+
+CONTACT_INQUIRIES_TABLE = "contact_inquiries"
+
+_CONTACT_INQUIRY_TYPES = frozenset(
+    {"general", "sales", "feedback", "support", "partnership", "careers"}
+)
+
+
+def insert_contact_inquiry(
+    *,
+    name: str,
+    email: str,
+    inquiry_type: str,
+    message: str,
+    client_ip: Optional[str] = None,
+    user_agent: Optional[str] = None,
+) -> Optional[int]:
+    """Persist a /contact form submission and return the new row id.
+
+    Returns ``None`` on any failure (no Supabase client, network error,
+    constraint violation). The caller \u2014 ``routes/contact.py:post_contact``
+    \u2014 always returns the success page regardless, so a DB hiccup never
+    leaks to the visitor; the failure is captured in the application log
+    for operator follow-up.
+
+    Args:
+        name:         Visitor's name (1-200 chars after caller-side trim).
+        email:        Visitor's email (3-320 chars; format checked by caller).
+        inquiry_type: One of the allowlisted slugs (see ``_CONTACT_INQUIRY_TYPES``).
+                      Falls back to ``"general"`` if unknown so a stale option
+                      value can't 500 the form.
+        message:      Free-form body (1-10000 chars; caller enforces the cap).
+        client_ip:    Best-effort source IP for rate limiting; ``None`` is fine.
+        user_agent:   Best-effort UA string for triage; ``None`` is fine.
+    """
+    if not supabase_client:
+        logger.warning("insert_contact_inquiry: no supabase_client; dropping inquiry")
+        return None
+
+    payload: Dict[str, Any] = {
+        "name": name,
+        "email": email,
+        "inquiry_type": inquiry_type if inquiry_type in _CONTACT_INQUIRY_TYPES else "general",
+        "message": message,
+    }
+    if client_ip:
+        payload["client_ip"] = client_ip
+    if user_agent:
+        payload["user_agent"] = user_agent
+
+    try:
+        resp = _db_execute(
+            lambda: supabase_client.table(CONTACT_INQUIRIES_TABLE).insert(payload).execute()
+        )
+    except Exception:
+        logger.exception("insert_contact_inquiry: insert failed for <%s>", email)
+        return None
+
+    rows = resp.data or []
+    if not rows:
+        logger.warning("insert_contact_inquiry: insert returned no rows for <%s>", email)
+        return None
+    return rows[0].get("id")
+
+
+def count_contact_inquiries_from_ip(client_ip: str, *, within_minutes: int = 60) -> int:
+    """Return how many inquiries the given IP submitted in the recent window.
+
+    Used by ``post_contact`` to short-circuit obvious flooders before doing
+    a write. Returns ``0`` on any error so a transient DB blip can never
+    block a legitimate user (worst case: rate limit briefly under-counts).
+
+    The lookup is index-supported by
+    ``idx_contact_inquiries_client_ip_created_at``.
+    """
+    if not supabase_client or not client_ip:
+        return 0
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(minutes=within_minutes)).isoformat()
+
+    try:
+        resp = _db_execute(
+            lambda: supabase_client.table(CONTACT_INQUIRIES_TABLE)
+            .select("id", count="exact")
+            .eq("client_ip", client_ip)
+            .gte("created_at", cutoff)
+            .execute()
+        )
+    except Exception:
+        logger.exception("count_contact_inquiries_from_ip: lookup failed for %s", client_ip)
+        return 0
+
+    return int(getattr(resp, "count", 0) or 0)
+
+
+def mark_contact_inquiry_forwarded(inquiry_id: int) -> bool:
+    """Record a successful transactional-email send. Returns True on update."""
+    if not supabase_client or not inquiry_id:
+        return False
+    try:
+        _db_execute(
+            lambda: supabase_client.table(CONTACT_INQUIRIES_TABLE)
+            .update(
+                {
+                    "forwarded_at": datetime.now(timezone.utc).isoformat(),
+                    "forward_error": None,
+                }
+            )
+            .eq("id", inquiry_id)
+            .execute()
+        )
+        return True
+    except Exception:
+        logger.exception("mark_contact_inquiry_forwarded: update failed for id=%s", inquiry_id)
+        return False
+
+
+def mark_contact_inquiry_forward_error(inquiry_id: int, error: str) -> bool:
+    """Record a failed transactional-email send. Returns True on update.
+
+    ``error`` is truncated to a sane length so a multi-MB stack trace can't
+    bloat the row \u2014 detailed traces belong in the log, not the DB.
+    """
+    if not supabase_client or not inquiry_id:
+        return False
+    try:
+        _db_execute(
+            lambda: supabase_client.table(CONTACT_INQUIRIES_TABLE)
+            .update({"forward_error": (error or "")[:1000]})
+            .eq("id", inquiry_id)
+            .execute()
+        )
+        return True
+    except Exception:
+        logger.exception("mark_contact_inquiry_forward_error: update failed for id=%s", inquiry_id)
+        return False

--- a/db.py
+++ b/db.py
@@ -3959,6 +3959,12 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
 
 CONTACT_INQUIRIES_TABLE = "contact_inquiries"
 
+# Allowlisted inquiry-type slugs. KEEP IN SYNC with the
+# ``contact_inquiries_type_allowed`` CHECK constraint in
+# ``db/migrations/041_contact_inquiries.sql`` and with the ``<select>``
+# options in ``routes/contact.py``. ``insert_contact_inquiry`` defends
+# against drift by falling back to ``"general"`` for unknown values, so a
+# stale list here cannot 500 the form — it can only mis-categorise.
 _CONTACT_INQUIRY_TYPES = frozenset(
     {"general", "sales", "feedback", "support", "partnership", "careers"}
 )

--- a/db/migrations/041_contact_inquiries.sql
+++ b/db/migrations/041_contact_inquiries.sql
@@ -1,0 +1,62 @@
+-- Migration 041: Contact form inquiries
+--
+-- Backing store for the /contact form submission. Email forwarding via a
+-- transactional provider (Resend / Postmark) is layered on top in a
+-- subsequent change — the table is the system of record so an outbound
+-- send failure never loses an inquiry.
+--
+-- Design notes:
+--   • inet column for client_ip enables cheap per-IP rate-limit lookups
+--     without a separate rate-limit table.
+--   • forwarded_at / forward_error capture the email delivery state;
+--     NULL forwarded_at + NULL forward_error means "queued, not attempted".
+--   • RLS is enabled and only the service role can read/write — the table
+--     contains PII (visitor email + free-form message) and must never be
+--     reachable from the anon JWT used by the web app.
+--
+-- Run once in the Supabase SQL editor.
+
+CREATE TABLE IF NOT EXISTS public.contact_inquiries (
+    id              bigserial PRIMARY KEY,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    name            text        NOT NULL,
+    email           text        NOT NULL,
+    inquiry_type    text        NOT NULL DEFAULT 'general',
+    message         text        NOT NULL,
+    client_ip       inet,
+    user_agent      text,
+    forwarded_at    timestamptz,
+    forward_error   text,
+    CONSTRAINT contact_inquiries_name_length    CHECK (char_length(name)    BETWEEN 1 AND 200),
+    CONSTRAINT contact_inquiries_email_length   CHECK (char_length(email)   BETWEEN 3 AND 320),
+    CONSTRAINT contact_inquiries_message_length CHECK (char_length(message) BETWEEN 1 AND 10000),
+    CONSTRAINT contact_inquiries_type_allowed   CHECK (
+        inquiry_type IN ('general', 'sales', 'feedback', 'support', 'partnership', 'careers')
+    )
+);
+
+-- Most-recent-first listing in the admin UI.
+CREATE INDEX IF NOT EXISTS idx_contact_inquiries_created_at
+    ON public.contact_inquiries (created_at DESC);
+
+-- Per-IP rate-limit lookup: "how many inquiries from this IP in the last hour?"
+CREATE INDEX IF NOT EXISTS idx_contact_inquiries_client_ip_created_at
+    ON public.contact_inquiries (client_ip, created_at DESC)
+    WHERE client_ip IS NOT NULL;
+
+-- Drains the retry queue: rows that have never been forwarded and have no
+-- recorded error are eligible for a (re)send attempt.
+CREATE INDEX IF NOT EXISTS idx_contact_inquiries_pending_forward
+    ON public.contact_inquiries (created_at)
+    WHERE forwarded_at IS NULL AND forward_error IS NULL;
+
+-- RLS — service role only. Contains PII; the anon key must not see it.
+ALTER TABLE public.contact_inquiries ENABLE ROW LEVEL SECURITY;
+
+-- (No policies are created. With RLS enabled and zero policies, only the
+-- service_role bypass — used by the FastHTML backend — can read or write.)
+
+COMMENT ON TABLE public.contact_inquiries IS
+    'Submissions from the /contact form. PII; service-role only. '
+    'forwarded_at is set when the transactional email send succeeds; '
+    'forward_error captures the most recent failure.';

--- a/main.py
+++ b/main.py
@@ -123,6 +123,7 @@ from routes.creators import (
 from routes.about import about_page_content
 from routes.contact import contact_page_content, post_contact
 from routes.legal import privacy_page_content, terms_page_content
+from routes.press import press_page_content
 from routes.pricing import pricing_page_content
 from routes.stripe_webhooks import stripe_webhook
 from routes.stripe_checkout import (
@@ -1916,12 +1917,25 @@ def about(req, sess):
     )
 
 
+@rt("/press")
+def press(req, sess):
+    """Press Kit — public route linked from the footer."""
+    return Titled(
+        "Press Kit - ViralVibes",
+        Container(
+            NavComponent(oauth, req, sess),
+            press_page_content(),
+            cls=ContainerT.xl,
+        ),
+    )
+
+
 @rt("/contact", methods=["GET", "POST"])
-def contact(req, sess):
+async def contact(req, sess):
     """Contact page — public route with form submission."""
     if req.method == "POST":
-        # Handle form submission
-        return post_contact(req, sess)
+        # post_contact is async (reads form data); awaited here.
+        return await post_contact(req, sess)
     # GET request — render the form
     return Titled(
         "Contact Us - ViralVibes",

--- a/routes/contact.py
+++ b/routes/contact.py
@@ -28,6 +28,27 @@ logger = logging.getLogger(__name__)
 _MAX_MESSAGE_CHARS = 10_000
 
 
+def _mask_email(email: str) -> str:
+    """Return a privacy-preserving rendering of ``email`` for log lines.
+
+    Keeps the first character of the local part and the full domain so an
+    operator triaging logs can still recognise repeat senders, without
+    putting harvestable addresses in runtime log storage.
+
+    Examples:
+        ``jane@example.com``    -> ``j***@example.com``
+        ``a@example.com``       -> ``*@example.com``
+        ``no-at-sign``          -> ``(no email)``
+    """
+    if not email:
+        return "(no email)"
+    local, sep, domain = email.partition("@")
+    if not sep:
+        return "(invalid email)"
+    masked_local = (local[:1] + "***") if local else "*"
+    return f"{masked_local}@{domain}"
+
+
 # ---------------------------------------------------------------------------
 # Contact Form
 # ---------------------------------------------------------------------------
@@ -210,9 +231,10 @@ def contact_page_content() -> Div:
 async def post_contact(req, sess):
     """Handle contact form submission.
 
-    Reads the form, logs the inquiry at INFO level, and returns the success
-    page. Persistence to ``contact_inquiries`` and transactional-email
-    forwarding land in PR 2b / 2c — see the module docstring.
+    Reads the form, logs a *masked* record of the inquiry at INFO level,
+    and returns the success page. Persistence to ``contact_inquiries``
+    and transactional-email forwarding land in PR 2b / 2c — see the
+    module docstring.
     """
     form = await req.form()
     name = (form.get("name") or "").strip()
@@ -221,12 +243,16 @@ async def post_contact(req, sess):
     message = (form.get("message") or "").strip()[:_MAX_MESSAGE_CHARS]
 
     # Operator-visible record — lands in Vercel runtime logs alongside other
-    # request traffic. Replaced by a DB insert in PR 2b.
+    # request traffic. The email is masked (``j***@example.com``) so the
+    # log line stays operator-useful for triaging repeat senders without
+    # turning runtime logs into a harvestable address list. Full PII lands
+    # in the ``contact_inquiries`` table (PR 2b), which is RLS-restricted
+    # to the service role.
     logger.info(
-        "contact form submission: type=%s from=%s <%s> chars=%d",
+        "contact form submission: type=%s name_present=%s email=%s chars=%d",
         inquiry_type,
-        name or "(no name)",
-        email or "(no email)",
+        bool(name),
+        _mask_email(email),
         len(message),
     )
 

--- a/routes/contact.py
+++ b/routes/contact.py
@@ -1,6 +1,14 @@
 """
 Contact page — inquiry form, support channels, and FAQ.
+
+Form submissions are currently logged at INFO level so the operator has a
+durable record even without backing storage. PR 2b will persist each
+inquiry to ``contact_inquiries`` (migration 041) and PR 2c will add an
+HTTP transactional-email forward to ``CONTACT_EMAIL`` — SMTP from a
+Vercel serverless runtime was rejected as the wrong transport.
 """
+
+import logging
 
 from fasthtml.common import *
 from monsterui.all import *
@@ -12,6 +20,12 @@ from components.page_layout import (
     StaticPage,
 )
 from constants import CONTACT_EMAIL
+
+logger = logging.getLogger(__name__)
+
+# Hard cap so a pasted novel can't blow up the transactional-email payload
+# or fill the log line with megabytes of text.
+_MAX_MESSAGE_CHARS = 10_000
 
 
 # ---------------------------------------------------------------------------
@@ -193,15 +207,28 @@ def contact_page_content() -> Div:
     )
 
 
-def post_contact(req, sess):
+async def post_contact(req, sess):
     """Handle contact form submission.
 
-    Called from main.py's contact route handler.
-    Extracts form data and processes the submission.
+    Reads the form, logs the inquiry at INFO level, and returns the success
+    page. Persistence to ``contact_inquiries`` and transactional-email
+    forwarding land in PR 2b / 2c — see the module docstring.
     """
-    # TODO: Implement email sending or form processing
-    # For now, just return a success message
-    # Form data would be extracted via await req.form() if needed
+    form = await req.form()
+    name = (form.get("name") or "").strip()
+    email = (form.get("email") or "").strip()
+    inquiry_type = (form.get("inquiry_type") or "general").strip()
+    message = (form.get("message") or "").strip()[:_MAX_MESSAGE_CHARS]
+
+    # Operator-visible record — lands in Vercel runtime logs alongside other
+    # request traffic. Replaced by a DB insert in PR 2b.
+    logger.info(
+        "contact form submission: type=%s from=%s <%s> chars=%d",
+        inquiry_type,
+        name or "(no name)",
+        email or "(no email)",
+        len(message),
+    )
 
     return Div(
         Div(

--- a/routes/press.py
+++ b/routes/press.py
@@ -67,9 +67,11 @@ def _format_count(n: int | float | None) -> str:
 
     Wraps the shared ``utils.formatting.format_number`` so the press page
     matches numbers shown elsewhere (e.g. nav, hero) instead of inventing
-    its own "807K" vs "807.0K" rounding rules.
+    its own "807K" vs "807.0K" rounding rules. Only ``None`` is treated as
+    missing — a legitimate zero (e.g. "0 creators in a niche") passes
+    through to ``format_number`` instead of being silently hidden as "—".
     """
-    if not n:
+    if n is None:
         return "—"
     return format_number(n)
 
@@ -84,9 +86,23 @@ def press_page_content() -> Div:
     top_categories = _safe_top_categories(limit=6)
     top_countries = _safe_top_countries(limit=6)
 
+    # Headline numbers — use _format_count so missing data renders as "—"
+    # instead of a misleading "0+ countries" when the stats RPC is down.
+    # The "+" suffix is only appended when we actually have a number, so the
+    # fallback doesn't read as "—+ countries".
     total_creators = _format_count(stats.get("total_creators"))
-    total_countries = stats.get("total_countries") or 0
-    total_languages = stats.get("total_languages") or 0
+    total_countries_raw = stats.get("total_countries")
+    total_languages_raw = stats.get("total_languages")
+    countries_label = (
+        f"{_format_count(total_countries_raw)}+ countries"
+        if total_countries_raw is not None
+        else "Countries tracked"
+    )
+    languages_label = (
+        f"{_format_count(total_languages_raw)}+ languages"
+        if total_languages_raw is not None
+        else "Languages tracked"
+    )
 
     # Headline stat grid — three numbers a reporter can lift verbatim.
     headline_stats = FeatureGrid(
@@ -96,12 +112,12 @@ def press_page_content() -> Div:
                 "YouTube channels in the ViralVibes index, refreshed on a rolling basis.",
             ),
             (
-                f"{total_countries}+ countries",
+                countries_label,
                 "Geographies represented in the creator dataset, normalised for fair "
                 "cross-market comparison.",
             ),
             (
-                f"{total_languages}+ languages",
+                languages_label,
                 "Spoken-content languages covered, enabling discovery beyond English-first "
                 "creator lists.",
             ),

--- a/routes/press.py
+++ b/routes/press.py
@@ -1,0 +1,207 @@
+"""
+Press Kit page — public route for journalists, partners, and analysts.
+
+Renders a one-glance overview of ViralVibes: company description, live
+coverage stats (creator count, country coverage, top categories), and a
+press contact. Stats are queried at request time with graceful fallbacks
+so a DB hiccup degrades to a static-content page instead of a 500.
+"""
+
+import logging
+
+from fasthtml.common import *
+from monsterui.all import *
+
+from components.page_layout import (
+    FeatureGrid,
+    InfoCard,
+    LinkCard,
+    PageSection,
+    StaticPage,
+)
+from constants import CONTACT_EMAIL
+from db_lists import (
+    get_top_categories_with_counts,
+    get_top_countries_with_counts,
+)
+from utils.formatting import format_number
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Live stats — graceful fallbacks so the page is never broken by a DB blip.
+# ---------------------------------------------------------------------------
+
+
+def _safe_hero_stats() -> dict:
+    """Return creator hero stats, or a conservative fallback on any failure."""
+    try:
+        # Imported lazily so a Supabase import-time error can't kill the page.
+        from db import get_creator_hero_stats
+
+        return get_creator_hero_stats() or {}
+    except Exception:
+        logger.warning("press: get_creator_hero_stats failed", exc_info=True)
+        return {}
+
+
+def _safe_top_categories(limit: int = 6) -> list[tuple[str, int]]:
+    try:
+        return get_top_categories_with_counts(limit=limit) or []
+    except Exception:
+        logger.warning("press: get_top_categories_with_counts failed", exc_info=True)
+        return []
+
+
+def _safe_top_countries(limit: int = 6) -> list[tuple[str, int]]:
+    try:
+        return get_top_countries_with_counts(limit=limit) or []
+    except Exception:
+        logger.warning("press: get_top_countries_with_counts failed", exc_info=True)
+        return []
+
+
+def _format_count(n: int | float | None) -> str:
+    """Press-page count formatter — ``format_number`` with an em-dash for missing data.
+
+    Wraps the shared ``utils.formatting.format_number`` so the press page
+    matches numbers shown elsewhere (e.g. nav, hero) instead of inventing
+    its own "807K" vs "807.0K" rounding rules.
+    """
+    if not n:
+        return "—"
+    return format_number(n)
+
+
+# ---------------------------------------------------------------------------
+# Page content
+# ---------------------------------------------------------------------------
+
+
+def press_page_content() -> Div:
+    stats = _safe_hero_stats()
+    top_categories = _safe_top_categories(limit=6)
+    top_countries = _safe_top_countries(limit=6)
+
+    total_creators = _format_count(stats.get("total_creators"))
+    total_countries = stats.get("total_countries") or 0
+    total_languages = stats.get("total_languages") or 0
+
+    # Headline stat grid — three numbers a reporter can lift verbatim.
+    headline_stats = FeatureGrid(
+        [
+            (
+                f"{total_creators} creators tracked",
+                "YouTube channels in the ViralVibes index, refreshed on a rolling basis.",
+            ),
+            (
+                f"{total_countries}+ countries",
+                "Geographies represented in the creator dataset, normalised for fair "
+                "cross-market comparison.",
+            ),
+            (
+                f"{total_languages}+ languages",
+                "Spoken-content languages covered, enabling discovery beyond English-first "
+                "creator lists.",
+            ),
+        ],
+        cols=3,
+    )
+
+    # Top categories — only render if we have data, so the page never shows
+    # an empty grid.
+    category_items = [
+        (label or "—", f"{_format_count(count)} creators") for label, count in top_categories
+    ]
+    category_block = (
+        FeatureGrid(category_items, cols=3)
+        if category_items
+        else P(
+            "Category breakdown is temporarily unavailable.",
+            cls="text-muted-foreground text-sm",
+        )
+    )
+
+    # Top countries rendered as a compact comma-joined sentence — feels more
+    # editorial than another grid in the same page.
+    country_sentence = (
+        ", ".join(f"{code.upper()} ({_format_count(count)})" for code, count in top_countries)
+        if top_countries
+        else "Country breakdown is temporarily unavailable."
+    )
+
+    return StaticPage(
+        "Press Kit",
+        # Lede — the one-paragraph pitch a journalist can quote.
+        PageSection(
+            "About ViralVibes",
+            "ViralVibes is a creator intelligence platform for brands and agencies running "
+            "YouTube campaigns. Instead of picking creators by subscriber count, customers get "
+            "ranked lists built on real engagement signals, growth velocity, and consistency — "
+            "the inputs that actually predict whether a campaign will convert. Anyone can also "
+            "analyze a public playlist for free, with no account required.",
+            variant="lead",
+            eyebrow="01 — Company",
+        ),
+        # Headline stats — the numbers a reporter wants up top.
+        PageSection(
+            "By the numbers",
+            "Live coverage figures from the ViralVibes index.",
+            variant="centered",
+            eyebrow="02 — Scale",
+        ),
+        headline_stats,
+        # Top categories block.
+        PageSection(
+            "Where the coverage is deepest",
+            "The largest categories in our index by tracked-creator count. Numbers update as "
+            "the index grows.",
+            variant="split",
+            eyebrow="03 — Categories",
+        ),
+        category_block,
+        # Top countries — short editorial line, not a grid.
+        PageSection(
+            "Top markets",
+            country_sentence,
+            variant="accent",
+            eyebrow="04 — Geography",
+        ),
+        # Founding thesis — quotable one-liner.
+        PageSection(
+            "The thesis",
+            "Subscriber counts lie. Engagement quality doesn't. ViralVibes was built to give "
+            "marketers a defensible answer to the question 'will this creator actually convert?' "
+            "— before the budget is spent, not after.",
+            variant="lead",
+            eyebrow="05 — Editorial",
+        ),
+        # Press contact + assets.
+        PageSection(
+            "Press contact",
+            "For interviews, custom data pulls, or product questions, please reach out below. "
+            "We typically respond within one business day.",
+            variant="centered",
+            eyebrow="06 — Contact",
+        ),
+        Div(
+            LinkCard(
+                "Email the team",
+                "Press, analyst, and partnership enquiries.",
+                CONTACT_EMAIL,
+                f"mailto:{CONTACT_EMAIL}?subject=Press%20enquiry%20—%20ViralVibes",
+                variant="accent",
+            ),
+            InfoCard(
+                "Product screenshots",
+                P(
+                    "High-resolution screenshots and brand assets are available on request — "
+                    "email the address above and we will share a download link.",
+                    cls="text-muted-foreground leading-relaxed text-sm",
+                ),
+                variant="tinted",
+            ),
+            cls="grid grid-cols-1 md:grid-cols-2 gap-5",
+        ),
+    )


### PR DESCRIPTION
SMTP from Vercel serverless is the wrong transport (blocking outbound, no pooling, ProtonMail rejects plain SMTP anyway). Strip the smtplib machinery from routes/contact.py; the route keeps reading the form and logs the submission so nothing regresses.

Add migration 041 introducing contact_inquiries with length/type CHECK constraints, three purpose-built indexes (admin list, per-IP rate lookup, retry queue), and RLS enabled with zero policies so the anon key can never reach the PII.

Add db.py helpers — insert_contact_inquiry, count_contact_inquiries_ from_ip, mark_contact_inquiry_forwarded, mark_contact_inquiry_forward_ error — staged for PR 2b (DB wiring) and PR 2c (Resend forward).

## Summary by Sourcery

Introduce a persisted contact inquiry system and add a public press kit page while simplifying the contact form handler.

New Features:
- Add a contact_inquiries table via migration 041 to store contact form submissions with constraints, indexes, and RLS protection.
- Expose a new /press route and press kit page that surfaces live creator stats, top categories, and top countries with graceful fallbacks.

Enhancements:
- Add database helpers for inserting and updating contact inquiry records, including rate-limit lookups and forwarding status tracking.
- Update the contact form POST handler and route to be async, parse form fields, and log submissions with a defensive message length cap.