### PR TITLE
Lists category bug

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -908,47 +908,67 @@ def get_top_creators_by_categories(
             term_to_cats.setdefault(ilike_term, []).append(category)
 
     for ilike_term, matching_cats in term_to_cats.items():
-        try:
 
-            def _run_query(*, jsonb_contains: str | None = None, ilike: str | None = None):
-                query = supabase_client.table("creators").select("*")
-                if jsonb_contains:
-                    query = query.filter(
-                        "topic_categories",
-                        "cs",
-                        json.dumps([jsonb_contains]),
-                    )
-                elif ilike:
-                    query = query.ilike("topic_categories", f"%{_escape_ilike(ilike)}%")
-                return (
-                    query.not_.is_("channel_name", "null")
-                    .gt("current_subscribers", 0)
-                    .order("current_subscribers", desc=True)
-                    .limit(limit_per_category)
-                    .execute()
+        def _run_query(*, jsonb_contains: str | None = None, ilike: str | None = None):
+            query = supabase_client.table("creators").select("*")
+            if jsonb_contains:
+                query = query.filter(
+                    "topic_categories",
+                    "cs",
+                    json.dumps([jsonb_contains]),
+                )
+            elif ilike:
+                # Use the word-level pattern builder: it handles URLs, underscore
+                # slugs, and space-separated labels without escaping the separator.
+                pattern = _topic_category_ilike_pattern(ilike)
+                if pattern:
+                    query = query.ilike("topic_categories", pattern)
+            return (
+                query.not_.is_("channel_name", "null")
+                .gt("current_subscribers", 0)
+                .order("current_subscribers", desc=True)
+                .limit(limit_per_category)
+                .execute()
+            )
+
+        creators: list[dict] = []
+
+        # Tier 1 – JSONB containment with clean display label (fastest path).
+        label = _topic_category_label(ilike_term)
+        if label:
+            try:
+                r = _run_query(jsonb_contains=label)
+                creators = r.data or []
+            except Exception:
+                logger.debug(
+                    "JSONB label query failed for %r, trying URL tier", label, exc_info=True
                 )
 
-            creators: list[dict] = []
-            label = _topic_category_label(ilike_term)
-            if label:
-                response = _run_query(jsonb_contains=label)
-                creators = response.data if response.data else []
+        # Tier 2 – JSONB containment with canonical Wikipedia URL.
+        if not creators:
+            jsonb_value = _topic_category_jsonb_value(ilike_term)
+            if jsonb_value:
+                try:
+                    r = _run_query(jsonb_contains=jsonb_value)
+                    creators = r.data or []
+                except Exception:
+                    logger.debug(
+                        "JSONB URL query failed for %r, falling back to ILIKE",
+                        jsonb_value,
+                        exc_info=True,
+                    )
 
-            if not creators:
-                jsonb_value = _topic_category_jsonb_value(ilike_term)
-                if jsonb_value:
-                    response = _run_query(jsonb_contains=jsonb_value)
-                    creators = response.data if response.data else []
+        # Tier 3 – ILIKE text search (handles any legacy storage format).
+        if not creators:
+            try:
+                r = _run_query(ilike=ilike_term)
+                creators = r.data or []
+            except Exception:
+                logger.exception("All query tiers failed for category %r", ilike_term)
 
-            if not creators:
-                response = _run_query(ilike=ilike_term)
-                creators = response.data if response.data else []
-
-            # All keys that share this term get the same creator list.
-            for cat in matching_cats:
-                result[cat] = creators
-        except Exception as e:
-            logger.exception("Error fetching creators for category %r: %s", ilike_term, e)
+        # All keys that share this ilike_term get the same creator list.
+        for cat in matching_cats:
+            result[cat] = creators
 
     return result
 

--- a/db_lists.py
+++ b/db_lists.py
@@ -306,7 +306,7 @@ def _apply_topic_category_filters(query, category: str):
     """Apply filters shared by category group cards and detail pages."""
     label = _topic_category_label(category)
     if label:
-        query = query.filter("topic_categories::jsonb", "cs", json.dumps([label]))
+        query = query.filter("topic_categories", "cs", json.dumps([label]))
     return (
         query.eq("sync_status", "synced")
         .not_.is_("channel_name", "null")
@@ -914,7 +914,7 @@ def get_top_creators_by_categories(
                 query = supabase_client.table("creators").select("*")
                 if jsonb_contains:
                     query = query.filter(
-                        "topic_categories::jsonb",
+                        "topic_categories",
                         "cs",
                         json.dumps([jsonb_contains]),
                     )

--- a/db_lists.py
+++ b/db_lists.py
@@ -7,9 +7,10 @@ import json
 import logging
 import random
 import time
-from typing import Callable
+from typing import Callable, NamedTuple
+from urllib.parse import unquote
 
-from utils import normalize_category_name, safe_get_value
+from utils import normalize_category_name, safe_get_value, slugify
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,253 @@ def _escape_ilike(term: str) -> str:
     replacements don't double-escape the wildcards.
     """
     return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+# YouTube channel ``topicDetails.topicCategories`` are Wikipedia/Knowledge Graph
+# topic labels. They are distinct from the video-level ``primary_category``
+# values in creators. The list is intentionally finite and stable enough to use
+# as the basis for URL slug resolution; live DB counts only tell us which of
+# these categories currently have creators.
+YOUTUBE_TOPIC_CATEGORY_LABELS: tuple[str, ...] = (
+    "Music",
+    "Christian music",
+    "Classical music",
+    "Country music",
+    "Electronic music",
+    "Hip hop music",
+    "Independent music",
+    "Jazz",
+    "Music of Asia",
+    "Music of Latin America",
+    "Pop music",
+    "Reggae",
+    "Rhythm and blues",
+    "Rock music",
+    "Soul music",
+    "Action game",
+    "Action-adventure game",
+    "Casual game",
+    "Music video game",
+    "Puzzle video game",
+    "Racing video game",
+    "Role-playing video game",
+    "Simulation video game",
+    "Sports game",
+    "Strategy video game",
+    "American football",
+    "Baseball",
+    "Basketball",
+    "Boxing",
+    "Cricket",
+    "Association football",
+    "Golf",
+    "Ice hockey",
+    "Mixed martial arts",
+    "Motorsport",
+    "Tennis",
+    "Volleyball",
+    "Entertainment",
+    "Humour",
+    "Film",
+    "Performing arts",
+    "Professional wrestling",
+    "Television program",
+    "Lifestyle (sociology)",
+    "Fashion",
+    "Physical fitness",
+    "Food",
+    "Hobby",
+    "Pet",
+    "Physical attractiveness",
+    "Society",
+    "Business",
+    "Health",
+    "Military",
+    "Politics",
+    "Religion",
+    "Technology",
+    "Tourism",
+    "Vehicle",
+    "Knowledge",
+    "Video game culture",
+)
+
+_FIXED_TOPIC_CATEGORY_SLUG_MAP: dict[str, str] = {
+    slugify(label): label for label in YOUTUBE_TOPIC_CATEGORY_LABELS
+}
+
+
+def topic_category_slug(category: str) -> str:
+    """Return the stable URL slug for a topic category label."""
+    return slugify(normalize_category_name(str(category or "")))
+
+
+def _topic_category_label(category: str) -> str:
+    """Normalize a route value, DB value, or old Wikipedia URL into a label."""
+    return normalize_category_name(unquote(str(category or "").strip()))
+
+
+def _topic_category_ilike_pattern(category: str) -> str:
+    """Build a separator-tolerant ILIKE pattern for ``topic_categories`` text.
+
+    The clean storage form is a JSON array of labels, e.g.
+    ``["Lifestyle (sociology)"]``. Older rows may still contain Wikipedia URLs
+    or underscores, so the fallback text pattern keeps word order while allowing
+    arbitrary separators between words.
+    """
+    label = _topic_category_label(category)
+    words = [w for w in label.replace("(", " ").replace(")", " ").split() if w]
+    if not words:
+        return ""
+    return "%" + "%".join(_escape_ilike(word) for word in words) + "%"
+
+
+class TopicCategoryPageResult(NamedTuple):
+    creators: list[dict]
+    total_count: int
+
+
+# Slug → canonical category name (fixed labels plus live DB categories).
+_CATEGORY_SLUG_CACHE_TTL_S = 60 * 60
+_category_slug_cache: dict[str, object] = {"expires_at": 0.0, "map": {}}
+
+
+def _get_category_slug_map() -> dict[str, str]:
+    """Return ``{slug: canonical_name}`` for fixed and currently observed topics."""
+    now = time.monotonic()
+    expires_at = float(_category_slug_cache.get("expires_at") or 0.0)
+    cached_map = _category_slug_cache.get("map")
+    if isinstance(cached_map, dict) and now < expires_at:
+        return cached_map
+
+    slug_map: dict[str, str] = dict(_FIXED_TOPIC_CATEGORY_SLUG_MAP)
+    for cat_name, _ in get_top_categories_with_counts(limit=2000):
+        label = _topic_category_label(cat_name)
+        if label:
+            slug_map.setdefault(topic_category_slug(label), label)
+
+    _category_slug_cache["expires_at"] = now + _CATEGORY_SLUG_CACHE_TTL_S
+    _category_slug_cache["map"] = slug_map
+    return slug_map
+
+
+def resolve_category_slug(slug: str) -> str | None:
+    """Map a URL slug or encoded label back to a canonical topic category name."""
+    if not slug or not str(slug).strip():
+        return None
+
+    raw = unquote(str(slug)).strip()
+    slug_key = slugify(raw)
+    if not slug_key:
+        return None
+
+    fixed = _FIXED_TOPIC_CATEGORY_SLUG_MAP.get(slug_key)
+    if fixed:
+        return fixed
+
+    resolved = _get_category_slug_map().get(slug_key)
+    if resolved:
+        return resolved
+
+    # Backward compatibility for quoted canonical labels or unknown-but-valid
+    # topic labels. This lets the route degrade to "no creators" instead of
+    # presenting a mangled title like "Lifestyle Sociology".
+    label = _topic_category_label(raw.replace("-", " "))
+    return label or None
+
+
+def _apply_topic_category_filters(query, category: str):
+    """Apply filters shared by category group cards and detail pages."""
+    label = _topic_category_label(category)
+    if label:
+        query = query.filter("topic_categories::jsonb", "cs", json.dumps([label]))
+    return (
+        query.eq("sync_status", "synced")
+        .not_.is_("channel_name", "null")
+        .not_.is_("topic_categories", "null")
+        .gt("current_subscribers", 0)
+    )
+
+
+def _apply_topic_category_text_filters(query, category: str):
+    """Fallback text filter for legacy rows that do not exact-match JSON labels."""
+    pattern = _topic_category_ilike_pattern(category)
+    if pattern:
+        query = query.ilike("topic_categories", pattern)
+    return (
+        query.eq("sync_status", "synced")
+        .not_.is_("channel_name", "null")
+        .not_.is_("topic_categories", "null")
+        .gt("current_subscribers", 0)
+    )
+
+
+def get_topic_category_creators(
+    category: str,
+    *,
+    limit: int = 20,
+    offset: int = 0,
+    return_count: bool = False,
+) -> list[dict] | TopicCategoryPageResult:
+    """
+    Paginated creator listing for a topic category detail page.
+
+    Filters on ``topic_categories`` (same column as category counts / list
+    cards), not ``primary_category`` — the latter holds YouTube video-level
+    categories and does not match Wikipedia topic taxonomy.
+    """
+    supabase_client = _get_supabase_client()
+    if not supabase_client or not category:
+        return TopicCategoryPageResult([], 0) if return_count else []
+
+    category_label = _topic_category_label(category)
+    if not category_label:
+        return TopicCategoryPageResult([], 0) if return_count else []
+
+    def _run(use_text_fallback: bool = False):
+        query = supabase_client.table("creators").select(
+            "*", count="exact" if return_count else None
+        )
+        query = (
+            _apply_topic_category_text_filters(query, category_label)
+            if use_text_fallback
+            else _apply_topic_category_filters(query, category_label)
+        )
+        query = query.order("current_subscribers", desc=True).limit(limit)
+        if offset:
+            query = query.offset(offset)
+        return query.execute()
+
+    try:
+        response = _run()
+    except Exception:
+        logger.info(
+            "Exact topic category query failed for %r; trying text fallback",
+            category_label,
+            exc_info=True,
+        )
+        response = _run(use_text_fallback=True)
+
+    creators = response.data if response.data else []
+    total_count = (getattr(response, "count", 0) or 0) if return_count else 0
+
+    if not creators:
+        try:
+            fallback = _run(use_text_fallback=True)
+            creators = fallback.data if fallback.data else []
+            total_count = (getattr(fallback, "count", 0) or 0) if return_count else 0
+        except Exception:
+            logger.exception(
+                "Error fetching topic category creators for %r via text fallback",
+                category_label,
+            )
+
+    for idx, creator in enumerate(creators, 1):
+        creator["_rank"] = offset + idx
+
+    if return_count:
+        return TopicCategoryPageResult(creators, total_count)
+    return creators
 
 
 # ---------------------------------------------------------------------------
@@ -536,22 +784,24 @@ def get_top_creators_by_categories(
     # same term so we fire one query instead of N identical ones.
     term_to_cats: dict[str, list[str]] = {}
     for category in categories:
-        # Extract the meaningful segment from a (possibly URL-normalised) key.
-        segment = category.split("/")[-1] if "/" in category else category
-        # Strip any query-string or fragment that may appear in non-canonical URLs.
-        segment = segment.split("?")[0].split("#")[0].strip()
-        # Spaces → _ so the ILIKE wildcard matches both storage forms.
-        ilike_term = segment.replace(" ", "_")
+        ilike_term = _topic_category_ilike_term(category)
         if ilike_term:
             term_to_cats.setdefault(ilike_term, []).append(category)
 
     for ilike_term, matching_cats in term_to_cats.items():
         try:
+            query = supabase_client.table("creators").select("*")
+            jsonb_value = _topic_category_jsonb_value(ilike_term)
+            if jsonb_value:
+                query = query.filter(
+                    "topic_categories::jsonb",
+                    "cs",
+                    json.dumps([jsonb_value]),
+                )
+            else:
+                query = query.ilike("topic_categories", f"%{_escape_ilike(ilike_term)}%")
             response = (
-                supabase_client.table("creators")
-                .select("*")
-                .ilike("topic_categories", f"%{_escape_ilike(ilike_term)}%")
-                .not_.is_("channel_name", "null")
+                query.not_.is_("channel_name", "null")
                 .gt("current_subscribers", 0)
                 .order("current_subscribers", desc=True)
                 .limit(limit_per_category)

--- a/db_lists.py
+++ b/db_lists.py
@@ -127,7 +127,8 @@ def _topic_category_wiki_slug(category: str) -> str:
             # urlparse already strips query/fragment into dedicated fields.
             wiki_path = parsed.path.split("/wiki/", 1)[-1].strip("/")
             if wiki_path:
-                return unquote(wiki_path)
+                normalized_path = normalize_category_name(unquote(wiki_path))
+                return normalized_path.replace(" ", "_") if normalized_path else ""
 
     label = normalize_category_name(raw)
     return label.replace(" ", "_") if label else ""
@@ -234,6 +235,29 @@ _CATEGORY_SLUG_CACHE_TTL_S = 60 * 60
 _category_slug_cache: dict[str, object] = {"expires_at": 0.0, "map": {}}
 
 
+def _get_observed_topic_category_labels(limit: int = 2000) -> list[str]:
+    """Return normalized topic labels currently observed in the DB.
+
+    Unlike ``get_top_categories_with_counts()``, this helper intentionally
+    returns raw observed labels so slug resolution can continue to learn
+    non-fixed topics seen in legacy or long-tail data.
+    """
+    observed = _fetch_top_counts(
+        "get_top_categories_with_counts",
+        "category",
+        _scan_categories_fallback,
+        limit,
+    )
+    labels: list[str] = []
+    seen: set[str] = set()
+    for cat_name, _ in observed:
+        label = _topic_category_label(cat_name)
+        if label and label not in seen:
+            seen.add(label)
+            labels.append(label)
+    return labels
+
+
 def _get_category_slug_map() -> dict[str, str]:
     """Return ``{slug: canonical_name}`` for fixed and currently observed topics."""
     now = time.monotonic()
@@ -243,10 +267,8 @@ def _get_category_slug_map() -> dict[str, str]:
         return cached_map
 
     slug_map: dict[str, str] = dict(_FIXED_TOPIC_CATEGORY_SLUG_MAP)
-    for cat_name, _ in get_top_categories_with_counts(limit=2000):
-        label = _topic_category_label(cat_name)
-        if label:
-            slug_map.setdefault(topic_category_slug(label), label)
+    for label in _get_observed_topic_category_labels(limit=2000):
+        slug_map.setdefault(topic_category_slug(label), label)
 
     _category_slug_cache["expires_at"] = now + _CATEGORY_SLUG_CACHE_TTL_S
     _category_slug_cache["map"] = slug_map
@@ -275,7 +297,9 @@ def resolve_category_slug(slug: str) -> str | None:
     # Backward compatibility for unknown-but-valid labels: degrade to the
     # best normalized label rather than generating a mangled display title.
     fallback_label = _topic_category_label(raw.replace("-", " "))
-    return fallback_label or None
+    if not fallback_label:
+        return None
+    return fallback_label[0].upper() + fallback_label[1:]
 
 
 def _apply_topic_category_filters(query, category: str):
@@ -318,8 +342,11 @@ def get_topic_category_creators(
     cards), not ``primary_category`` — the latter holds YouTube video-level
     categories and does not match Wikipedia topic taxonomy.
     """
+    if not category or not str(category).strip():
+        return TopicCategoryPageResult([], 0) if return_count else []
+
     supabase_client = _get_supabase_client()
-    if not supabase_client or not category:
+    if not supabase_client:
         return TopicCategoryPageResult([], 0) if return_count else []
 
     category_label = _topic_category_label(category)
@@ -340,6 +367,7 @@ def get_topic_category_creators(
             query = query.offset(offset)
         return query.execute()
 
+    response = None
     try:
         response = _run()
     except Exception:
@@ -348,21 +376,19 @@ def get_topic_category_creators(
             category_label,
             exc_info=True,
         )
-        response = _run(use_text_fallback=True)
 
-    creators = response.data if response.data else []
-    total_count = (getattr(response, "count", 0) or 0) if return_count else 0
-
-    if not creators:
+    if response is None or not response.data:
         try:
-            fallback = _run(use_text_fallback=True)
-            creators = fallback.data if fallback.data else []
-            total_count = (getattr(fallback, "count", 0) or 0) if return_count else 0
+            response = _run(use_text_fallback=True)
         except Exception:
             logger.exception(
                 "Error fetching topic category creators for %r via text fallback",
                 category_label,
             )
+            response = None
+
+    creators = response.data if response and response.data else []
+    total_count = (getattr(response, "count", 0) or 0) if return_count and response else 0
 
     for idx, creator in enumerate(creators, 1):
         creator["_rank"] = offset + idx

--- a/db_lists.py
+++ b/db_lists.py
@@ -8,7 +8,7 @@ import logging
 import random
 import time
 from typing import Callable, NamedTuple
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 from utils import normalize_category_name, safe_get_value, slugify
 
@@ -104,6 +104,99 @@ YOUTUBE_TOPIC_CATEGORY_LABELS: tuple[str, ...] = (
 _FIXED_TOPIC_CATEGORY_SLUG_MAP: dict[str, str] = {
     slugify(label): label for label in YOUTUBE_TOPIC_CATEGORY_LABELS
 }
+_FIXED_TOPIC_CATEGORY_LABEL_SET: set[str] = set(YOUTUBE_TOPIC_CATEGORY_LABELS)
+TOTAL_TOPIC_CATEGORIES = len(YOUTUBE_TOPIC_CATEGORY_LABELS)
+
+
+# The YouTube Data API returns topic categories as full Wikipedia URLs under
+# ``topicDetails.topicCategories``. Build and parse URLs from one place so
+# category slugs, cards, and detail pages all resolve consistently.
+_TOPIC_CATEGORY_WIKIPEDIA_BASE_URL = "https://en.wikipedia.org/wiki/"
+
+
+def _topic_category_wiki_slug(category: str) -> str:
+    """Return a Wikipedia slug token (underscored, no URL prefix)."""
+    raw = unquote(str(category or "")).strip()
+    if not raw:
+        return ""
+
+    if raw.startswith(("http://", "https://")):
+        parsed = urlparse(raw)
+        host = (parsed.hostname or "").lower()
+        if (host == "wikipedia.org" or host.endswith(".wikipedia.org")) and "/wiki/" in parsed.path:
+            # urlparse already strips query/fragment into dedicated fields.
+            wiki_path = parsed.path.split("/wiki/", 1)[-1].strip("/")
+            if wiki_path:
+                return unquote(wiki_path)
+
+    label = normalize_category_name(raw)
+    return label.replace(" ", "_") if label else ""
+
+
+def _topic_category_ilike_term(category: str) -> str:
+    """Return a DB text-search token for category matching.
+
+    The token mirrors YouTube/Wikipedia slugs (underscores), allowing a single
+    ILIKE pattern to match legacy URL storage and normalized-label rows.
+    """
+    return _topic_category_wiki_slug(category)
+
+
+def _topic_category_jsonb_value(category: str) -> str:
+    """Return canonical topic_categories JSON entry for exact jsonb containment."""
+    slug = _topic_category_wiki_slug(category)
+    if not slug:
+        return ""
+    if str(category or "").strip().startswith(("http://", "https://")):
+        return f"{_TOPIC_CATEGORY_WIKIPEDIA_BASE_URL}{slug}"
+
+    label = _topic_category_label(category)
+    if not label:
+        return ""
+
+    # Prefer fixed YouTube topic labels for canonical jsonb containment checks.
+    if label in _FIXED_TOPIC_CATEGORY_LABEL_SET:
+        return f"{_TOPIC_CATEGORY_WIKIPEDIA_BASE_URL}{label.replace(' ', '_')}"
+    return ""
+
+
+def _iter_normalized_topic_categories(categories_raw) -> list[str]:
+    """Parse raw topic_categories payload and return normalized labels."""
+    if not categories_raw:
+        return []
+
+    if isinstance(categories_raw, list):
+        cat_list = categories_raw
+    elif isinstance(categories_raw, str):
+        try:
+            parsed = json.loads(categories_raw)
+            cat_list = parsed if isinstance(parsed, list) else []
+        except (json.JSONDecodeError, ValueError):
+            cat_list = [c.strip() for c in categories_raw.split(",")]
+    else:
+        return []
+
+    normalized: list[str] = []
+    for cat in cat_list:
+        clean = normalize_category_name(str(cat))
+        if clean:
+            normalized.append(clean)
+    return normalized
+
+
+def _merge_with_fixed_topic_categories(
+    category_counts: list[tuple[str, int]],
+) -> list[tuple[str, int]]:
+    """Return counts projected onto the fixed YouTube topic taxonomy."""
+    counts_by_label: dict[str, int] = {}
+    for raw_name, count in category_counts:
+        label = _topic_category_label(raw_name)
+        if label in _FIXED_TOPIC_CATEGORY_LABEL_SET:
+            counts_by_label[label] = int(count or 0)
+
+    merged = [(label, counts_by_label.get(label, 0)) for label in YOUTUBE_TOPIC_CATEGORY_LABELS]
+    merged.sort(key=lambda x: x[1], reverse=True)
+    return merged
 
 
 def topic_category_slug(category: str) -> str:
@@ -161,12 +254,13 @@ def _get_category_slug_map() -> dict[str, str]:
 
 
 def resolve_category_slug(slug: str) -> str | None:
-    """Map a URL slug or encoded label back to a canonical topic category name."""
+    """Map a URL slug, encoded label, or Wikipedia URL to a canonical label."""
     if not slug or not str(slug).strip():
         return None
 
     raw = unquote(str(slug)).strip()
-    slug_key = slugify(raw)
+    label = _topic_category_label(raw)
+    slug_key = topic_category_slug(label or raw)
     if not slug_key:
         return None
 
@@ -178,11 +272,10 @@ def resolve_category_slug(slug: str) -> str | None:
     if resolved:
         return resolved
 
-    # Backward compatibility for quoted canonical labels or unknown-but-valid
-    # topic labels. This lets the route degrade to "no creators" instead of
-    # presenting a mangled title like "Lifestyle Sociology".
-    label = _topic_category_label(raw.replace("-", " "))
-    return label or None
+    # Backward compatibility for unknown-but-valid labels: degrade to the
+    # best normalized label rather than generating a mangled display title.
+    fallback_label = _topic_category_label(raw.replace("-", " "))
+    return fallback_label or None
 
 
 def _apply_topic_category_filters(query, category: str):
@@ -394,7 +487,7 @@ def _get_supabase_client():
 _EMPTY_META: dict[str, int] = {
     "total_creators": 0,
     "total_countries": 0,
-    "total_categories": 0,
+    "total_categories": TOTAL_TOPIC_CATEGORIES,
     "total_languages": 0,
 }
 
@@ -729,16 +822,16 @@ def get_top_creators_by_categories(
     categories: list[str], limit_per_category: int = 5
 ) -> dict[str, list[dict]]:
     """
-    Fetch the top creators for each category via per-category ILIKE queries.
+    Fetch the top creators for each category via per-category DB-filtered queries.
 
     The previous implementation fetched a global top-N by subscribers and
     matched client-side.  That was broken for categories whose top creators
     are not globally top-ranked (e.g. "Lifestyle (sociology)" has 4 700
     creators but none are in the global top 200, so it always returned empty).
 
-    This version issues one ILIKE query per distinct ilike_term — efficient
-    because each query is DB-filtered and returns only ``limit_per_category``
-    rows.
+    This version issues one filtered query per distinct category token,
+    preferring exact JSONB containment and falling back to ILIKE when needed.
+    Each query is DB-filtered and returns only ``limit_per_category`` rows.
 
     Why not OR-ILIKE batching?
     ───────────────────────────
@@ -790,24 +883,41 @@ def get_top_creators_by_categories(
 
     for ilike_term, matching_cats in term_to_cats.items():
         try:
-            query = supabase_client.table("creators").select("*")
-            jsonb_value = _topic_category_jsonb_value(ilike_term)
-            if jsonb_value:
-                query = query.filter(
-                    "topic_categories::jsonb",
-                    "cs",
-                    json.dumps([jsonb_value]),
+
+            def _run_query(*, jsonb_contains: str | None = None, ilike: str | None = None):
+                query = supabase_client.table("creators").select("*")
+                if jsonb_contains:
+                    query = query.filter(
+                        "topic_categories::jsonb",
+                        "cs",
+                        json.dumps([jsonb_contains]),
+                    )
+                elif ilike:
+                    query = query.ilike("topic_categories", f"%{_escape_ilike(ilike)}%")
+                return (
+                    query.not_.is_("channel_name", "null")
+                    .gt("current_subscribers", 0)
+                    .order("current_subscribers", desc=True)
+                    .limit(limit_per_category)
+                    .execute()
                 )
-            else:
-                query = query.ilike("topic_categories", f"%{_escape_ilike(ilike_term)}%")
-            response = (
-                query.not_.is_("channel_name", "null")
-                .gt("current_subscribers", 0)
-                .order("current_subscribers", desc=True)
-                .limit(limit_per_category)
-                .execute()
-            )
-            creators = response.data if response.data else []
+
+            creators: list[dict] = []
+            label = _topic_category_label(ilike_term)
+            if label:
+                response = _run_query(jsonb_contains=label)
+                creators = response.data if response.data else []
+
+            if not creators:
+                jsonb_value = _topic_category_jsonb_value(ilike_term)
+                if jsonb_value:
+                    response = _run_query(jsonb_contains=jsonb_value)
+                    creators = response.data if response.data else []
+
+            if not creators:
+                response = _run_query(ilike=ilike_term)
+                creators = response.data if response.data else []
+
             # All keys that share this term get the same creator list.
             for cat in matching_cats:
                 result[cat] = creators
@@ -1221,7 +1331,7 @@ def get_lists_meta() -> dict:
             meta = {
                 "total_creators": int(row.get("total_creators") or 0),
                 "total_countries": int(row.get("total_countries") or 0),
-                "total_categories": int(row.get("total_categories") or 0),
+                "total_categories": TOTAL_TOPIC_CATEGORIES,
                 # total_languages added in migration 003; defaults to 0 on older DBs
                 "total_languages": int(row.get("total_languages") or 0),
             }
@@ -1259,24 +1369,10 @@ def _get_lists_meta_cached_tables() -> dict:
             return _get_lists_meta_fallback()
 
         meta_row = meta_resp.data[0]
-        categories = 0
-        try:
-            stats_resp = (
-                supabase_client.table("app_stats")
-                .select("value")
-                .eq("key", "total_categories")
-                .limit(1)
-                .execute()
-            )
-            if stats_resp.data:
-                categories = int(stats_resp.data[0].get("value") or 0)
-        except Exception:
-            logger.warning("[Lists] app_stats total_categories fallback failed", exc_info=True)
-
         meta = {
             "total_creators": int(meta_row.get("total_creators") or 0),
             "total_countries": int(meta_row.get("total_countries") or 0),
-            "total_categories": categories,
+            "total_categories": TOTAL_TOPIC_CATEGORIES,
             "total_languages": int(meta_row.get("total_languages") or 0),
         }
 
@@ -1310,33 +1406,15 @@ def _get_lists_meta_fallback() -> dict:
         total_creators = response.count if response.count is not None else len(rows)
         countries: set[str] = set()
         languages: set[str] = set()
-        categories: set[str] = set()
         for row in rows:
             if cc := row.get("country_code"):
                 countries.add(cc)
             if lang := row.get("default_language"):
                 languages.add(lang)
-            cats_raw = row.get("topic_categories")
-            if cats_raw:
-                if isinstance(cats_raw, list):
-                    cat_list = cats_raw
-                elif isinstance(cats_raw, str):
-                    try:
-                        cat_list = json.loads(cats_raw)
-                        if not isinstance(cat_list, list):
-                            cat_list = []
-                    except (json.JSONDecodeError, ValueError):
-                        cat_list = [c.strip() for c in cats_raw.split(",")]
-                else:
-                    cat_list = []
-                for cat in cat_list:
-                    clean = normalize_category_name(str(cat))
-                    if clean:
-                        categories.add(clean)
         return {
             "total_creators": total_creators,
             "total_countries": len(countries),
-            "total_categories": len(categories),
+            "total_categories": TOTAL_TOPIC_CATEGORIES,
             "total_languages": len(languages),
         }
     except Exception as e:
@@ -1346,22 +1424,28 @@ def _get_lists_meta_fallback() -> dict:
 
 def get_top_categories_with_counts(limit: int = 10) -> list[tuple[str, int]]:
     """
-    Get top topic categories by creator count via DB-side RPC aggregation.
+    Get topic categories mapped to the fixed YouTube topic taxonomy.
+
+    The YouTube ``topicDetails.topicCategories`` taxonomy is finite. This
+    function always projects DB counts onto that fixed label set so endpoint
+    pagination and category counts remain stable even when DB refresh jobs lag.
 
     Returns list of (category_name, creator_count) tuples.
     Used for the "By Category" tab and the /creators filter dropdown.
-
-    Delegates to the ``get_top_categories_with_counts`` Supabase RPC
-    (see db/migrations/002_lists_page_rpc_functions.sql), which unnests
-    and normalises ``topic_categories`` server-side with zero row transfer.
-    Falls back to ``_scan_categories_fallback`` if the RPC is unavailable.
     """
-    return _fetch_top_counts(
+    if limit <= 0:
+        return []
+
+    # Fetch enough rows to cover the full fixed taxonomy before projection.
+    fetch_limit = max(limit, TOTAL_TOPIC_CATEGORIES)
+    raw_counts = _fetch_top_counts(
         "get_top_categories_with_counts",
         "category",
         _scan_categories_fallback,
-        limit,
+        fetch_limit,
     )
+    merged = _merge_with_fixed_topic_categories(raw_counts)
+    return merged[: min(limit, TOTAL_TOPIC_CATEGORIES)]
 
 
 def suggest_primary_categories(q: str, limit: int = 8) -> list[tuple[str, int]]:
@@ -1429,25 +1513,8 @@ def _scan_categories_fallback(limit: int) -> list[tuple[str, int]]:
         )
         category_counts: dict[str, int] = {}
         for row in response.data or []:
-            categories_raw = row.get("topic_categories")
-            if not categories_raw:
-                continue
-            if isinstance(categories_raw, list):
-                cat_list = categories_raw
-            elif isinstance(categories_raw, str):
-                try:
-                    cat_list = json.loads(categories_raw)
-                    if not isinstance(cat_list, list):
-                        cat_list = []
-                except (json.JSONDecodeError, ValueError):
-                    cat_list = [c.strip() for c in categories_raw.split(",")]
-            else:
-                continue
-            for cat in cat_list:
-                if cat:
-                    clean = normalize_category_name(str(cat))
-                    if clean:
-                        category_counts[clean] = category_counts.get(clean, 0) + 1
+            for clean in _iter_normalized_topic_categories(row.get("topic_categories")):
+                category_counts[clean] = category_counts.get(clean, 0) + 1
         return sorted(category_counts.items(), key=lambda x: x[1], reverse=True)[:limit]
     except Exception as e:
         logger.exception("Error in categories scan fallback: %s", e)
@@ -1568,19 +1635,8 @@ def get_niche_heatmap_data(min_creators: int = 3) -> list[dict]:
     # Accumulate per-category stats
     buckets: dict[str, dict] = {}
     for row in rows:
-        cats_raw = row.get("topic_categories")
-        if not cats_raw:
-            continue
-        if isinstance(cats_raw, list):
-            cat_list = cats_raw
-        elif isinstance(cats_raw, str):
-            try:
-                cat_list = json.loads(cats_raw)
-                if not isinstance(cat_list, list):
-                    cat_list = []
-            except (json.JSONDecodeError, ValueError):
-                cat_list = [c.strip() for c in cats_raw.split(",")]
-        else:
+        cat_list = _iter_normalized_topic_categories(row.get("topic_categories"))
+        if not cat_list:
             continue
 
         engagement = row.get("engagement_score")
@@ -1594,10 +1650,7 @@ def get_niche_heatmap_data(min_creators: int = 3) -> list[dict]:
         if subs_change is not None and current_subs > 0:
             growth_pct = subs_change / current_subs * 100
 
-        for cat in cat_list:
-            clean = normalize_category_name(str(cat))
-            if not clean:
-                continue
+        for clean in cat_list:
             if clean not in buckets:
                 buckets[clean] = {
                     "category": clean,

--- a/main.py
+++ b/main.py
@@ -157,6 +157,7 @@ from routes.admin import (
     admin_rescue_quota_jobs,
     admin_outreach_export_route,
 )
+from db_lists import resolve_category_slug
 from views.lists import _unslugify
 
 # Get logger instance
@@ -1418,7 +1419,7 @@ def lists_languages_explorer(req, sess):
 @rt("/lists/category/{category_slug}")
 def lists_category_detail(req, sess, category_slug: str):
     """Detailed creator rankings for a specific topic category."""
-    display_name = _unslugify(category_slug).title()
+    display_name = resolve_category_slug(category_slug) or _unslugify(category_slug).title()
     page_content = category_detail_route(req, category_slug)
     return Titled(
         f"{display_name} Creators - YouTube",

--- a/routes/lists.py
+++ b/routes/lists.py
@@ -7,8 +7,7 @@ from urllib.parse import unquote
 
 from fasthtml.common import Div
 
-from db import get_creators
-from db import get_user_favourite_list_keys
+from db import get_creators, get_user_favourite_list_keys
 from db_lists import (
     _count_distinct_languages,
     get_category_groups,
@@ -23,8 +22,10 @@ from db_lists import (
     get_top_countries_with_counts,
     get_top_languages_with_counts,
     get_top_rated_creators,
+    get_topic_category_creators,
     get_veteran_creators,
     merge_language_variants,
+    resolve_category_slug,
 )
 from views.lists import (
     render_lists_page,
@@ -361,32 +362,29 @@ def country_detail_more_route(request):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _fetch_category_page(category_slug: str, page: int) -> tuple[list, int, int]:
+def _fetch_category_page(category_slug: str, page: int) -> tuple[list, int, int, str]:
     """
     Fetch one page of creators for a category detail view.
 
     Shared by ``category_detail_route`` and ``category_detail_more_route`` so
     the query parameters, sort order, and pagination formula stay in sync.
 
-    The slug is converted back to a space-separated search term
-    (e.g. ``"video-game-culture"`` → ``"video game culture"``), which is
-    then matched via ``get_creators(category_filter=...)`` using
-    ``ilike "%term%"`` against ``topic_categories``.
+    The URL slug is resolved back to the canonical topic category name via
+    ``resolve_category_slug`` (counts/cards use ``topic_categories``, not
+    ``primary_category``).  Creators are fetched with the same ILIKE logic as
+    ``get_top_creators_by_categories``.
 
     Args:
-        category_slug: URL-encoded hyphen/space-separated category slug from the URL.
+        category_slug: URL slug from the path (may be hyphenated or encoded).
         page: 1-based page number.
 
     Returns:
-        ``(creators, total_count, total_pages)`` tuple.
+        ``(creators, total_count, total_pages, category_name)`` tuple.
     """
-    # Decode URL-encoded characters (e.g. %20 for space, %28 for '(') to ensure
-    # categories with spaces or special characters round-trip correctly.
     decoded_slug = unquote(category_slug)
-    category_filter = _unslugify(decoded_slug)
-    result = get_creators(
-        category_filter=category_filter,
-        sort="subscribers",
+    category_name = resolve_category_slug(decoded_slug) or _unslugify(decoded_slug)
+    result = get_topic_category_creators(
+        category_name,
         limit=DETAIL_PAGE_LIMIT,
         offset=(page - 1) * DETAIL_PAGE_LIMIT,
         return_count=True,
@@ -396,7 +394,7 @@ def _fetch_category_page(category_slug: str, page: int) -> tuple[list, int, int]
     total_pages = (
         (total_count + DETAIL_PAGE_LIMIT - 1) // DETAIL_PAGE_LIMIT if total_count > 0 else 1
     )
-    return creators, total_count, total_pages
+    return creators, total_count, total_pages, category_name
 
 
 def category_detail_route(request, category_slug: str):
@@ -417,10 +415,11 @@ def category_detail_route(request, category_slug: str):
 
     page = _parse_page(request)
 
-    creators, total_count, total_pages = _fetch_category_page(category_slug, page)
+    creators, total_count, total_pages, category_name = _fetch_category_page(category_slug, page)
 
     return render_category_detail_page(
         category_slug=category_slug,
+        category_name=category_name,
         creators=creators,
         page=page,
         total_pages=total_pages,
@@ -449,10 +448,11 @@ def category_detail_more_route(request):
 
     page = _parse_page(request)
 
-    creators, total_count, total_pages = _fetch_category_page(category_slug, page)
+    creators, total_count, total_pages, category_name = _fetch_category_page(category_slug, page)
 
     return render_category_creators_rows(
         category_slug=category_slug,
+        category_name=category_name,
         creators=creators,
         page=page,
         total_pages=total_pages,

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -39,6 +39,7 @@ for _name in [
 ]:
     setattr(views_lists_stub, _name, lambda *args, **kwargs: None)
 views_lists_stub._unslugify = lambda slug: slug.replace("-", " ").title()
+views_lists_stub._list_heart_btn = lambda *args, **kwargs: None
 sys.modules.setdefault("views.lists", views_lists_stub)
 
 import db_lists

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -1,6 +1,6 @@
 """Tests for /lists/category/{slug} slug resolution and topic category queries."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import db_lists
 import routes.lists as lists_routes
@@ -9,6 +9,13 @@ import routes.lists as lists_routes
 def test_topic_category_ilike_term_wikipedia_url():
     term = db_lists._topic_category_ilike_term(
         "https://en.wikipedia.org/wiki/Lifestyle (sociology)"
+    )
+    assert term == "Lifestyle_(sociology)"
+
+
+def test_topic_category_ilike_term_handles_query_fragment_and_encoding():
+    term = db_lists._topic_category_ilike_term(
+        "https://en.wikipedia.org/wiki/Lifestyle_%28sociology%29?utm=foo#bar"
     )
     assert term == "Lifestyle_(sociology)"
 
@@ -28,6 +35,10 @@ def test_topic_category_jsonb_value_builds_wikipedia_url():
     )
 
 
+def test_topic_category_jsonb_value_non_catalog_label_returns_empty():
+    assert db_lists._topic_category_jsonb_value("Totally New Niche") == ""
+
+
 def test_resolve_category_slug_matches_slugify_catalogue(monkeypatch):
     monkeypatch.setattr(
         db_lists,
@@ -39,7 +50,14 @@ def test_resolve_category_slug_matches_slugify_catalogue(monkeypatch):
     )
     assert db_lists.resolve_category_slug("lifestyle-sociology") == "Lifestyle (sociology)"
     assert db_lists.resolve_category_slug("music") == "Music"
-    assert db_lists.resolve_category_slug("unknown-niche") is None
+    assert db_lists.resolve_category_slug("unknown-niche") == "Unknown niche"
+
+
+def test_resolve_category_slug_handles_wikipedia_url_input():
+    assert (
+        db_lists.resolve_category_slug("https://en.wikipedia.org/wiki/Video_game_culture")
+        == "Video game culture"
+    )
 
 
 def test_fetch_category_page_uses_topic_categories_not_primary_category(monkeypatch):

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -1,0 +1,68 @@
+"""Tests for /lists/category/{slug} slug resolution and topic category queries."""
+
+from unittest.mock import MagicMock, patch
+
+import db_lists
+import routes.lists as lists_routes
+
+
+def test_topic_category_ilike_term_wikipedia_url():
+    term = db_lists._topic_category_ilike_term(
+        "https://en.wikipedia.org/wiki/Lifestyle (sociology)"
+    )
+    assert term == "Lifestyle_(sociology)"
+
+
+def test_topic_category_ilike_term_plain_name():
+    assert db_lists._topic_category_ilike_term("Music") == "Music"
+
+
+def test_topic_category_jsonb_value_builds_wikipedia_url():
+    assert (
+        db_lists._topic_category_jsonb_value("Lifestyle (sociology)")
+        == "https://en.wikipedia.org/wiki/Lifestyle_(sociology)"
+    )
+    assert (
+        db_lists._topic_category_jsonb_value("https://en.wikipedia.org/wiki/Video_game_culture")
+        == "https://en.wikipedia.org/wiki/Video_game_culture"
+    )
+
+
+def test_resolve_category_slug_matches_slugify_catalogue(monkeypatch):
+    monkeypatch.setattr(
+        db_lists,
+        "_get_category_slug_map",
+        lambda: {
+            "lifestyle-sociology": "Lifestyle (sociology)",
+            "music": "Music",
+        },
+    )
+    assert db_lists.resolve_category_slug("lifestyle-sociology") == "Lifestyle (sociology)"
+    assert db_lists.resolve_category_slug("music") == "Music"
+    assert db_lists.resolve_category_slug("unknown-niche") is None
+
+
+def test_fetch_category_page_uses_topic_categories_not_primary_category(monkeypatch):
+    page_result = db_lists.TopicCategoryPageResult(
+        creators=[{"channel_name": "Test Channel", "current_subscribers": 1000}],
+        total_count=42,
+    )
+
+    monkeypatch.setattr(lists_routes, "resolve_category_slug", lambda slug: "Lifestyle (sociology)")
+    mock_get = MagicMock(return_value=page_result)
+    monkeypatch.setattr(lists_routes, "get_topic_category_creators", mock_get)
+
+    creators, total_count, total_pages, category_name = lists_routes._fetch_category_page(
+        "lifestyle-sociology", page=1
+    )
+
+    assert category_name == "Lifestyle (sociology)"
+    assert total_count == 42
+    assert total_pages == 3  # ceil(42 / 20)
+    assert len(creators) == 1
+    mock_get.assert_called_once_with(
+        "Lifestyle (sociology)",
+        limit=20,
+        offset=0,
+        return_count=True,
+    )

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -1,9 +1,111 @@
 """Tests for /lists/category/{slug} slug resolution and topic category queries."""
 
+import sys
+import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+supabase_stub = types.ModuleType("supabase")
+supabase_stub.Client = object
+supabase_stub.create_client = lambda *args, **kwargs: None
+sys.modules.setdefault("supabase", supabase_stub)
+
+monsterui_pkg = types.ModuleType("monsterui")
+monsterui_all = types.ModuleType("monsterui.all")
+monsterui_pkg.all = monsterui_all
+sys.modules.setdefault("monsterui", monsterui_pkg)
+sys.modules.setdefault("monsterui.all", monsterui_all)
+
+db_stub = types.ModuleType("db")
+db_stub.get_creators = lambda *args, **kwargs: None
+db_stub.get_user_favourite_list_keys = lambda *args, **kwargs: frozenset()
+sys.modules.setdefault("db", db_stub)
+
+views_lists_stub = types.ModuleType("views.lists")
+for _name in [
+    "render_lists_page",
+    "render_more_categories",
+    "render_more_countries",
+    "render_more_languages",
+    "render_categories_explorer_page",
+    "render_countries_explorer_page",
+    "render_languages_explorer_page",
+    "render_country_detail_page",
+    "render_country_creators_rows",
+    "render_category_detail_page",
+    "render_category_creators_rows",
+    "render_language_detail_page",
+    "render_language_creators_rows",
+]:
+    setattr(views_lists_stub, _name, lambda *args, **kwargs: None)
+views_lists_stub._unslugify = lambda slug: slug.replace("-", " ").title()
+sys.modules.setdefault("views.lists", views_lists_stub)
 
 import db_lists
 import routes.lists as lists_routes
+
+
+class _FakeQuery:
+    def __init__(self, client, call):
+        self._client = client
+        self._call = call
+
+    @property
+    def not_(self):
+        return self
+
+    def select(self, *args, **kwargs):
+        self._call["select"] = {"args": args, "kwargs": kwargs}
+        return self
+
+    def filter(self, *args):
+        self._call["filter"] = args
+        return self
+
+    def eq(self, *args):
+        self._call.setdefault("eq", []).append(args)
+        return self
+
+    def is_(self, *args):
+        self._call.setdefault("is", []).append(args)
+        return self
+
+    def gt(self, *args):
+        self._call.setdefault("gt", []).append(args)
+        return self
+
+    def ilike(self, *args):
+        self._call["ilike"] = args
+        return self
+
+    def order(self, *args, **kwargs):
+        self._call["order"] = {"args": args, "kwargs": kwargs}
+        return self
+
+    def limit(self, limit):
+        self._call["limit"] = limit
+        return self
+
+    def offset(self, offset):
+        self._call["offset"] = offset
+        return self
+
+    def execute(self):
+        result = self._client.responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return SimpleNamespace(**result)
+
+
+class _FakeSupabaseClient:
+    def __init__(self, *responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def table(self, name):
+        call = {"table": name}
+        self.calls.append(call)
+        return _FakeQuery(self, call)
 
 
 def test_topic_category_ilike_term_wikipedia_url():
@@ -18,6 +120,11 @@ def test_topic_category_ilike_term_handles_query_fragment_and_encoding():
         "https://en.wikipedia.org/wiki/Lifestyle_%28sociology%29?utm=foo#bar"
     )
     assert term == "Lifestyle_(sociology)"
+
+
+def test_topic_category_ilike_term_empty_input_returns_empty_string():
+    assert db_lists._topic_category_ilike_term("") == ""
+    assert db_lists._topic_category_ilike_term(None) == ""
 
 
 def test_topic_category_ilike_term_plain_name():
@@ -58,6 +165,99 @@ def test_resolve_category_slug_handles_wikipedia_url_input():
         db_lists.resolve_category_slug("https://en.wikipedia.org/wiki/Video_game_culture")
         == "Video game culture"
     )
+
+
+def test_get_category_slug_map_learns_observed_non_fixed_labels(monkeypatch):
+    monkeypatch.setattr(
+        db_lists,
+        "_fetch_top_counts",
+        lambda *args, **kwargs: [("Unexpected category", 7)],
+    )
+    monkeypatch.setattr(db_lists, "_category_slug_cache", {"expires_at": 0.0, "map": {}})
+
+    slug_map = db_lists._get_category_slug_map()
+
+    assert slug_map["unexpected-category"] == "Unexpected category"
+
+
+def test_get_topic_category_creators_empty_category_returns_empty(monkeypatch):
+    monkeypatch.setattr(
+        db_lists,
+        "_get_supabase_client",
+        lambda: (_ for _ in ()).throw(AssertionError("client should not be used")),
+    )
+
+    result = db_lists.get_topic_category_creators("   ", return_count=True)
+
+    assert result.creators == []
+    assert result.total_count == 0
+
+
+def test_get_topic_category_creators_exact_failure_falls_back_once(monkeypatch):
+    fake_client = _FakeSupabaseClient(
+        RuntimeError("jsonb path failed"),
+        {
+            "data": [{"channel_name": "Fallback Channel", "current_subscribers": 123}],
+            "count": 1,
+        },
+    )
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+
+    result = db_lists.get_topic_category_creators(
+        "Lifestyle (sociology)",
+        limit=10,
+        return_count=True,
+    )
+
+    assert result.total_count == 1
+    assert result.creators[0]["channel_name"] == "Fallback Channel"
+    assert len(fake_client.calls) == 2
+    assert "filter" in fake_client.calls[0]
+    assert "ilike" in fake_client.calls[1]
+
+
+def test_get_topic_category_creators_empty_exact_result_uses_text_fallback(monkeypatch):
+    fake_client = _FakeSupabaseClient(
+        {"data": [], "count": 0},
+        {
+            "data": [{"channel_name": "Legacy Match", "current_subscribers": 456}],
+            "count": 1,
+        },
+    )
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+
+    result = db_lists.get_topic_category_creators("Lifestyle (sociology)", return_count=True)
+
+    assert result.total_count == 1
+    assert result.creators[0]["channel_name"] == "Legacy Match"
+    assert len(fake_client.calls) == 2
+    assert "filter" in fake_client.calls[0]
+    assert "ilike" in fake_client.calls[1]
+
+
+def test_get_topic_category_creators_applies_offset_to_rank(monkeypatch):
+    fake_client = _FakeSupabaseClient(
+        {
+            "data": [
+                {"channel_name": "Ranked Channel 1", "current_subscribers": 100},
+                {"channel_name": "Ranked Channel 2", "current_subscribers": 90},
+            ],
+            "count": 2,
+        }
+    )
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+
+    offset = 10
+    result = db_lists.get_topic_category_creators(
+        "Video game culture",
+        limit=2,
+        offset=offset,
+        return_count=True,
+    )
+
+    assert result.total_count == 2
+    assert result.creators[0]["_rank"] == 11
+    assert result.creators[1]["_rank"] == 12
 
 
 def test_fetch_category_page_uses_topic_categories_not_primary_category(monkeypatch):

--- a/tests/test_lists_category_endpoints.py
+++ b/tests/test_lists_category_endpoints.py
@@ -1,0 +1,145 @@
+"""Endpoint-level unit tests for lists category flows."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import db_lists
+import routes.lists as lists_routes
+
+
+def _req(*, query_params=None, session=None, category_slug=None):
+    req = SimpleNamespace(
+        query_params=query_params or {},
+        session=session or {},
+    )
+    if category_slug is not None:
+        req.category_slug = category_slug
+    return req
+
+
+def test_get_top_categories_with_counts_projects_onto_fixed_taxonomy(monkeypatch):
+    monkeypatch.setattr(
+        db_lists,
+        "_fetch_top_counts",
+        lambda *args, **kwargs: [
+            ("Music", 100),
+            ("Technology", 80),
+            ("Lifestyle (sociology)", 50),
+            ("Unexpected category", 999),
+        ],
+    )
+
+    rows = db_lists.get_top_categories_with_counts(limit=db_lists.TOTAL_TOPIC_CATEGORIES)
+
+    assert len(rows) == db_lists.TOTAL_TOPIC_CATEGORIES
+    assert rows[0] == ("Music", 100)
+    assert not any(name == "Unexpected category" for name, _ in rows)
+
+
+def test_get_lists_meta_forces_fixed_total_categories(monkeypatch):
+    class _RpcCall:
+        def execute(self):
+            return SimpleNamespace(
+                data=[
+                    {
+                        "total_creators": 10,
+                        "total_countries": 3,
+                        "total_categories": 999,
+                        "total_languages": 4,
+                    }
+                ]
+            )
+
+    class _Client:
+        def rpc(self, *_args, **_kwargs):
+            return _RpcCall()
+
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: _Client())
+    db_lists.clear_lists_meta_cache()
+
+    meta = db_lists.get_lists_meta()
+
+    assert meta["total_creators"] == 10
+    assert meta["total_countries"] == 3
+    assert meta["total_languages"] == 4
+    assert meta["total_categories"] == db_lists.TOTAL_TOPIC_CATEGORIES
+
+
+def test_lists_more_categories_route_uses_meta_and_renders(monkeypatch):
+    monkeypatch.setattr(
+        lists_routes,
+        "get_lists_meta",
+        lambda: {"total_categories": db_lists.TOTAL_TOPIC_CATEGORIES},
+    )
+    monkeypatch.setattr(
+        lists_routes,
+        "get_category_groups",
+        lambda **kwargs: [{"category": "Music", "count": 100, "creators": []}],
+    )
+
+    captured = {}
+
+    def _render(groups, next_offset, has_more, total, fav_keys, authenticated):
+        captured.update(
+            {
+                "groups": groups,
+                "next_offset": next_offset,
+                "has_more": has_more,
+                "total": total,
+                "authenticated": authenticated,
+            }
+        )
+        return captured
+
+    monkeypatch.setattr(lists_routes, "render_more_categories", _render)
+
+    out = lists_routes.lists_more_categories_route(_req(query_params={"offset": "8"}))
+
+    assert out["groups"][0]["category"] == "Music"
+    assert out["next_offset"] == 9
+    assert out["total"] == db_lists.TOTAL_TOPIC_CATEGORIES
+    assert out["has_more"] is True
+
+
+def test_categories_explorer_route_calls_counts_endpoint(monkeypatch):
+    mock_counts = MagicMock(return_value=[("Music", 100), ("Technology", 80)])
+    monkeypatch.setattr(lists_routes, "get_top_categories_with_counts", mock_counts)
+    monkeypatch.setattr(lists_routes, "render_categories_explorer_page", lambda data: data)
+
+    out = lists_routes.categories_explorer_route()
+
+    mock_counts.assert_called_once_with(limit=2000)
+    assert out[0] == ("Music", 100)
+
+
+def test_category_detail_route_renders_with_slug_resolution(monkeypatch):
+    monkeypatch.setattr(
+        lists_routes,
+        "_fetch_category_page",
+        lambda slug, page: ([{"channel_name": "A"}], 21, 2, "Lifestyle (sociology)"),
+    )
+
+    captured = {}
+
+    def _render(**kwargs):
+        captured.update(kwargs)
+        return captured
+
+    monkeypatch.setattr(lists_routes, "render_category_detail_page", _render)
+
+    out = lists_routes.category_detail_route(
+        _req(query_params={"page": "1"}), "lifestyle-sociology"
+    )
+
+    assert out["category_slug"] == "lifestyle-sociology"
+    assert out["category_name"] == "Lifestyle (sociology)"
+    assert out["total_count"] == 21
+    assert out["total_pages"] == 2
+
+
+def test_category_detail_more_route_requires_slug(monkeypatch):
+    monkeypatch.setattr(lists_routes, "Div", lambda text, cls=None: {"text": text, "cls": cls})
+
+    out = lists_routes.category_detail_more_route(_req())
+
+    assert out["text"] == "Error: Invalid category"

--- a/tests/test_lists_category_endpoints.py
+++ b/tests/test_lists_category_endpoints.py
@@ -39,6 +39,7 @@ for _name in [
 ]:
     setattr(views_lists_stub, _name, lambda *args, **kwargs: None)
 views_lists_stub._unslugify = lambda slug: slug.replace("-", " ").title()
+views_lists_stub._list_heart_btn = lambda *args, **kwargs: None
 sys.modules.setdefault("views.lists", views_lists_stub)
 
 import db_lists

--- a/tests/test_lists_category_endpoints.py
+++ b/tests/test_lists_category_endpoints.py
@@ -1,7 +1,45 @@
 """Endpoint-level unit tests for lists category flows."""
 
+import sys
+import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+supabase_stub = types.ModuleType("supabase")
+supabase_stub.Client = object
+supabase_stub.create_client = lambda *args, **kwargs: None
+sys.modules.setdefault("supabase", supabase_stub)
+
+monsterui_pkg = types.ModuleType("monsterui")
+monsterui_all = types.ModuleType("monsterui.all")
+monsterui_pkg.all = monsterui_all
+sys.modules.setdefault("monsterui", monsterui_pkg)
+sys.modules.setdefault("monsterui.all", monsterui_all)
+
+db_stub = types.ModuleType("db")
+db_stub.get_creators = lambda *args, **kwargs: None
+db_stub.get_user_favourite_list_keys = lambda *args, **kwargs: frozenset()
+sys.modules.setdefault("db", db_stub)
+
+views_lists_stub = types.ModuleType("views.lists")
+for _name in [
+    "render_lists_page",
+    "render_more_categories",
+    "render_more_countries",
+    "render_more_languages",
+    "render_categories_explorer_page",
+    "render_countries_explorer_page",
+    "render_languages_explorer_page",
+    "render_country_detail_page",
+    "render_country_creators_rows",
+    "render_category_detail_page",
+    "render_category_creators_rows",
+    "render_language_detail_page",
+    "render_language_creators_rows",
+]:
+    setattr(views_lists_stub, _name, lambda *args, **kwargs: None)
+views_lists_stub._unslugify = lambda slug: slug.replace("-", " ").title()
+sys.modules.setdefault("views.lists", views_lists_stub)
 
 import db_lists
 import routes.lists as lists_routes
@@ -34,6 +72,32 @@ def test_get_top_categories_with_counts_projects_onto_fixed_taxonomy(monkeypatch
     assert len(rows) == db_lists.TOTAL_TOPIC_CATEGORIES
     assert rows[0] == ("Music", 100)
     assert not any(name == "Unexpected category" for name, _ in rows)
+
+
+def test_get_top_categories_with_counts_respects_smaller_limit_and_tie_order(monkeypatch):
+    monkeypatch.setattr(
+        db_lists,
+        "_fetch_top_counts",
+        lambda *args, **kwargs: [
+            ("Technology", 80),
+            ("Music", 80),
+            ("Lifestyle (sociology)", 50),
+        ],
+    )
+
+    rows = db_lists.get_top_categories_with_counts(limit=2)
+
+    assert rows == [("Music", 80), ("Technology", 80)]
+
+
+def test_get_top_categories_with_counts_zero_limit_returns_empty(monkeypatch):
+    monkeypatch.setattr(
+        db_lists,
+        "_fetch_top_counts",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not fetch")),
+    )
+
+    assert db_lists.get_top_categories_with_counts(limit=0) == []
 
 
 def test_get_lists_meta_forces_fixed_total_categories(monkeypatch):
@@ -143,3 +207,28 @@ def test_category_detail_more_route_requires_slug(monkeypatch):
     out = lists_routes.category_detail_more_route(_req())
 
     assert out["text"] == "Error: Invalid category"
+
+
+def test_category_detail_more_route_happy_path(monkeypatch):
+    monkeypatch.setattr(
+        lists_routes,
+        "_fetch_category_page",
+        lambda slug, page: ([{"channel_name": "A"}], 21, 2, "Lifestyle (sociology)"),
+    )
+
+    captured = {}
+
+    def _render(**kwargs):
+        captured.update(kwargs)
+        return captured
+
+    monkeypatch.setattr(lists_routes, "render_category_creators_rows", _render)
+
+    out = lists_routes.category_detail_more_route(
+        _req(query_params={"page": "1"}, category_slug="lifestyle-sociology")
+    )
+
+    assert out["category_slug"] == "lifestyle-sociology"
+    assert out["category_name"] == "Lifestyle (sociology)"
+    assert out["page"] == 1
+    assert out["total_pages"] == 2

--- a/views/lists.py
+++ b/views/lists.py
@@ -497,7 +497,7 @@ def _category_group_card(
 
     list_key = f"category:{display_name}"
     list_label = f"{emoji} {display_name}"
-    list_url = f"/lists/category/{quote(display_name, safe='')}"
+    list_url = f"/lists/category/{slugify(display_name)}"
 
     return Div(
         # Header: emoji + name + creator count + heart
@@ -1599,6 +1599,7 @@ def render_category_detail_page(
     total_pages: int = 1,
     total_count: int = 0,
     page_size: int = 20,
+    category_name: str | None = None,
 ) -> Div:
     """
     Render the detailed category-wise creator rankings page.
@@ -1607,6 +1608,7 @@ def render_category_detail_page(
 
     Args:
         category_slug: URL slug derived from the category display name
+        category_name: Canonical topic category label (resolved from slug)
         creators: List of creator dicts for this page
         page: Current page number (1-based)
         total_pages: Total number of pages
@@ -1616,7 +1618,7 @@ def render_category_detail_page(
     Returns:
         Div component with full detail page
     """
-    display_name = _unslugify(category_slug).title()
+    display_name = category_name or _unslugify(category_slug).title()
     emoji = get_topic_category_emoji(display_name)
 
     start_rank = (page - 1) * page_size + 1
@@ -1695,6 +1697,7 @@ def render_category_creators_rows(
     total_pages: int = 1,
     total_count: int = 0,
     page_size: int = 20,
+    category_name: str | None = None,
 ) -> Div:
     """
     Render just the creator rows for the HTMX load-more endpoint.
@@ -1959,7 +1962,7 @@ def render_categories_explorer_page(
     for i, (cat_name, count) in enumerate(categories):
         pct = round(count / max_count * 100)
         emoji = get_topic_category_emoji(cat_name)
-        slug = quote(cat_name, safe="")
+        slug = slugify(cat_name)
         bar_cls = bar_colours[i % len(bar_colours)]
 
         bar_rows.append(
@@ -2504,7 +2507,7 @@ def _heatmap_tile(item: dict, max_count: int) -> FT:
         f"avg growth {growth_str} · engagement {engagement_str} · "
         f"A/A+ {premium_str}"
     )
-    href = f"/lists/category/{quote(cat.replace(' ', '-').lower())}"
+    href = f"/lists/category/{slugify(cat)}"
 
     return A(
         Div(
@@ -2545,7 +2548,7 @@ def _heatmap_spotlight_bar(item: dict, rank: int) -> FT:
     growth_str = f"{avg_growth:+.1f}%" if avg_growth is not None else "—"
     medals = {1: "🥇", 2: "🥈", 3: "🥉"}
     rank_badge = medals.get(rank, f"#{rank}")
-    href = f"/lists/category/{quote(cat.replace(' ', '-').lower())}"
+    href = f"/lists/category/{slugify(cat)}"
     bar_pct = max(0, min(100, round((avg_growth or 0) / 35 * 100)))
     emoji = _CATEGORY_EMOJI.get(cat.lower(), "📺")
 
@@ -2575,7 +2578,7 @@ def _heatmap_cooling_bar(item: dict) -> FT:
     avg_growth = item.get("avg_growth_pct")
     growth_str = f"{avg_growth:+.1f}%" if avg_growth is not None else "—"
     emoji = _CATEGORY_EMOJI.get(cat.lower(), "📺")
-    href = f"/lists/category/{quote(cat.replace(' ', '-').lower())}"
+    href = f"/lists/category/{slugify(cat)}"
 
     return Div(
         Span("📉", cls="shrink-0"),


### PR DESCRIPTION
## Summary by Sourcery

Align topic category URLs, counts, and detail pages with a fixed YouTube topic taxonomy and robust slug resolution, and update endpoints/tests accordingly.

New Features:
- Introduce a fixed YouTube topic category taxonomy with canonical labels, slugs, and Wikipedia URL handling.
- Add slug resolution and topic-category-specific creator pagination for category detail pages.

Bug Fixes:
- Ensure category detail pages, heatmap links, and group cards correctly resolve and query topic categories regardless of URL encoding or legacy storage formats.
- Fix category totals and category lists to use the fixed taxonomy instead of volatile DB-derived counts.

Enhancements:
- Refine category filtering logic to prefer exact JSONB containment with fallbacks to text search for legacy rows.
- Centralize topic category normalization/parsing helpers and reuse them across counts, heatmap, and meta fallbacks.

Tests:
- Add endpoint and helper tests covering topic category slug resolution, taxonomy projection, list meta totals, and category detail flows.