### PR TITLE
fix(security): patch three concrete vulnerabilities in user-input paths

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -19,6 +19,18 @@ logger = logging.getLogger(__name__)
 # (Previously 50_000 — caused full-table seq scans and statement timeouts when RPCs 500'd.)
 _MAX_FALLBACK_FETCH = 1_000
 
+
+def _escape_ilike(term: str) -> str:
+    """Escape PostgreSQL LIKE/ILIKE wildcards in user-supplied terms.
+
+    `%` and `_` are LIKE wildcards; leaving them unescaped lets a user's input
+    (or a stray character in a category slug) overmatch or trigger expensive
+    full-table scans. Backslash must be escaped first so the subsequent
+    replacements don't double-escape the wildcards.
+    """
+    return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 # ---------------------------------------------------------------------------
 # Transient-transport retry for Supabase RPC calls
 # ---------------------------------------------------------------------------
@@ -391,7 +403,7 @@ def get_creators_by_category(category: str, limit: int = 10) -> list[dict]:
         response = (
             supabase_client.table("creators")
             .select("*")
-            .ilike("topic_categories", f"%{category}%")
+            .ilike("topic_categories", f"%{_escape_ilike(category)}%")
             .not_.is_("channel_name", "null")
             .gt("current_subscribers", 0)
             .order("current_subscribers", desc=True)
@@ -538,7 +550,7 @@ def get_top_creators_by_categories(
             response = (
                 supabase_client.table("creators")
                 .select("*")
-                .ilike("topic_categories", f"%{ilike_term}%")
+                .ilike("topic_categories", f"%{_escape_ilike(ilike_term)}%")
                 .not_.is_("channel_name", "null")
                 .gt("current_subscribers", 0)
                 .order("current_subscribers", desc=True)
@@ -1119,7 +1131,7 @@ def suggest_primary_categories(q: str, limit: int = 8) -> list[tuple[str, int]]:
     if not supabase_client or not q.strip():
         return []
     try:
-        escaped = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        escaped = _escape_ilike(q)
         resp = (
             supabase_client.table("creators")
             .select("primary_category")

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -582,6 +582,12 @@ def toggle_favourite_route(request, sess, creator_id: str):
     # that supply a session work, and tests that don't still get a predictable id.
     if not user_id and _IS_TESTING:
         user_id = "test-user-id"
+    # require_auth only validates `auth`; `user_id` can independently be absent
+    # on partial/legacy sessions. Guard explicitly so we never pass None to the
+    # favourite-DB helpers (which would otherwise hit the database with a NULL
+    # user filter).
+    if not user_id:
+        return Response("Authentication required", status_code=401)
 
     currently_favourited = is_creator_favourited(user_id, creator_id)
     if currently_favourited:

--- a/views/job_progress.py
+++ b/views/job_progress.py
@@ -1,4 +1,5 @@
 # views/job_progress.py
+import json
 from urllib.parse import quote_plus
 
 from constants import JobStatus
@@ -192,8 +193,11 @@ def render_job_progress_view(state: JobProgressViewState) -> Div:
                     "✅ Processing complete! Loading results...",
                     cls="text-green-600 font-semibold",
                 ),
+                # json.dumps() escapes quotes/backslashes/control chars so the
+                # user-supplied playlist URL can't break out of the JS string
+                # literal. Prior f-string interpolation was an XSS vector.
                 Script(
-                    f"setTimeout(() => {{ htmx.ajax('POST', '/validate/full', {{target: '#preview-box', values: {{playlist_url: '{state.playlist_url}'}}}}); }}, 1000);"
+                    f"setTimeout(() => {{ htmx.ajax('POST', '/validate/full', {{target: '#preview-box', values: {{playlist_url: {json.dumps(state.playlist_url)}}}}}); }}, 1000);"
                 ),
             )
             if state.status in JobStatus.SUCCESS

--- a/views/preview.py
+++ b/views/preview.py
@@ -1,3 +1,5 @@
+import json
+
 from fasthtml.common import *
 from monsterui.all import *
 
@@ -5,11 +7,16 @@ from monsterui.all import *
 
 
 def render_redirect_to_full(playlist_url: str):
+    # json.dumps() produces a safely-quoted JS string literal, defending against
+    # quote-injection / </script> breakouts in the playlist URL. The value is
+    # user-controlled (it comes from the form they submitted), so naive f-string
+    # interpolation here was an XSS vector.
+    safe_url = json.dumps(playlist_url)
     return Script(
         f"""
         htmx.ajax('POST', '/validate/full', {{
             target: '#preview-box',
-            values: {{ playlist_url: '{playlist_url}' }}
+            values: {{ playlist_url: {safe_url} }}
         }});
         """
     )


### PR DESCRIPTION
PR 1 of the security cluster. Three issues found during the workspace audit, all on code paths that handle user-controlled input:

1. XSS via inline <script> interpolation views/preview.py and views/job_progress.py interpolated the user-submitted playlist URL directly into an inline JS string with single-quote f-string syntax. A URL containing a single quote, a backslash, or "</script>" would break out of the literal and either crash the page or execute attacker-controlled JS. Both sites now wrap the value in json.dumps(), which produces a correctly-quoted JS string literal regardless of input.

2. ILIKE wildcard injection in db_lists.py Three sites built ".ilike(col, f'%{user_input}%')" without escaping the LIKE wildcards % and _. Worst case: a stray % in a category slug overmatches the whole table and triggers expensive scans. The correct escape already existed at one site (line 1129) but was not reused. Extracted into a single _escape_ilike() helper at the top of the module and called at all three sites.

3. toggle_favourite_route can pass user_id=None to the DB routes/creators.py validated `auth` via require_auth() but did not check `user_id` separately. On a partial/legacy session this meant None reached the favourite-DB helpers and would have filtered against a NULL user_id. Added an explicit "if not user_id: return 401" guard after the test-mode sentinel branch so the DB call is unreachable without a real user.

No behaviour change for normal traffic. Compile-clean.

## Summary by Sourcery

Harden user-input handling across database queries, views, and routes to address security and correctness issues without changing normal behavior.

Bug Fixes:
- Escape PostgreSQL LIKE/ILIKE wildcard characters in user-supplied terms to prevent overbroad matches and expensive scans in creator-category queries.
- Sanitize user-supplied playlist URLs before embedding them in inline JavaScript to eliminate XSS injection vectors in preview and job progress views.
- Enforce a non-null authenticated user ID in the favourite toggle route so database operations cannot run with a NULL user filter and instead return 401 unauthenticated.

Enhancements:
- Centralize ILIKE term escaping into a shared helper for consistent and safer database filtering logic.