### PR TITLE
feat(creator-profile): human-readable y-axes and peer scatter on box …

### DIFF
--- a/components/category_stats.py
+++ b/components/category_stats.py
@@ -32,17 +32,45 @@ from monsterui.all import ApexChart
 
 logger = logging.getLogger(__name__)
 
-# Metric config: (stats_key, display_label, js_formatter_suffix)
-_METRICS: list[tuple[str, str, str]] = [
-    ("subscribers", "Subscribers", ""),
-    ("views", "Total Views", ""),
-    ("engagement", "Engagement %", "%"),
-    ("monthly_uploads", "Monthly Uploads", "/mo"),
+# Metric config: (stats_key, display_label, creator_field, js_y_formatter)
+# js_y_formatter: JS function string passed to ApexCharts yaxis.labels.formatter
+# and tooltip.y.formatter so every number is human-readable.
+_METRICS: list[tuple[str, str, str, str]] = [
+    (
+        "subscribers",
+        "Subscribers",
+        "current_subscribers",
+        "function(val){if(val>=1e9)return(val/1e9).toFixed(1)+'B';"
+        "if(val>=1e6)return(val/1e6).toFixed(1)+'M';"
+        "if(val>=1e3)return(val/1e3).toFixed(1)+'K';return String(Math.round(val));}",
+    ),
+    (
+        "views",
+        "Total Views",
+        "current_view_count",
+        "function(val){if(val>=1e9)return(val/1e9).toFixed(1)+'B';"
+        "if(val>=1e6)return(val/1e6).toFixed(1)+'M';"
+        "if(val>=1e3)return(val/1e3).toFixed(1)+'K';return String(Math.round(val));}",
+    ),
+    (
+        "engagement",
+        "Engagement %",
+        "engagement_score",
+        "function(val){return val.toFixed(2)+'%';}",
+    ),
+    (
+        "monthly_uploads",
+        "Monthly Uploads",
+        "monthly_uploads",
+        "function(val){return val.toFixed(1)+'/mo';}",
+    ),
 ]
 
 _BOX_FILL = "#f1f5f9"  # slate-100
 _BOX_STROKE = "#94a3b8"  # slate-400
 _STAR_COLOR = "#ef4444"  # red-500
+_PEER_COLOR = "#6366f1"  # indigo-500 — muted reference dots for peer creators
+_PEER_MAX = 20  # max peer samples per chart to avoid clutter
 
 
 # Public API
@@ -51,23 +79,49 @@ _STAR_COLOR = "#ef4444"  # red-500
 def render_category_box_plots(
     creator: dict,
     category_stats: dict | None,
+    peers: list[dict] | None = None,
 ) -> Div:
     """
     Top-level entry point called from views/creators.py.
 
     Returns a self-contained Div - either the 2x2 ApexChart grid or a
     muted placeholder when stats are not available yet.
+
+    Args:
+        creator:        Creator dict (must contain at least primary_category).
+        category_stats: Pre-aggregated box plot stats row from the DB cache.
+        peers:          Optional combined list of "you may also like" +
+                        "similar creators" dicts.  Up to _PEER_MAX samples
+                        are plotted as indigo scatter points so the viewer
+                        can see where their peer group sits relative to the
+                        category distribution.
     """
     category = creator.get("primary_category", "")
 
     if not category_stats or not category:
         return _placeholder(category)
 
-    creator_values = {
-        "subscribers": _safe_float(creator.get("current_subscribers")),
-        "views": _safe_float(creator.get("current_view_count")),
-        "engagement": _safe_float(creator.get("engagement_score")),
-        "monthly_uploads": _safe_float(creator.get("monthly_uploads")),
+    # Map stats_key → creator metric value using the field name from _METRICS.
+    creator_values: dict[str, float | None] = {
+        key: _safe_float(creator.get(field)) for key, _, field, _ in _METRICS
+    }
+
+    # Deduplicate and cap peer samples (exclude the current creator itself).
+    creator_id = creator.get("id")
+    seen_ids: set = {creator_id} if creator_id else set()
+    sampled_peers: list[dict] = []
+    for p in peers or []:
+        pid = p.get("id")
+        if pid and pid not in seen_ids:
+            seen_ids.add(pid)
+            sampled_peers.append(p)
+            if len(sampled_peers) >= _PEER_MAX:
+                break
+
+    # Per-metric peer value lists (preserves _METRICS order, filters None).
+    peer_values_by_metric: dict[str, list[float]] = {
+        key: [v for p in sampled_peers if (v := _safe_float(p.get(field))) is not None]
+        for key, _, field, _ in _METRICS
     }
 
     peer_count = category_stats.get("count", 0)
@@ -91,8 +145,10 @@ def render_category_box_plots(
                     stats=category_stats.get(key, {}),
                     creator_value=creator_values.get(key),
                     category=category,
+                    formatter=fmt,
+                    peer_values=peer_values_by_metric.get(key, []),
                 )
-                for key, label, _ in _METRICS
+                for key, label, _, fmt in _METRICS
                 if category_stats.get(key)
             ],
             cls="grid grid-cols-1 sm:grid-cols-2 gap-4",
@@ -112,12 +168,19 @@ def _box_chart(
     stats: dict,
     creator_value: float | None,
     category: str,
+    formatter: str = "",
+    peer_values: list[float] | None = None,
 ) -> Div:
     """
-    Single ApexChart box plot with optional scatter overlay for the creator.
+    Single ApexChart box plot with optional scatter overlays.
 
-    ApexCharts boxPlot series expects y as [min, q1, median, q3, max].
-    The scatter series overlays the creator's value as a coloured marker.
+    - The category distribution is the box (min/p25/median/p75/max).
+    - ``creator_value`` is plotted as a red star so the viewer can see
+      where this creator sits inside the distribution.
+    - ``peer_values`` (you-may-also-like + similar creators) are plotted
+      as indigo circles behind the creator star, giving a peer reference.
+    - ``formatter`` is a JS function string applied to both yaxis labels
+      and tooltip values (e.g. "function(val){return (val/1e6).toFixed(1)+'M'}").
 
     Returns an empty Div if the stats dict is missing any required key —
     guards against partially populated cache rows without scattering .get()
@@ -149,7 +212,18 @@ def _box_chart(
         ],
     }
 
-    series = [box_series]
+    # Build series list: boxPlot → peers (behind) → creator (on top).
+    series: list[dict] = [box_series]
+
+    has_peers = bool(peer_values)
+    if has_peers:
+        series.append(
+            {
+                "name": "Peers",
+                "type": "scatter",
+                "data": [{"x": category, "y": v} for v in peer_values],
+            }
+        )
 
     if creator_value is not None:
         series.append(
@@ -159,6 +233,30 @@ def _box_chart(
                 "data": [{"x": category, "y": creator_value}],
             }
         )
+
+    # Marker config arrays are indexed by series position.
+    marker_sizes: list[int] = [0]  # boxPlot: no dots
+    marker_colors: list[str] = [_BOX_STROKE]
+    marker_shapes: list[str] = ["circle"]
+
+    if has_peers:
+        marker_sizes.append(5)
+        marker_colors.append(_PEER_COLOR)
+        marker_shapes.append("circle")
+
+    if creator_value is not None:
+        marker_sizes.append(8)
+        marker_colors.append(_STAR_COLOR)
+        marker_shapes.append("star")
+
+    # Tooltip and yaxis both use the same formatter when provided.
+    tooltip: dict = {"shared": False, "intersect": True}
+    if formatter:
+        tooltip["y"] = {"formatter": formatter}
+
+    yaxis_labels: dict = {"show": True}
+    if formatter:
+        yaxis_labels["formatter"] = formatter
 
     opts = {
         "chart": {
@@ -180,17 +278,16 @@ def _box_chart(
             },
         },
         "markers": {
-            # index 0 = boxPlot (no dots), index 1 = scatter (star marker)
-            "size": [0, 8],
-            "colors": [_BOX_STROKE, _STAR_COLOR],
-            "strokeColors": ["#fff", "#fff"],
+            "size": marker_sizes,
+            "colors": marker_colors,
+            "strokeColors": ["#fff"] * len(marker_sizes),
             "strokeWidth": 2,
-            "shape": ["circle", "star"],
+            "shape": marker_shapes,
         },
-        "tooltip": {"shared": False, "intersect": True},
+        "tooltip": tooltip,
         "xaxis": {"labels": {"show": False}, "axisTicks": {"show": False}},
-        "yaxis": {"labels": {"show": True}},
-        "legend": {"show": False},
+        "yaxis": {"labels": yaxis_labels},
+        "legend": {"show": has_peers},
         "grid": {"borderColor": "#f3f4f6", "strokeDashArray": 4},
     }
 

--- a/components/category_stats.py
+++ b/components/category_stats.py
@@ -35,23 +35,16 @@ logger = logging.getLogger(__name__)
 # Metric config: (stats_key, display_label, creator_field, js_y_formatter)
 # js_y_formatter: JS function string passed to ApexCharts yaxis.labels.formatter
 # and tooltip.y.formatter so every number is human-readable.
+
+_LARGE_NUMBER_FORMATTER = (
+    "function(val){if(val>=1e9)return(val/1e9).toFixed(1)+'B';"
+    "if(val>=1e6)return(val/1e6).toFixed(1)+'M';"
+    "if(val>=1e3)return(val/1e3).toFixed(1)+'K';return String(Math.round(val));}"
+)
+
 _METRICS: list[tuple[str, str, str, str]] = [
-    (
-        "subscribers",
-        "Subscribers",
-        "current_subscribers",
-        "function(val){if(val>=1e9)return(val/1e9).toFixed(1)+'B';"
-        "if(val>=1e6)return(val/1e6).toFixed(1)+'M';"
-        "if(val>=1e3)return(val/1e3).toFixed(1)+'K';return String(Math.round(val));}",
-    ),
-    (
-        "views",
-        "Total Views",
-        "current_view_count",
-        "function(val){if(val>=1e9)return(val/1e9).toFixed(1)+'B';"
-        "if(val>=1e6)return(val/1e6).toFixed(1)+'M';"
-        "if(val>=1e3)return(val/1e3).toFixed(1)+'K';return String(Math.round(val));}",
-    ),
+    ("subscribers", "Subscribers", "current_subscribers", _LARGE_NUMBER_FORMATTER),
+    ("views", "Total Views", "current_view_count", _LARGE_NUMBER_FORMATTER),
     (
         "engagement",
         "Engagement %",

--- a/views/creators.py
+++ b/views/creators.py
@@ -4502,7 +4502,14 @@ def render_creator_profile_page(
     # ═══════════════════════════════════════════════════════════════════════════
     # SECTION 5 — Category comparison box plots
     # ═══════════════════════════════════════════════════════════════════════════
-    box_plot_section = render_category_box_plots(creator, category_stats)
+    # Combine "you may also like" (similar_creators) and embedding peers into
+    # one deduplicated pool so all peer scatter points come from faces the
+    # viewer already sees elsewhere on the page.
+    _peer_pool = (similar_creators or []) + (embedding_peers or [])
+    _peers_deduped = list(
+        {p["id"]: p for p in _peer_pool if p.get("id") and p.get("id") != creator_id}.values()
+    )
+    box_plot_section = render_category_box_plots(creator, category_stats, peers=_peers_deduped)
 
     return Div(
         banner_section,


### PR DESCRIPTION
…plots

- add JS number formatters to _METRICS (M/K/B suffixes for subscribers and views, % for engagement, /mo for uploads); applied to both yaxis labels and tooltips so raw numbers like 31200000 become "31.2M"

- plot "you may also like" and "similar creators" as indigo scatter points on each box plot so viewers can see where their peer group sits relative to the full category distribution; capped at 20 points per chart to avoid clutter, legend shown only when peers are present

- deduplicate peer pool in views/creators.py before passing to render_category_box_plots; no additional DB queries needed

## Summary by Sourcery

Add human-readable formatting and peer scatter overlays to creator category box plots.

New Features:
- Format box plot y-axes and tooltips with human-readable suffixes for subscribers, views, engagement percentage, and monthly uploads.
- Overlay peer creators as indigo scatter points on category box plots, capped per chart and shown only when peers are available.

Enhancements:
- Derive creator and peer metric values from a shared metric configuration to keep box plots consistent across stats.
- Deduplicate and cap the combined pool of similar and embedding peers before passing them into box plot rendering so scatter points reflect unique, visible peers.