### PR TITLE
feat(mentions): add mentions feature with lazy-loading for creator profiles

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,6 +120,7 @@ from routes.creators import (
     creators_top_route,
     toggle_favourite_route,
 )
+from routes.mentions import mentions_route
 from routes.about import about_page_content
 from routes.contact import contact_page_content, post_contact
 from routes.legal import privacy_page_content, terms_page_content
@@ -1447,6 +1448,10 @@ def lists_language_detail(req, sess, language_code: str):
             page_content,
         ),
     )
+
+
+# Wire mentions route (must come before generic /creator/{creator_id} for path resolution)
+rt("/creator/{creator_id}/mentions")(mentions_route)
 
 
 @rt("/creator/{creator_id}")

--- a/routes/mentions.py
+++ b/routes/mentions.py
@@ -1,0 +1,40 @@
+"""
+routes/mentions.py
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Single endpoint: GET /creator/{creator_id}/mentions
+
+Called by the HTMX placeholder in the profile page after it renders.
+Fetches both feeds, renders the card, and returns the HTML fragment.
+
+Wire into main.py:
+    from routes.mentions import mentions_route
+    rt("/creator/{creator_id}/mentions")(mentions_route)
+"""
+
+from __future__ import annotations
+
+from db import get_creator_stats
+from services.mentions import get_mentions
+from views.mentions import render_mentions_card, render_mentions_error
+
+
+def mentions_route(req, sess, creator_id: str):
+    """GET /creator/{creator_id}/mentions — HTMX lazy-load fragment."""
+    try:
+        creator = get_creator_stats(creator_id)
+        if not creator:
+            return render_mentions_error()
+
+        channel_id = creator.get("channel_id", "")
+        channel_name = creator.get("channel_name", "")
+
+        if not channel_id or not channel_name:
+            return render_mentions_error()
+
+        bundle = get_mentions(channel_id, channel_name)
+        return render_mentions_card(bundle)
+
+    except Exception as exc:
+        # Fail silently — mentions are supplementary, not critical
+        print(f"[mentions_route] error for {creator_id}: {exc!r}")
+        return render_mentions_error()

--- a/routes/mentions.py
+++ b/routes/mentions.py
@@ -13,9 +13,13 @@ Wire into main.py:
 
 from __future__ import annotations
 
+import logging
+
 from db import get_creator_stats
 from services.mentions import get_mentions
 from views.mentions import render_mentions_card, render_mentions_error
+
+logger = logging.getLogger(__name__)
 
 
 def mentions_route(req, sess, creator_id: str):
@@ -36,5 +40,11 @@ def mentions_route(req, sess, creator_id: str):
 
     except Exception as exc:
         # Fail silently — mentions are supplementary, not critical
-        print(f"[mentions_route] error for {creator_id}: {exc!r}")
+        logger.error(
+            "mentions_route error while rendering mentions card",
+            extra={
+                "creator_id": creator_id,
+                "exception": repr(exc),
+            },
+        )
         return render_mentions_error()

--- a/services/mentions.py
+++ b/services/mentions.py
@@ -15,6 +15,7 @@ the upstream feeds.
 
 from __future__ import annotations
 
+import logging
 import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
@@ -23,6 +24,8 @@ from typing import Optional
 from urllib.parse import quote_plus
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 # ── Models ─────────────────────────────────────────────────────────────────
 
@@ -59,8 +62,12 @@ class MentionBundle:
 
 
 # ── In-process cache (TTL: 30 minutes) ────────────────────────────────────
+#
+# TTL keeps entries fresh, and a max size cap prevents unbounded growth
+# across many channel_id/channel_name pairs.
 
 _CACHE_TTL = 30 * 60  # seconds
+_MAX_CACHE_ENTRIES = 128  # hard cap to avoid unbounded growth
 _cache: dict[str, MentionBundle] = {}
 
 
@@ -76,7 +83,32 @@ def _cached(channel_id: str, channel_name: str) -> Optional[MentionBundle]:
     return None
 
 
+def _prune_cache_now() -> None:
+    """Evict expired entries and trim cache down to _MAX_CACHE_ENTRIES.
+
+    Called opportunistically on cache writes so the cache can't grow
+    without bound in higher-tenant scenarios.
+    """
+    if not _cache:
+        return
+
+    now = time.monotonic()
+
+    # Drop anything older than TTL.
+    expired_keys = [key for key, bundle in _cache.items() if now - bundle.fetched_at > _CACHE_TTL]
+    for key in expired_keys:
+        _cache.pop(key, None)
+
+    # Enforce max size, evicting oldest first by fetched_at.
+    excess = len(_cache) - _MAX_CACHE_ENTRIES
+    if excess > 0:
+        # Sort by fetched_at so we remove the stalest entries first.
+        for key, _bundle in sorted(_cache.items(), key=lambda item: item[1].fetched_at)[:excess]:
+            _cache.pop(key, None)
+
+
 def _store(bundle: MentionBundle) -> None:
