### PR TITLE
feat(creators): expand lookalike landing page to 50, slim profile rai…

### DIFF
--- a/components/cards.py
+++ b/components/cards.py
@@ -120,7 +120,7 @@ _TICKER_ITEMS = [
     ("📈", "Growth Rate", "+34%"),
     ("🎯", "CTR", "6.1%"),
     ("⏱", "Watch Time", "14m 22s"),
-    ("🏆", "Top Creator", "MrBeast"),
+    ("🏆", "Top Niche", "Gaming"),
     ("📊", "Playlists", "10,419"),
     ("⚡", "Real-time", "< 2 sec"),
     ("🌐", "Countries", "142"),
@@ -234,9 +234,9 @@ def _product_switcher() -> Div:
             Span("🇺🇸 United States", style="font-size:0.65rem;color:rgba(255,255,255,0.3);"),
             style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.75rem;",
         ),
-        _creator_row(1, "MrBeast", "Entertainment", 9.4),
-        _creator_row(2, "Mark Rober", "Science", 8.1),
-        _creator_row(3, "MKBHD", "Tech", 7.6),
+        _creator_row(1, "Creator A", "Entertainment", 9.4),
+        _creator_row(2, "Creator B", "Science", 8.1),
+        _creator_row(3, "Creator C", "Tech", 7.6),
         Div(
             UkIcon("trending-up", cls="w-3 h-3"),
             Span("Updated 2h ago"),
@@ -261,7 +261,7 @@ def _product_switcher() -> Div:
 
     creator_panel = Div(
         Div(
-            Div("Mark Rober", style="font-size:0.85rem;font-weight:700;color:#fff;"),
+            Div("Creator B", style="font-size:0.85rem;font-weight:700;color:#fff;"),
             Span(
                 "Science & Education",
                 style="font-size:0.6rem;background:rgba(239,68,68,0.15);color:#f87171;border-radius:9999px;padding:0.15rem 0.5rem;",

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -537,7 +537,13 @@ def creator_profile_route(request, creator_id: str, user_id: str | None = None):
     niche_leaderboard = get_category_leaderboard(creator.get("primary_category", ""), limit=5)
     is_fav = is_creator_favourited(user_id, creator_id) if user_id else False
     similar_creators = _get_similar_creators(creator)
-    embedding_peers = get_embedding_peers(creator_id)
+    # Fetch the full peer list once (cheap: one JSONB read + one IN-list hydrate)
+    # then slice for the profile rail. The total length drives the CTA copy on
+    # the rail ("See N more lookalikes for X") so users know there's more on
+    # the dedicated landing page.
+    embedding_peers_full = get_embedding_peers(creator_id, limit=LOOKALIKE_LIMIT) or []
+    embedding_peers = embedding_peers_full[:_PROFILE_PEER_RAIL_LIMIT] or None
+    embedding_peer_total = len(embedding_peers_full)
 
     return render_creator_profile_page(
         creator,
@@ -549,6 +555,7 @@ def creator_profile_route(request, creator_id: str, user_id: str | None = None):
         is_favourited=is_fav,
         similar_creators=similar_creators,
         embedding_peers=embedding_peers,
+        embedding_peer_total=embedding_peer_total,
     )
 
 
@@ -948,7 +955,11 @@ def creators_top_route(request, *, category_slug: str | None = None):
 #   * Reuses ContactExtractorService for the export so the CSV shape stays
 #     identical to /me/outreach/export and the admin bulk export.
 
-LOOKALIKE_LIMIT = 20  # peers shown on /creators/like/{handle}
+LOOKALIKE_LIMIT = 50  # peers shown on /creators/like/{handle} (SEO destination)
+# Profile-page rail is intentionally shorter than the landing page so the CTA
+# ("See N more lookalikes for X") has real information scent. Matches the
+# fold-friendly 8-tile shape used by the category-leaderboard rail above.
+_PROFILE_PEER_RAIL_LIMIT = 8
 
 
 @dataclass(frozen=True)

--- a/views/creators.py
+++ b/views/creators.py
@@ -3013,6 +3013,7 @@ def render_creator_profile_page(
     niche_leaderboard: list[dict] | None = None,
     recent_upload: dict | None = None,
     embedding_peers: list[dict] | None = None,
+    embedding_peer_total: int = 0,
 ) -> Div:
     """
     Full-page creator profile — award-showcase design.
@@ -4249,20 +4250,28 @@ def render_creator_profile_page(
     # Passing None means the caller found no row in creator_peers → hide section.
     # ═══════════════════════════════════════════════════════════════════════════
     # When embedding peers exist we also offer a one-click jump to the full
-    # /creators/like/{handle} landing page (20 peers + CSV export). Handle
-    # slug is sourced from custom_url so it matches the public URL shape.
+    # /creators/like/{handle} landing page (shareable URL + optional CSV
+    # contact export when peers have contact info). Handle slug is sourced
+    # from custom_url so it matches the public URL shape; custom_url is
+    # stored lowercase without "@", which is exactly what the route expects.
+    # CTA copy surfaces the additional peers available on the landing page
+    # (embedding_peer_total counts the full peer list; the rail is a slice)
+    # so users get real information scent for clicking through.
+    # ═══════════════════════════════════════════════════════════════════════════
     _peer_handle_slug = (custom_url or "").lstrip("@").lower()
+    _extra_peers = max(0, embedding_peer_total - len(embedding_peers or []))
+    _cta_label = (
+        f"See {_extra_peers} more lookalikes for {channel_name} →"
+        if _extra_peers > 0
+        else f"Open the lookalike page for {channel_name} →"
+    )
     _lookalike_cta = (
         Div(
             A(
-                Span(
-                    f"See all {len(embedding_peers)} lookalikes for " f"{channel_name} ",
-                    cls="font-medium",
-                ),
-                Span("with verified contacts →", cls="text-muted-foreground"),
+                _cta_label,
                 href=f"/creators/like/{_peer_handle_slug}",
                 cls=(
-                    "inline-flex items-center gap-1 text-sm "
+                    "inline-flex items-center gap-1 text-sm font-medium "
                     "text-primary hover:underline no-underline"
                 ),
             ),

--- a/views/creators.py
+++ b/views/creators.py
@@ -4260,8 +4260,9 @@ def render_creator_profile_page(
     # ═══════════════════════════════════════════════════════════════════════════
     _peer_handle_slug = (custom_url or "").lstrip("@").lower()
     _extra_peers = max(0, embedding_peer_total - len(embedding_peers or []))
+    _noun = "lookalike" if _extra_peers == 1 else "lookalikes"
     _cta_label = (
-        f"See {_extra_peers} more lookalikes for {channel_name} →"
+        f"See {_extra_peers} more {_noun} for {channel_name} →"
         if _extra_peers > 0
         else f"Open the lookalike page for {channel_name} →"
     )


### PR DESCRIPTION
…l to 8

The profile-page embedding rail and the /creators/like/{handle} landing page both fetched 20 peers and rendered the same content. Two issues:

  1. The "See all lookalikes" CTA had no real information scent — the destination showed the exact same peer count in a different layout.
  2. 20 tiles is more than users typically consume in a "more like this" rail; the inline real estate was overspent.

Split the budgets so each surface plays to its strength:

  - Profile rail: cap at 8 (fold-friendly, matches the leaderboard rail above it). The CTA now reads "See N more lookalikes for X →" when the full peer list exceeds the rail size, giving the click real payoff. Falls back to neutral copy when the gap is zero.
  - Landing page: bump LOOKALIKE_LIMIT 20 → 50 so the SEO destination competes with category pages on density and is worth sharing.

Threads embedding_peer_total through render_creator_profile_page so the CTA copy can be computed without an extra DB call.

Also fixes an over-promise in the previous CTA copy ("with verified contacts") — that promise only holds when contact_count > 0 on the landing page, which the rail can't know without another round trip.

Note: requires re-running the offline embedding job with TOP_K=50 (currently 20) for the landing page to actually receive 50 peers. Until then the page renders whatever peer_list length is stored — the rail behaviour is already correct against existing data.

## Summary by Sourcery

Adjust creator lookalike surfaces to better differentiate the inline profile rail from the dedicated landing page and improve CTA relevance.

New Features:
- Show a concise lookalike rail on creator profiles with CTA text that reflects how many additional peers are available on the dedicated landing page.

Enhancements:
- Increase the lookalike landing page peer limit from 20 to 50 while capping the profile-page rail at 8 items so each surface is tailored to its use case.
- Thread the total embedding peer count from the route into the profile renderer so CTA copy can be computed without extra database calls.
- Refresh demo card copy to use neutral placeholder creator names and updated metric labels.