### PR TITLE
fix(creators): fix statement timeouts on country and multi-filter que…

### DIFF
--- a/db.py
+++ b/db.py
@@ -3263,7 +3263,10 @@ def get_creators(
         # Only show fully-synced creators — mirrors calculate_creator_stats() behaviour.
         # Excludes "pending" / "error" rows that have no real stats yet, which would
         # otherwise appear as blank cards and skew pagination counts.
-        query = query.in_("sync_status", ["synced", "pending"])
+        # NOTE: must stay as .eq("synced") — partial indexes (migrations 008, 028, etc.)
+        # are all defined WHERE sync_status = 'synced'. Using IN ('synced', 'pending')
+        # disqualifies every partial index and forces a full table scan.
+        query = query.eq("sync_status", "synced")
 
         # Apply search filter
         if search:
@@ -3321,11 +3324,16 @@ def get_creators(
             elif age_filter == "veteran":
                 query = query.gte("channel_age_days", 3650)  # >= 10 years
 
-        # Apply country filter (case-insensitive: DB stores "US", URL may pass "us")
+        # Apply country filter. DB stores ISO 3166-1 alpha-2 codes in uppercase ("US",
+        # "BM", "JP"). Normalize the input to uppercase so we can use .eq() and let
+        # idx_creators_country_synced (B-tree, migration 008) serve the query as an
+        # index scan. Using .ilike() here defeats the B-tree index and forces a full
+        # sequential scan, which causes statement timeouts on large tables (pg error
+        # 57014). .eq() is safe because there is only one valid casing for country codes.
         if country_filter and country_filter != "all":
-            normalized_country = country_filter.strip()
+            normalized_country = country_filter.strip().upper()
             if normalized_country:
-                query = query.ilike("country_code", normalized_country)
+                query = query.eq("country_code", normalized_country)
 
         # Apply category filter using the primary_category column.
         # primary_category is a clean, normalized, single-value text field

--- a/db/migrations/043_add_filter_sort_indexes.sql
+++ b/db/migrations/043_add_filter_sort_indexes.sql
@@ -1,0 +1,64 @@
+-- Migration 043: Add B-tree partial indexes for filter and sort columns
+--
+-- Problem: get_creators() supports filtering on language, grade, activity,
+-- and channel age, plus sorting by upload consistency.  None of these columns
+-- had indexes, so every filtered query fell back to a full sequential scan
+-- of the creators table, causing statement timeouts (pg error 57014) or
+-- HTTP/2 server disconnects (RemoteProtocolError) on large datasets.
+--
+-- All indexes are partial, matching the same WHERE predicate as the existing
+-- base listing indexes (migrations 008, 028) so the query planner can
+-- combine them via BitmapAnd / BitmapOr plans rather than seq-scanning.
+--
+-- Note: uses plain CREATE INDEX (not CONCURRENTLY) so it can run inside a
+-- transaction block (Supabase SQL editor / migration runners). Each index
+-- build briefly acquires a ShareLock on the creators table; run during a
+-- low-traffic window if the table is large.
+--
+-- Prerequisites: migration 008 (idx_creators_listing_base already exists).
+
+-- 1. default_language — used by language_filter (eq).
+--    Allows the planner to jump directly to rows for a single language
+--    rather than scanning all synced creators.
+CREATE INDEX IF NOT EXISTS idx_creators_language_synced
+    ON public.creators (default_language)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- 2. quality_grade — used by grade_filter (eq: A+, A, B+, B, C).
+CREATE INDEX IF NOT EXISTS idx_creators_grade_synced
+    ON public.creators (quality_grade)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- 3. monthly_uploads — used by:
+--    a) activity_filter: dormant (< 1) and active (> 5) via range predicates
+--    b) consistency sort: ORDER BY monthly_uploads DESC
+--    A DESC index serves the ORDER BY directly (no sort step) and also
+--    supports range predicates in either direction.
+CREATE INDEX IF NOT EXISTS idx_creators_monthly_uploads_synced
+    ON public.creators (monthly_uploads DESC)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- 4. channel_age_days — used by age_filter (new <365, established 365-3650,
+--    veteran >=3650) via range predicates.
+CREATE INDEX IF NOT EXISTS idx_creators_channel_age_synced
+    ON public.creators (channel_age_days)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- Verification queries (run after applying):
+-- SELECT indexname, indexdef
+-- FROM pg_indexes
+-- WHERE tablename = 'creators'
+--   AND indexname IN (
+--     'idx_creators_language_synced',
+--     'idx_creators_grade_synced',
+--     'idx_creators_monthly_uploads_synced',
+--     'idx_creators_channel_age_synced'
+--   );


### PR DESCRIPTION
…ries

- change country_code filter from ilike to eq with .upper() normalization so idx_creators_country_synced (B-tree, migration 008) is used instead of forcing a full sequential scan on every country filter request

- change sync_status from IN ('synced', 'pending') back to eq('synced') so all existing partial indexes (migrations 008, 028, etc.) remain usable; IN predicates do not match partial index WHERE clauses

- add migration 043 with four missing partial indexes for the remaining filter and sort columns: default_language, quality_grade, monthly_uploads (also covers consistency sort), channel_age_days

## Summary by Sourcery

Optimize creator listing queries to avoid full table scans and statement timeouts by aligning filters with indexed columns and adding missing partial indexes for key filters and sorts.

Bug Fixes:
- Limit creator results to fully synced records so existing partial indexes on sync_status remain usable.
- Normalize and compare country codes case-sensitively to leverage the existing country_code index instead of triggering sequential scans.

Enhancements:
- Add partial B-tree indexes on language, quality grade, monthly uploads, and channel age to speed up creator filtering and sorting on large datasets.

Build:
- Introduce migration 043 to create the new partial indexes on the creators table.