+    _prune_cache_now()
     _cache[_cache_key(bundle.channel_id, bundle.channel_name)] = bundle
 
 
@@ -93,10 +125,11 @@ _YT_NS = {
 
 
 def _parse_yt_date(raw: str) -> str:
-    """Convert ISO-8601 to a readable 'Jan 5 2025' string."""
+    """Convert ISO-8601 to a readable 'Jan 5 2025' string (platform-agnostic)."""
     try:
         dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-        return dt.strftime("%-d %b %Y")
+        # Use platform-agnostic formatting: compose from day + strftime
+        return f"{dt.day} {dt.strftime('%b %Y')}"
     except Exception:
         return raw[:10]
 
@@ -108,13 +141,19 @@ def fetch_recent_videos(channel_id: str, limit: int = 6) -> list[VideoItem]:
             resp = client.get(url, headers={"User-Agent": "ViralVibesBot/1.0"})
             resp.raise_for_status()
     except Exception as exc:
-        print(f"[mentions/youtube_rss] failed for {channel_id}: {exc!r}")
+        logger.error(
+            "Failed to fetch YouTube RSS feed",
+            extra={"channel_id": channel_id, "exception": repr(exc)},
+        )
         return []
 
     try:
         root = ET.fromstring(resp.text)
     except ET.ParseError as exc:
-        print(f"[mentions/youtube_rss] XML parse error for {channel_id}: {exc!r}")
+        logger.error(
+            "Failed to parse YouTube RSS XML",
+            extra={"channel_id": channel_id, "exception": repr(exc)},
+        )
         return []
 
     videos: list[VideoItem] = []
@@ -160,7 +199,6 @@ def fetch_recent_videos(channel_id: str, limit: int = 6) -> list[VideoItem]:
 # Google exposes this as their official RSS product; it's not scraping.
 
 _GNEWS_RSS = "https://news.google.com/rss/search?q={query}&hl=en&gl=US&ceid=US:en"
-_GNEWS_NS = {"": "http://www.w3.org/2005/Atom"}
 
 
 def _strip_source(title: str) -> tuple[str, str]:
@@ -175,13 +213,14 @@ def _strip_source(title: str) -> tuple[str, str]:
 
 
 def _parse_gnews_date(raw: str) -> str:
-    """Convert RFC-2822 pubDate to a readable string."""
+    """Convert RFC-2822 pubDate to a readable string (platform-agnostic)."""
     try:
         # e.g. 'Mon, 05 Jan 2026 10:00:00 GMT'
         from email.utils import parsedate_to_datetime
 
         dt = parsedate_to_datetime(raw)
-        return dt.strftime("%-d %b %Y")
+        # Use platform-agnostic formatting: compose from day + strftime
+        return f"{dt.day} {dt.strftime('%b %Y')}"
     except Exception:
         return raw[:16] if raw else ""
 
@@ -199,13 +238,19 @@ def fetch_news_mentions(
             resp = client.get(url, headers={"User-Agent": "ViralVibesBot/1.0"})
             resp.raise_for_status()
     except Exception as exc:
-        print(f"[mentions/google_news] failed for {channel_name!r}: {exc!r}")
+        logger.error(
+            "Failed to fetch Google News RSS feed",
+            extra={"channel_name": channel_name, "exception": repr(exc)},
+        )
         return []
 
     try:
         root = ET.fromstring(resp.text)
     except ET.ParseError as exc:
-        print(f"[mentions/google_news] XML parse error: {exc!r}")
+        logger.error(
+            "Failed to parse Google News RSS XML",
+            extra={"exception": repr(exc)},
+        )
         return []
 
     channel_el = root.find("channel")

--- a/services/mentions.py
+++ b/services/mentions.py
@@ -1,0 +1,271 @@
+"""
+services/mentions.py
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Zero-cost mentions for a creator profile using only what the worker already
+stores: channel_id and channel_name.
+
+Two sources:
+  YouTube RSS   — last 15 videos from the channel itself (uses channel_id)
+  Google News   — external press/mentions (uses channel_name)
+
+No API keys. No DB writes. Called lazily from the profile route.
+Cached in-process for 30 minutes so repeated profile visits don't hammer
+the upstream feeds.
+"""
+
+from __future__ import annotations
+
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import quote_plus
+
+import httpx
+
+# ── Models ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class VideoItem:
+    title: str
+    url: str
+    published: str  # human-readable date string
+    view_count: Optional[int]
+    thumbnail_url: str
+
+
+@dataclass
+class MentionItem:
+    title: str
+    url: str
+    source: str  # e.g. "BBC News"
+    published: str
+    snippet: str
+
+
+@dataclass
+class MentionBundle:
+    channel_id: str
+    channel_name: str
+    recent_videos: list[VideoItem] = field(default_factory=list)
+    news_mentions: list[MentionItem] = field(default_factory=list)
+    fetched_at: float = field(default_factory=time.monotonic)
+
+    @property
+    def has_any(self) -> bool:
+        return bool(self.recent_videos or self.news_mentions)
+
+
+# ── In-process cache (TTL: 30 minutes) ────────────────────────────────────
+
+_CACHE_TTL = 30 * 60  # seconds
+_cache: dict[str, MentionBundle] = {}
+
+
+def _cache_key(channel_id: str, channel_name: str) -> str:
+    return f"{channel_id}:{channel_name.lower()}"
+
+
+def _cached(channel_id: str, channel_name: str) -> Optional[MentionBundle]:
+    key = _cache_key(channel_id, channel_name)
+    bundle = _cache.get(key)
+    if bundle and (time.monotonic() - bundle.fetched_at) < _CACHE_TTL:
+        return bundle
+    return None
+
+
+def _store(bundle: MentionBundle) -> None:
+    _cache[_cache_key(bundle.channel_id, bundle.channel_name)] = bundle
+
+
+# ── YouTube RSS ────────────────────────────────────────────────────────────
+# https://www.youtube.com/feeds/videos.xml?channel_id=UCxxxxxx
+# No API key. Returns last 15 published videos with view counts.
+
+_YT_RSS = "https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
+_YT_NS = {
+    "atom": "http://www.w3.org/2005/Atom",
+    "yt": "http://www.youtube.com/xml/schemas/2015",
+    "media": "http://search.yahoo.com/mrss/",
+}
+
+
+def _parse_yt_date(raw: str) -> str:
+    """Convert ISO-8601 to a readable 'Jan 5 2025' string."""
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return dt.strftime("%-d %b %Y")
+    except Exception:
+        return raw[:10]
+
+
+def fetch_recent_videos(channel_id: str, limit: int = 6) -> list[VideoItem]:
+    url = _YT_RSS.format(channel_id=channel_id)
+    try:
+        with httpx.Client(timeout=8.0) as client:
+            resp = client.get(url, headers={"User-Agent": "ViralVibesBot/1.0"})
+            resp.raise_for_status()
+    except Exception as exc:
+        print(f"[mentions/youtube_rss] failed for {channel_id}: {exc!r}")
+        return []
+
+    try:
+        root = ET.fromstring(resp.text)
+    except ET.ParseError as exc:
+        print(f"[mentions/youtube_rss] XML parse error for {channel_id}: {exc!r}")
+        return []
+
+    videos: list[VideoItem] = []
+    for entry in root.findall("atom:entry", _YT_NS)[:limit]:
+        title_el = entry.find("atom:title", _YT_NS)
+        link_el = entry.find("atom:link", _YT_NS)
+        pub_el = entry.find("atom:published", _YT_NS)
+        stats_el = entry.find("yt:statistics", _YT_NS)
+        thumb_el = entry.find("media:group/media:thumbnail", _YT_NS)
+
+        title = title_el.text if title_el is not None else ""
+        url = (link_el.get("href") if link_el is not None else "") or ""
+        pub = _parse_yt_date(pub_el.text or "") if pub_el is not None else ""
+
+        view_count: Optional[int] = None
+        if stats_el is not None:
+            try:
+                view_count = int(stats_el.get("viewCount", 0))
+            except (ValueError, TypeError):
+                pass
+
+        thumb = ""
+        if thumb_el is not None:
+            thumb = thumb_el.get("url", "")
+
+        if title and url:
+            videos.append(
+                VideoItem(
+                    title=title,
+                    url=url,
+                    published=pub,
+                    view_count=view_count,
+                    thumbnail_url=thumb,
+                )
+            )
+
+    return videos
+
+
+# ── Google News RSS ────────────────────────────────────────────────────────
+# https://news.google.com/rss/search?q={query}&hl=en
+# No API key. Returns Google News headlines for the query.
+# Google exposes this as their official RSS product; it's not scraping.
+
+_GNEWS_RSS = "https://news.google.com/rss/search?q={query}&hl=en&gl=US&ceid=US:en"
+_GNEWS_NS = {"": "http://www.w3.org/2005/Atom"}
+
+
+def _strip_source(title: str) -> tuple[str, str]:
+    """
+    Google News titles are formatted 'Headline - Source Name'.
+    Split on ' - ' from the right to separate headline from source.
+    """
+    if " - " in title:
+        parts = title.rsplit(" - ", 1)
+        return parts[0].strip(), parts[1].strip()
+    return title.strip(), ""
+
+
+def _parse_gnews_date(raw: str) -> str:
+    """Convert RFC-2822 pubDate to a readable string."""
+    try:
+        # e.g. 'Mon, 05 Jan 2026 10:00:00 GMT'
+        from email.utils import parsedate_to_datetime
+
+        dt = parsedate_to_datetime(raw)
+        return dt.strftime("%-d %b %Y")
+    except Exception:
+        return raw[:16] if raw else ""
+
+
+def fetch_news_mentions(
+    channel_name: str,
+    limit: int = 6,
+) -> list[MentionItem]:
+    # Narrow to YouTube mentions to reduce noise
+    query = f'"{channel_name}" youtube'
+    url = _GNEWS_RSS.format(query=quote_plus(query))
+
+    try:
+        with httpx.Client(timeout=8.0, follow_redirects=True) as client:
+            resp = client.get(url, headers={"User-Agent": "ViralVibesBot/1.0"})
+            resp.raise_for_status()
+    except Exception as exc:
+        print(f"[mentions/google_news] failed for {channel_name!r}: {exc!r}")
+        return []
+
+    try:
+        root = ET.fromstring(resp.text)
+    except ET.ParseError as exc:
+        print(f"[mentions/google_news] XML parse error: {exc!r}")
+        return []
+
+    channel_el = root.find("channel")
+    if channel_el is None:
+        return []
+
+    mentions: list[MentionItem] = []
+    for item in channel_el.findall("item")[:limit]:
+        raw_title = (item.findtext("title") or "").strip()
+        link = (item.findtext("link") or "").strip()
+        pub_raw = (item.findtext("pubDate") or "").strip()
+        desc = (item.findtext("description") or "").strip()
+
+        headline, source = _strip_source(raw_title)
+        if not headline or not link:
+            continue
+
+        mentions.append(
+            MentionItem(
+                title=headline,
+                url=link,
+                source=source,
+                published=_parse_gnews_date(pub_raw),
+                snippet=desc[:200],
+            )
+        )
+
+    return mentions
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+
+def get_mentions(
+    channel_id: str,
+    channel_name: str,
+    video_limit: int = 6,
+    news_limit: int = 6,
+) -> MentionBundle:
+    """
+    Return a MentionBundle for the given creator, served from cache when fresh.
+
+    Args:
+        channel_id:   YouTube channel ID (UC...)  — used for RSS feed
+        channel_name: Display name — used for Google News search
+        video_limit:  Max recent videos to return
+        news_limit:   Max news mentions to return
+    """
+    cached = _cached(channel_id, channel_name)
+    if cached:
+        return cached
+
+    recent_videos = fetch_recent_videos(channel_id, limit=video_limit)
+    news_mentions = fetch_news_mentions(channel_name, limit=news_limit)
+
+    bundle = MentionBundle(
+        channel_id=channel_id,
+        channel_name=channel_name,
+        recent_videos=recent_videos,
+        news_mentions=news_mentions,
+    )
+    _store(bundle)
+    return bundle

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -129,6 +129,27 @@ def test_fetch_recent_videos_returns_empty_on_malformed_xml():
     assert videos == []
 
 
+def test_fetch_news_mentions_returns_empty_on_malformed_xml():
+    with patch("services.mentions.httpx.Client", return_value=_mock_http("not xml at all <<<")):
+        mentions = fetch_news_mentions("MrBeast", limit=10)
+    assert mentions == []
+
+
+def test_fetch_news_mentions_returns_empty_when_channel_missing():
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0">
+      <notchannel>
+        <item>
+          <title>Some title</title>
+        </item>
+      </notchannel>
+    </rss>
+    """
+    with patch("services.mentions.httpx.Client", return_value=_mock_http(xml)):
+        mentions = fetch_news_mentions("MrBeast", limit=10)
+    assert mentions == []
+
+
 # ── Google News RSS ────────────────────────────────────────────────────────
 
 

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -292,13 +292,15 @@ def test_fetch_recent_videos_handles_partial_entries():
     full = videos_map["Video With All Fields"]
     assert "watch?v=full001" in full.url
     assert full.view_count == 1000
-    assert "full001.jpg" in full.thumbnail_url
+    assert "full001" in full.thumbnail_url
+    assert "ytimg.com" in full.thumbnail_url
 
     no_stats = videos_map["No Stats Video"]
     assert "watch?v=nostats" in no_stats.url
     # When yt:statistics is missing, view_count should be None.
     assert no_stats.view_count is None
-    assert "nostats.jpg" in no_stats.thumbnail_url
+    assert "nostats" in no_stats.thumbnail_url
+    assert "ytimg.com" in no_stats.thumbnail_url
 
     no_thumb = videos_map["No Thumbnail Video"]
     assert "watch?v=nothumb" in no_thumb.url

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -8,6 +8,7 @@ All HTTP calls are stubbed — no network required.
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -95,7 +96,10 @@ def test_fetch_recent_videos_returns_correct_fields():
     assert v.title == "Amazing Video Title"
     assert "watch?v=vid001" in v.url
     assert v.view_count == 4_200_000
-    assert "ytimg.com" in v.thumbnail_url
+    thumbnail_host = urlparse(v.thumbnail_url).hostname
+    assert thumbnail_host and (
+        thumbnail_host == "ytimg.com" or thumbnail_host.endswith(".ytimg.com")
+    )
     assert "2025" in v.published
 
 

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -140,7 +140,8 @@ def test_fetch_news_mentions_returns_empty_when_channel_missing():
     <rss version="2.0">
       <notchannel>
         <item>
-          <title>Some title</title>
+    news_host = urlparse(m.url).hostname
+    assert news_host and (news_host == "bbc.com" or news_host.endswith(".bbc.com"))
         </item>
       </notchannel>
     </rss>

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -229,3 +229,79 @@ def test_get_mentions_bundle_has_any_false_when_both_empty():
         # Clear cache for clean test (use a unique channel_id)
         bundle = get_mentions("UCempty_test_xyz", "Empty Channel XYZ")
     assert bundle.has_any is False
+
+
+# ── YouTube RSS with partial/missing fields ──────────────────────────────
+
+
+_YT_RSS_MIXED_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+      xmlns:media="http://search.yahoo.com/mrss/">
+  <entry>
+    <title>Video With All Fields</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=full001"/>
+    <media:group>
+      <media:thumbnail url="https://i.ytimg.com/vi/full001/hqdefault.jpg"/>
+    </media:group>
+    <yt:statistics viewCount="1000"/>
+    <published>2025-01-01T00:00:00+00:00</published>
+  </entry>
+  <entry>
+    <title>No Stats Video</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=nostats"/>
+    <media:group>
+      <media:thumbnail url="https://i.ytimg.com/vi/nostats/hqdefault.jpg"/>
+    </media:group>
+    <published>2025-01-02T00:00:00+00:00</published>
+  </entry>
+  <entry>
+    <title>No Thumbnail Video</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=nothumb"/>
+    <yt:statistics viewCount="2000"/>
+    <published>2025-01-03T00:00:00+00:00</published>
+  </entry>
+  <entry>
+    <title>Missing Link Should Be Skipped</title>
+    <published>2025-01-04T00:00:00+00:00</published>
+  </entry>
+  <entry>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=notitle"/>
+    <published>2025-01-05T00:00:00+00:00</published>
+  </entry>
+</feed>
+"""
+
+
+def test_fetch_recent_videos_handles_partial_entries():
+    """Verify partial/missing fields are handled gracefully."""
+    with patch("services.mentions.httpx.Client", return_value=_mock_http(_YT_RSS_MIXED_XML)):
+        videos = fetch_recent_videos("UCtest123", limit=10)
+
+    # Two entries are missing either title or link and should be skipped.
+    # The remaining three entries should be present with partially populated fields.
+    assert len(videos) == 3
+
+    videos_by_title = {video.title for video in videos}
+    assert "Video With All Fields" in videos_by_title
+    assert "No Stats Video" in videos_by_title
+    assert "No Thumbnail Video" in videos_by_title
+
+    videos_map = {video.title: video for video in videos}
+
+    full = videos_map["Video With All Fields"]
+    assert "watch?v=full001" in full.url
+    assert full.view_count == 1000
+    assert "full001.jpg" in full.thumbnail_url
+
+    no_stats = videos_map["No Stats Video"]
+    assert "watch?v=nostats" in no_stats.url
+    # When yt:statistics is missing, view_count should be None.
+    assert no_stats.view_count is None
+    assert "nostats.jpg" in no_stats.thumbnail_url
+
+    no_thumb = videos_map["No Thumbnail Video"]
+    assert "watch?v=nothumb" in no_thumb.url
+    assert no_thumb.view_count == 2000
+    # When media:thumbnail is missing, thumbnail_url should be empty.
+    assert no_thumb.thumbnail_url == ""

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,205 @@
+"""
+tests/test_mentions.py
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Unit tests for services/mentions.py.
+All HTTP calls are stubbed — no network required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.mentions import (
+    MentionBundle,
+    fetch_news_mentions,
+    fetch_recent_videos,
+    get_mentions,
+    _strip_source,
+    _parse_yt_date,
+)
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+_YT_RSS_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+      xmlns:media="http://search.yahoo.com/mrss/">
+  <entry>
+    <yt:videoId>vid001</yt:videoId>
+    <title>Amazing Video Title</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=vid001"/>
+    <published>2025-12-01T10:00:00+00:00</published>
+    <yt:statistics viewCount="4200000"/>
+    <media:group>
+      <media:thumbnail url="https://i.ytimg.com/vi/vid001/hqdefault.jpg"/>
+    </media:group>
+  </entry>
+  <entry>
+    <yt:videoId>vid002</yt:videoId>
+    <title>Another Great Video</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=vid002"/>
+    <published>2025-11-20T10:00:00+00:00</published>
+    <yt:statistics viewCount="800000"/>
+    <media:group>
+      <media:thumbnail url="https://i.ytimg.com/vi/vid002/hqdefault.jpg"/>
+    </media:group>
+  </entry>
+</feed>
+"""
+
+_GNEWS_RSS_XML = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>MrBeast Breaks YouTube Record - BBC News</title>
+      <link>https://bbc.com/news/article-1</link>
+      <pubDate>Mon, 02 Dec 2025 09:00:00 GMT</pubDate>
+      <description>The popular YouTuber has set a new record for fastest video to reach 100 million views.</description>
+    </item>
+    <item>
+      <title>How MrBeast Funds His Videos - Forbes</title>
+      <link>https://forbes.com/article-2</link>
+      <pubDate>Sat, 30 Nov 2025 14:00:00 GMT</pubDate>
+      <description>An inside look at the business model behind viral philanthropy content.</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+def _mock_http(xml_text: str):
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = xml_text
+    mock_resp.raise_for_status = MagicMock()
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.return_value = mock_resp
+    return mock_client
+
+
+# ── YouTube RSS ────────────────────────────────────────────────────────────
+
+
+def test_fetch_recent_videos_returns_correct_fields():
+    with patch("services.mentions.httpx.Client", return_value=_mock_http(_YT_RSS_XML)):
+        videos = fetch_recent_videos("UCtest123", limit=10)
+
+    assert len(videos) == 2
+    v = videos[0]
+    assert v.title == "Amazing Video Title"
+    assert "watch?v=vid001" in v.url
+    assert v.view_count == 4_200_000
+    assert "ytimg.com" in v.thumbnail_url
+    assert "2025" in v.published
+
+
+def test_fetch_recent_videos_respects_limit():
+    with patch("services.mentions.httpx.Client", return_value=_mock_http(_YT_RSS_XML)):
+        videos = fetch_recent_videos("UCtest123", limit=1)
+    assert len(videos) == 1
+
+
+def test_fetch_recent_videos_returns_empty_on_http_error():
+    import httpx
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.side_effect = httpx.HTTPStatusError(
+        "404", request=MagicMock(), response=MagicMock(status_code=404)
+    )
+    with patch("services.mentions.httpx.Client", return_value=mock_client):
+        videos = fetch_recent_videos("UCbad", limit=6)
+    assert videos == []
+
+
+def test_fetch_recent_videos_returns_empty_on_malformed_xml():
+    with patch("services.mentions.httpx.Client", return_value=_mock_http("not xml at all <<<")):
+        videos = fetch_recent_videos("UCtest", limit=6)
+    assert videos == []
+
+
+# ── Google News RSS ────────────────────────────────────────────────────────
+
+
+def test_fetch_news_mentions_returns_correct_fields():
+    with patch("services.mentions.httpx.Client", return_value=_mock_http(_GNEWS_RSS_XML)):
+        mentions = fetch_news_mentions("MrBeast", limit=10)
+
+    assert len(mentions) == 2
+    m = mentions[0]
+    assert m.title == "MrBeast Breaks YouTube Record"
+    assert m.source == "BBC News"
+    assert "bbc.com" in m.url
+    assert "2025" in m.published
+    assert len(m.snippet) <= 200
+
+
+def test_fetch_news_mentions_splits_source_from_title():
+    headline, source = _strip_source("Some Big Story - The New York Times")
+    assert headline == "Some Big Story"
+    assert source == "The New York Times"
+
+
+def test_fetch_news_mentions_handles_title_without_source():
+    headline, source = _strip_source("Untitled Article")
+    assert headline == "Untitled Article"
+    assert source == ""
+
+
+def test_fetch_news_mentions_returns_empty_on_http_error():
+    import httpx
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.side_effect = httpx.TimeoutException("timeout")
+    with patch("services.mentions.httpx.Client", return_value=mock_client):
+        mentions = fetch_news_mentions("MrBeast", limit=6)
+    assert mentions == []
+
+
+# ── Date helpers ───────────────────────────────────────────────────────────
+
+
+def test_parse_yt_date_formats_correctly():
+    result = _parse_yt_date("2025-01-05T10:00:00+00:00")
+    assert "Jan" in result
+    assert "2025" in result
+
+
+def test_parse_yt_date_handles_garbage_gracefully():
+    result = _parse_yt_date("not-a-date")
+    assert isinstance(result, str)  # does not raise
+
+
+# ── Cache ──────────────────────────────────────────────────────────────────
+
+
+def test_get_mentions_serves_from_cache_on_second_call():
+    with (
+        patch("services.mentions.fetch_recent_videos", return_value=[]) as mock_vid,
+        patch("services.mentions.fetch_news_mentions", return_value=[]) as mock_news,
+    ):
+        get_mentions("UCtest", "Test Channel")
+        get_mentions("UCtest", "Test Channel")
+
+    # Both fetchers called exactly once — second call served from cache
+    mock_vid.assert_called_once()
+    mock_news.assert_called_once()
+
+
+def test_get_mentions_bundle_has_any_false_when_both_empty():
+    with (
+        patch("services.mentions.fetch_recent_videos", return_value=[]),
+        patch("services.mentions.fetch_news_mentions", return_value=[]),
+    ):
+        # Clear cache for clean test (use a unique channel_id)
+        bundle = get_mentions("UCempty_test_xyz", "Empty Channel XYZ")
+    assert bundle.has_any is False

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -293,14 +293,18 @@ def test_fetch_recent_videos_handles_partial_entries():
     assert "watch?v=full001" in full.url
     assert full.view_count == 1000
     assert "full001" in full.thumbnail_url
-    assert "ytimg.com" in full.thumbnail_url
+    full_thumb_host = urlparse(full.thumbnail_url).hostname
+    assert full_thumb_host is not None
+    assert full_thumb_host == "ytimg.com" or full_thumb_host.endswith(".ytimg.com")
 
     no_stats = videos_map["No Stats Video"]
     assert "watch?v=nostats" in no_stats.url
     # When yt:statistics is missing, view_count should be None.
     assert no_stats.view_count is None
     assert "nostats" in no_stats.thumbnail_url
-    assert "ytimg.com" in no_stats.thumbnail_url
+    no_stats_thumb_host = urlparse(no_stats.thumbnail_url).hostname
+    assert no_stats_thumb_host is not None
+    assert no_stats_thumb_host == "ytimg.com" or no_stats_thumb_host.endswith(".ytimg.com")
 
     no_thumb = videos_map["No Thumbnail Video"]
     assert "watch?v=nothumb" in no_thumb.url

--- a/views/creators.py
+++ b/views/creators.py
@@ -55,6 +55,7 @@ from utils.creator_metrics import (
 from db import calculate_creator_stats, get_creator_hero_stats
 from services.contact_extractor import extract_social_links
 from components.category_stats import render_category_box_plots
+from views.mentions import render_mentions_placeholder
 
 logger = logging.getLogger(__name__)
 
@@ -4237,6 +4238,7 @@ def render_creator_profile_page(
         performance_card,
         rankings_card,
         *([leaderboard_card] if leaderboard_card else []),
+        render_mentions_placeholder(creator_id),
         topic_pill_section,
         cat_dist_card,
         cls="flex flex-col gap-4",

--- a/views/mentions.py
+++ b/views/mentions.py
@@ -1,0 +1,175 @@
+"""
+views/mentions.py
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Renders the "In the News / Recent Videos" card for the creator profile.
+
+render_mentions_placeholder()
+  → Emits the HTMX trigger div that the profile page drops in.
+    No network calls here — just a skeleton with hx-get pointing to the
+    lazy-load endpoint.
+
+render_mentions_card(bundle)
+  → The actual card, returned by the lazy-load route once the service
+    has fetched both feeds.
+"""
+
+from __future__ import annotations
+
+from fasthtml.common import (
+    A,
+    Div,
+    H2,
+    H3,
+    Li,
+    P,
+    Span,
+    Ul,
+)
+from monsterui.all import Card, UkIcon
+
+from services.mentions import MentionBundle, MentionItem, VideoItem
+from utils.formatting import format_number
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _view_badge(view_count: int) -> Span:
+    return Span(
+        UkIcon("eye", cls="w-3 h-3 mr-1"),
+        format_number(view_count),
+        cls="inline-flex items-center text-xs text-muted-foreground",
+    )
+
+
+def _video_row(video: VideoItem) -> Li:
+    return Li(
+        A(
+            Div(
+                Span(
+                    video.title, cls="text-sm font-medium text-foreground line-clamp-2 leading-snug"
+                ),
+                Div(
+                    Span(video.published, cls="text-xs text-muted-foreground"),
+                    *([_view_badge(video.view_count)] if video.view_count else []),
+                    cls="flex items-center gap-3 mt-1",
+                ),
+                cls="flex-1 min-w-0",
+            ),
+            UkIcon("external-link", cls="w-3.5 h-3.5 text-muted-foreground shrink-0 ml-2"),
+            href=video.url,
+            target="_blank",
+            rel="noopener noreferrer",
+            cls="flex items-start gap-2 py-2.5 hover:bg-accent/50 rounded-lg px-2 -mx-2 transition-colors",
+        ),
+        cls="border-b border-border/50 last:border-0",
+    )
+
+
+def _news_row(mention: MentionItem) -> Li:
+    return Li(
+        A(
+            Div(
+                Span(
+                    mention.title,
+                    cls="text-sm font-medium text-foreground line-clamp-2 leading-snug",
+                ),
+                Div(
+                    *(
+                        [
+                            Span(
+                                mention.source,
+                                cls="text-xs font-medium text-blue-600 dark:text-blue-400",
+                            )
+                        ]
+                        if mention.source
+                        else []
+                    ),
+                    Span(mention.published, cls="text-xs text-muted-foreground"),
+                    cls="flex items-center gap-2 mt-1",
+                ),
+                cls="flex-1 min-w-0",
+            ),
+            UkIcon("external-link", cls="w-3.5 h-3.5 text-muted-foreground shrink-0 ml-2"),
+            href=mention.url,
+            target="_blank",
+            rel="noopener noreferrer",
+            cls="flex items-start gap-2 py-2.5 hover:bg-accent/50 rounded-lg px-2 -mx-2 transition-colors",
+        ),
+        cls="border-b border-border/50 last:border-0",
+    )
+
+
+def _section(icon: str, title: str, items: list, row_fn) -> Div:
+    return Div(
+        Div(
+            UkIcon(icon, cls="w-4 h-4 text-muted-foreground"),
+            H3(title, cls="text-sm font-semibold text-foreground"),
+            cls="flex items-center gap-2 mb-2",
+        ),
+        Ul(*[row_fn(item) for item in items], cls="divide-y divide-border/50"),
+        cls="mb-5 last:mb-0",
+    )
+
+
+# ── Public renderers ───────────────────────────────────────────────────────
+
+
+def render_mentions_placeholder(creator_id: str) -> Div:
+    """
+    Drop this into the profile page template.
+    HTMX fetches the real card after the profile has rendered.
+    hx-trigger="load" fires as soon as this element enters the DOM.
+    """
+    return Div(
+        Div(
+            Div(cls="h-3 w-24 bg-accent animate-pulse rounded"),
+            Div(cls="h-3 w-full bg-accent animate-pulse rounded mt-2"),
+            Div(cls="h-3 w-4/5 bg-accent animate-pulse rounded mt-2"),
+            cls="p-5 space-y-2",
+        ),
+        id="mentions-card",
+        hx_get=f"/creator/{creator_id}/mentions",
+        hx_trigger="load",
+        hx_swap="outerHTML",
+        cls="rounded-xl border border-border bg-card",
+    )
+
+
+def render_mentions_card(bundle: MentionBundle) -> Div:
+    """
+    Full card rendered once both feeds have been fetched.
+    Returned by the lazy-load route and swapped in by HTMX.
+    """
+    if not bundle.has_any:
+        return Div(
+            P(
+                "No recent news or videos found for this creator.",
+                cls="text-sm text-muted-foreground text-center py-6",
+            ),
+            id="mentions-card",
+            cls="rounded-xl border border-border bg-card px-5",
+        )
+
+    sections = []
+    if bundle.news_mentions:
+        sections.append(_section("newspaper", "In the News", bundle.news_mentions, _news_row))
+    if bundle.recent_videos:
+        sections.append(_section("youtube", "Recent Videos", bundle.recent_videos, _video_row))
+
+    return Div(
+        Card(
+            Div(
+                H2("Mentions & Recent Content", cls="text-base font-bold text-foreground"),
+                cls="mb-4",
+            ),
+            *sections,
+            body_cls="p-5",
+        ),
+        id="mentions-card",
+    )
+
+
+def render_mentions_error() -> Div:
+    """Shown when both feeds fail — silently degrades."""
+    return Div(id="mentions-card")


### PR DESCRIPTION
## Summary by Sourcery

Add a lazily loaded mentions and recent content card to creator profiles using external RSS feeds.

New Features:
- Expose a /creator/{creator_id}/mentions endpoint that fetches and renders mentions and recent videos for a creator via HTMX.
- Introduce a mentions service that aggregates recent YouTube videos and Google News mentions for a channel without requiring API keys or persistence.
- Add UI components to display an 'In the News / Recent Videos' card on creator profiles, loaded asynchronously to avoid blocking the main page.

Tests:
- Add unit tests for the mentions service covering RSS parsing, error handling, date formatting, and in-process caching behavior.