### PR TITLE
feat(auth): update login prompts to emphasize Google sign-in

### DIFF
--- a/components/auth_dropdown.py
+++ b/components/auth_dropdown.py
@@ -37,7 +37,7 @@ def AuthDropdown(
     # --- LOGGED OUT STATE ---
     if not user or not user.get("user_id"):
         return A(
-            "Log in",
+            "Sign in with Google",
             href=login_href,
             cls=f"{ButtonT.primary} text-sm",
         )

--- a/components/navigation.py
+++ b/components/navigation.py
@@ -4,12 +4,28 @@ Shows personalized content when user is logged in (avatar dropdown with menu).
 """
 
 import logging
+from urllib.parse import urlencode
 
 from fasthtml.common import *
 from monsterui.all import *
 
 from .auth_dropdown import AuthDropdown
 from routes.admin import _is_admin  # ✅ Import admin check
+
+
+def _current_return_url(req) -> str:
+    """Return the current same-site path for post-login continuation."""
+    if not req:
+        return "/"
+    path = req.url.path or "/"
+    if path in {"/login", "/login/new", "/login/onetap", "/redirect"}:
+        return "/"
+    query = getattr(req.url, "query", "")
+    return f"{path}?{query}" if query else path
+
+
+def _branded_login_href(req) -> str:
+    return f"/login?{urlencode({'return_url': _current_return_url(req)})}"
 
 
 def _nav_link_cls(req, path):
@@ -92,15 +108,10 @@ def NavComponent(oauth, req=None, sess=None):
     # Build auth section (right side of navbar)
     # ============================================================================
 
-    # Get login URL with fallback (used by both AuthDropdown and fallback button)
-    login_href = "/login"
-    if oauth and req:
-        try:
-            login_url = oauth.login_link(req)
-            if login_url and isinstance(login_url, str):
-                login_href = login_url
-        except Exception as e:
-            logging.warning(f"Failed to generate OAuth login link: {e}")
+    # Route logged-out users through the branded login page so it is clear that
+    # Google OAuth is the next step. The login card still owns the direct OAuth
+    # URL, preserving the legacy path in one place.
+    login_href = _branded_login_href(req)
 
     if is_authenticated:
         # ✅ LOGGED IN: Use AuthDropdown component
@@ -145,7 +156,7 @@ def NavComponent(oauth, req=None, sess=None):
         )
 
     else:
-        # ❌ LOGGED OUT: Single conversion action — Sign in.
+        # ❌ LOGGED OUT: Single conversion action — Sign in with Google.
         # Nav links already cover all discovery destinations. The only thing
         # missing for a guest is a way in. Mirroring Linear/Vercel/Notion pattern:
         # nav handles "where to go", CTA handles "what to do" — they never overlap.
@@ -153,7 +164,7 @@ def NavComponent(oauth, req=None, sess=None):
         # NavBar's internal flex layout treats both auth states consistently.
         auth_section = Div(
             A(
-                "Sign in",
+                "Sign in with Google",
                 href=login_href,
                 cls="btn-cta-primary text-sm",
             ),

--- a/main.py
+++ b/main.py
@@ -384,7 +384,10 @@ def login(req, sess):
     # clear any stale URLs so they get redirected to homepage after login
     normalize_intended_url(sess)
 
-    return_url = safe_local_return_url(req.query_params.get("return_url"), default="/")
+    return_url = safe_local_return_url(
+        req.query_params.get("return_url") or req.query_params.get("return_to"),
+        default="/",
+    )
 
     # Consume any contextual message set by a pre-auth redirect (e.g. checkout)
     subheadline = sess.pop("login_context", None) or login_subheadline_for_return_url(return_url)
@@ -406,7 +409,10 @@ def login_onetap_test(req, sess):
     """
     # Normalize session: clear stale intended_url if this was a manual visit
     normalize_intended_url(sess)
-    return_url = safe_local_return_url(req.query_params.get("return_url"), default="/")
+    return_url = safe_local_return_url(
+        req.query_params.get("return_url") or req.query_params.get("return_to"),
+        default="/",
+    )
     subheadline = sess.pop("login_context", None) or login_subheadline_for_return_url(return_url)
 
     # Use unified builder with force new UI (respects sess['intended_url'])
@@ -431,7 +437,10 @@ def login_new_ui(req, sess):
     """
     # Normalize session: clear stale intended_url if this was a manual visit
     normalize_intended_url(sess)
-    return_url = safe_local_return_url(req.query_params.get("return_url"), default="/")
+    return_url = safe_local_return_url(
+        req.query_params.get("return_url") or req.query_params.get("return_to"),
+        default="/",
+    )
     subheadline = sess.pop("login_context", None) or login_subheadline_for_return_url(return_url)
 
     # Use unified builder but FORCE new UI (respects sess['intended_url'])

--- a/routes/pricing.py
+++ b/routes/pricing.py
@@ -89,7 +89,7 @@ def _free_cta_target(is_authenticated: bool) -> tuple[str, str]:
     """Return (href, label) for the free-tier CTA based on auth state."""
     if is_authenticated:
         return "/creators", "Go to creators"
-    return "/login?return_url=/creators", "Get started free"
+    return "/login?return_url=/creators", "Start free with Google"
 
 
 def _free_card(is_authenticated: bool) -> Div:
@@ -127,7 +127,17 @@ def _free_card(is_authenticated: bool) -> Div:
     )
 
 
-def _pro_card() -> Div:
+def _checkout_hint(is_authenticated: bool) -> P | None:
+    if is_authenticated:
+        return None
+    return P(
+        "Google sign-in first; Stripe checkout follows.",
+        cls="text-xs text-muted-foreground text-center -mt-5 mb-6",
+    )
+
+
+def _pro_card(is_authenticated: bool) -> Div:
+    cta_label = "Start Pro free for 7 days" if is_authenticated else "Start Pro trial with Google"
     return Div(
         # "Most popular" badge positioned above the card border
         Div(
@@ -151,13 +161,14 @@ def _pro_card() -> Div:
             Input(type="hidden", name="plan", value="pro"),
             Input(type="hidden", name="interval", value="year"),
             Button(
-                "Start Pro free for 7 days",
+                cta_label,
                 type="submit",
                 cls=(ButtonT.primary, "block w-full text-center font-semibold text-sm py-2.5 mb-8"),
             ),
             method="post",
             action="/billing/checkout",
         ),
+        _checkout_hint(is_authenticated),
         Ul(
             _feature("Everything in Free", bold=True, color="red"),
             _feature("Unlimited saved dashboards", color="red"),
@@ -174,7 +185,10 @@ def _pro_card() -> Div:
     )
 
 
-def _agency_card() -> Div:
+def _agency_card(is_authenticated: bool) -> Div:
+    cta_label = (
+        "Start Agency free for 7 days" if is_authenticated else "Start Agency trial with Google"
+    )
     return Div(
         Div(
             P(
@@ -193,7 +207,7 @@ def _agency_card() -> Div:
             Input(type="hidden", name="plan", value="agency"),
             Input(type="hidden", name="interval", value="year"),
             Button(
-                "Start Agency free for 7 days",
+                cta_label,
                 type="submit",
                 cls=(
                     "block w-full text-center font-semibold text-sm py-2.5 mb-8 rounded-lg "
@@ -204,6 +218,7 @@ def _agency_card() -> Div:
             method="post",
             action="/billing/checkout",
         ),
+        _checkout_hint(is_authenticated),
         Ul(
             _feature("Everything in Pro", bold=True),
             _feature("Unlimited shortlists & creators"),
@@ -340,7 +355,7 @@ def _comparison_table() -> Div:
 
 def _bottom_cta(is_authenticated: bool) -> Div:
     cta_href, _ = _free_cta_target(is_authenticated)
-    cta_label = "Start browsing creators" if is_authenticated else "Get started free"
+    cta_label = "Start browsing creators" if is_authenticated else "Start free with Google"
     return Div(
         P(
             "Still deciding?",
@@ -411,8 +426,8 @@ def pricing_page_content(error: str = "", *, is_authenticated: bool) -> Div:
         # items-start so the Pro card badge overflow doesn't clip siblings
         Div(
             _free_card(is_authenticated),
-            _pro_card(),
-            _agency_card(),
+            _pro_card(is_authenticated),
+            _agency_card(is_authenticated),
             cls="grid grid-cols-1 md:grid-cols-3 gap-8 items-start",
         ),
         # ── Trust strip ───────────────────────────────────────────────────

--- a/tests/test_auth_conversion.py
+++ b/tests/test_auth_conversion.py
@@ -1,4 +1,5 @@
 from controllers.auth_routes import login_subheadline_for_return_url, safe_local_return_url
+from components.navigation import _branded_login_href
 from routes.pricing import _free_cta_target
 
 
@@ -22,4 +23,15 @@ def test_login_subheadline_for_free_pricing_path():
 def test_free_pricing_cta_preserves_creator_intent():
     href, label = _free_cta_target(is_authenticated=False)
     assert href == "/login?return_url=/creators"
-    assert label == "Get started free"
+    assert label == "Start free with Google"
+
+
+def test_nav_login_uses_branded_login_with_current_path():
+    class URL:
+        path = "/pricing"
+        query = "utm_source=test"
+
+    class Req:
+        url = URL()
+
+    assert _branded_login_href(Req()) == "/login?return_url=%2Fpricing%3Futm_source%3Dtest"

--- a/views/creators.py
+++ b/views/creators.py
@@ -80,6 +80,10 @@ _CLS_ICON_SM = "size-4 mr-1.5"
 _CLS_SEPARATOR = "text-border mx-1"  # mid-dot "·" between inline items
 
 
+def _login_href(return_url: str = "/creators") -> str:
+    return f"/login?{urlencode({'return_url': return_url})}"
+
+
 # Brand-accurate colours keyed by Lucide icon name
 _SOCIAL_COLOURS = {
     "instagram": "text-pink-500 hover:text-pink-600",
@@ -2651,8 +2655,8 @@ def _render_handle_not_found_banner(search: str, is_authenticated: bool) -> Div:
     else:
         action = A(
             UkIcon("log-in", cls=_CLS_ICON_SM),
-            "Log in to add",
-            href="/login",
+            "Sign in with Google to add",
+            href=_login_href(f"/creators?search={quote_plus(search)}" if search else "/creators"),
             cls="inline-flex items-center px-4 py-1.5 text-sm font-semibold rounded-lg "
             "border border-border hover:bg-accent transition-colors shrink-0",
         )
@@ -2727,8 +2731,8 @@ def _render_empty_state(
         else:
             add_cta = A(
                 UkIcon("log-in", cls=_CLS_ICON_SM),
-                "Log in to add this creator",
-                href=f"/login",
+                "Sign in with Google to add this creator",
+                href=_login_href(f"/creators?search={quote_plus(search)}"),
                 cls="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg "
                 "border border-border hover:bg-accent transition-colors",
             )
@@ -2783,7 +2787,13 @@ def _render_empty_state(
             )
         else:
             submit_area = P(
-                A("Log in", href="/login", cls="text-primary hover:underline font-medium"),
+                A(
+                    "Sign in with Google",
+                    href=_login_href(
+                        f"/creators?search={quote_plus(search)}" if search else "/creators"
+                    ),
+                    cls="text-primary hover:underline font-medium",
+                ),
                 " to submit a creator by @handle.",
                 cls=_CLS_MUTED_SM,
             )

--- a/views/lists.py
+++ b/views/lists.py
@@ -7,7 +7,7 @@ import logging
 import pycountry
 from fasthtml.common import *
 from monsterui.all import *
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 from utils import format_number, safe_get_value, slugify
 from utils.creator_metrics import (
@@ -21,6 +21,10 @@ from utils.creator_metrics import (
 from views.creators import get_topic_category_emoji
 
 logger = logging.getLogger(__name__)
+
+
+def _login_href(return_url: str = "/lists") -> str:
+    return f"/login?{urlencode({'return_url': return_url})}"
 
 
 def _render_lists_editors_rail() -> "Div":
@@ -395,8 +399,8 @@ def _list_heart_btn(
         return A(
             UkIcon("heart", cls="size-4 text-gray-200"),
             id=btn_id,
-            href="/login",
-            title="Sign in to save lists to your dashboard",
+            href=_login_href(list_url or "/lists"),
+            title="Sign in with Google to save lists to your dashboard",
             cls="inline-flex items-center p-1",
         )
     return Form(


### PR DESCRIPTION
## Summary by Sourcery

Emphasize Google sign-in as the primary authentication path across navigation, pricing, and creator/list views while routing users through a branded login page that preserves post-login return URLs.

New Features:
- Introduce helpers to generate branded login URLs that capture the current or intended return path for post-login redirects.
- Add contextual checkout messaging on pricing pages to clarify that Google sign-in precedes Stripe checkout for unauthenticated users.

Enhancements:
- Update navigation, pricing CTAs, auth dropdown, and creator/list actions to use Google-focused sign-in labels and routes.
- Extend login handlers to accept both return_url and return_to query parameters for safer and more flexible redirect handling.

Tests:
- Add a regression test to verify that the nav login link uses the branded login route with the current path encoded as the return_url.