### PR TITLE
fix: surface total DB size in hero; retry RemoteProtocolError in get_…

### DIFF
--- a/db.py
+++ b/db.py
@@ -1610,8 +1610,12 @@ def get_creator_stats(creator_id: str) -> Optional[Dict[str, Any]]:
         return None
 
     try:
-        response = (
-            supabase_client.table(CREATOR_TABLE).select("*").eq("id", creator_id).single().execute()
+        response = _db_execute(
+            lambda: supabase_client.table(CREATOR_TABLE)
+            .select("*")
+            .eq("id", creator_id)
+            .single()
+            .execute()
         )
 
         if response.data:
@@ -3378,7 +3382,7 @@ def get_creators(
 
         # Execute query (count already included in select if needed)
         try:
-            response = query.execute()
+            response = _db_execute(lambda: query.execute())
         except Exception as e:
             if search and no_extra_filters and offset == 0 and _is_statement_timeout_error(e):
                 exact_creator = _find_creator_by_normalized_handle(search)
@@ -3668,6 +3672,7 @@ def get_creator_hero_stats() -> dict:
 
         return {
             "total_creators": int(data.get("total_creators") or 0),
+            "total_db_creators": int(data.get("total_db_creators") or 0),
             "avg_engagement": round(avg_engagement, 2),
             "has_engagement_data": avg_engagement > 0,
             "growing_creators": int(data.get("growing_creators") or 0),

--- a/db/migrations/044_add_total_db_creators_to_mv_hero_stats.sql
+++ b/db/migrations/044_add_total_db_creators_to_mv_hero_stats.sql
@@ -1,0 +1,107 @@
+-- Migration 044: Add total_db_creators to mv_hero_stats
+--
+-- Context: The /creators page hero section wants to display the full size of
+-- the creators database (all sync_status values) to showcase scale, while
+-- total_creators in mv_hero_stats only counts sync_status='synced' rows and
+-- is used as the browseable pool denominator for filtered searches.
+--
+-- Problem: A live HEAD request (SELECT id FROM creators for COUNT) on the
+-- 800K-row table was added to db.py to get this number, defeating the purpose
+-- of the materialized view caching system (see migrations 009 and 025).
+--
+-- Fix: Add total_db_creators = COUNT(*) to mv_hero_stats so it is pre-computed
+-- alongside total_creators and costs nothing to read on page load.
+-- The existing refresh_mv_hero_stats() function automatically picks up the new
+-- column on the next worker Pass 5 refresh cycle.
+--
+-- Note: total_db_creators counts every row in the creators table with no
+-- filter — it will include pending, failed, invalid, and synced_partial rows.
+-- This is intentional: the goal is to showcase the full dataset size.
+
+-- 1. Recreate mv_hero_stats with the new column.
+--    REFRESH MATERIALIZED VIEW cannot add columns; we must DROP and recreate.
+DROP MATERIALIZED VIEW IF EXISTS public.mv_hero_stats CASCADE;
+
+CREATE MATERIALIZED VIEW public.mv_hero_stats AS
+SELECT
+    -- Synced, browseable pool (filter denominator for /creators page)
+    COUNT(*) FILTER (
+        WHERE channel_name IS NOT NULL
+          AND current_subscribers > 0
+          AND sync_status = 'synced'
+    ) AS total_creators,
+    -- Full DB size (all sync_status values) for hero marketing headline
+    COUNT(*) AS total_db_creators,
+    ROUND(
+        COALESCE(
+            AVG(engagement_score) FILTER (
+                WHERE channel_name IS NOT NULL
+                  AND current_subscribers > 0
+                  AND sync_status = 'synced'
+            ),
+            0
+        )::numeric,
+        2
+    ) AS avg_engagement,
+    CASE
+        WHEN COUNT(*) FILTER (
+            WHERE engagement_score IS NOT NULL
+              AND sync_status = 'synced'
+        ) > 0 THEN TRUE
+        ELSE FALSE
+    END AS has_engagement_data,
+    COUNT(*) FILTER (
+        WHERE subscribers_change_30d > 0
+          AND sync_status = 'synced'
+    ) AS growing_creators,
+    COUNT(*) FILTER (
+        WHERE quality_grade IN ('A+', 'A')
+          AND sync_status = 'synced'
+    ) AS premium_creators
+FROM public.creators;
+
+-- Recreate unique index (required for CONCURRENTLY refresh)
+CREATE UNIQUE INDEX mv_hero_stats_unique_idx ON public.mv_hero_stats ((1));
+
+COMMENT ON MATERIALIZED VIEW public.mv_hero_stats IS
+'Pre-computed aggregate stats for /creators hero section. '
+'total_creators = synced only (filter denominator). '
+'total_db_creators = all rows (hero headline). '
+'Refreshed by bootstrap_creators.py Pass 5 via refresh_mv_hero_stats().';
+
+
+-- 2. Update get_creator_hero_stats() RPC to return the new column.
+DROP FUNCTION IF EXISTS public.get_creator_hero_stats() CASCADE;
+
+CREATE OR REPLACE FUNCTION public.get_creator_hero_stats()
+RETURNS TABLE (
+    total_creators      BIGINT,
+    total_db_creators   BIGINT,
+    avg_engagement      NUMERIC,
+    has_engagement_data BOOLEAN,
+    growing_creators    BIGINT,
+    premium_creators    BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $$
+    SELECT
+        total_creators,
+        total_db_creators,
+        avg_engagement,
+        has_engagement_data,
+        growing_creators,
+        premium_creators
+    FROM public.mv_hero_stats
+    LIMIT 1;
+$$;
+
+COMMENT ON FUNCTION public.get_creator_hero_stats() IS
+'Reads pre-computed hero stats from mv_hero_stats materialized view (~1ms). '
+'total_db_creators added in migration 044 to surface full DB size in hero headline.';
+
+
+-- 3. Trigger an immediate refresh so the new column is populated.
+--    refresh_mv_hero_stats() sets statement_timeout=0 internally (migration 025).
+SELECT * FROM public.refresh_mv_hero_stats();

--- a/utils/dates.py
+++ b/utils/dates.py
@@ -217,3 +217,22 @@ def format_date_relative(date_str: str | None) -> str:
 
     except Exception:
         return "Unknown"
+
+
+def is_data_stale(date_str: str | None, threshold_days: int = 30) -> bool:
+    """Return True when *date_str* is older than *threshold_days* (default 30).
+
+    Used to flag creator records whose last_synced_at predates the threshold so
+    the UI can surface an amber staleness warning.  Returns False when the date
+    is unparseable or absent (fail-safe: don't warn on missing data).
+    """
+    if not date_str:
+        return False
+    try:
+        clean = date_str.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(clean)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - dt).days > threshold_days
+    except Exception:
+        return False

--- a/utils/dates.py
+++ b/utils/dates.py
@@ -220,7 +220,7 @@ def format_date_relative(date_str: str | None) -> str:
 
 
 def is_data_stale(date_str: str | None, threshold_days: int = 30) -> bool:
-    """Return True when *date_str* is older than *threshold_days* (default 30).
+    """Return True when *date_str* is older than or equal to *threshold_days* (default 30).
 
     Used to flag creator records whose last_synced_at predates the threshold so
     the UI can surface an amber staleness warning.  Returns False when the date
@@ -233,6 +233,6 @@ def is_data_stale(date_str: str | None, threshold_days: int = 30) -> bool:
         dt = datetime.fromisoformat(clean)
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
-        return (datetime.now(timezone.utc) - dt).days > threshold_days
-    except Exception:
+        return (datetime.now(timezone.utc) - dt).days >= threshold_days
+    except (ValueError, TypeError):
         return False

--- a/views/creators.py
+++ b/views/creators.py
@@ -31,7 +31,7 @@ from fasthtml.common import *
 from monsterui.all import *
 
 from utils import format_float, format_percentage
-from utils.dates import format_date_relative
+from utils.dates import format_date_relative, is_data_stale
 from utils import format_number, safe_get_value, slugify
 from utils.creator_metrics import (
     calculate_avg_views_per_video,
@@ -844,7 +844,8 @@ def _render_hero(stats: dict, filtered_count: int = 0, has_filters: bool = False
     Designed for agencies looking to identify collaboration opportunities.
     """
     # Extract only the metrics actually used in hero rendering
-    total_creators = stats.get("total_creators", 0)
+    total_creators = stats.get("total_creators", 0)  # synced-only (filter denominator)
+    total_db_creators = stats.get("total_db_creators") or total_creators  # all rows in DB
     total_countries = stats.get("total_countries", 0)
     total_languages = stats.get("total_languages", 0)
     total_categories = stats.get("total_categories", 0)
@@ -866,7 +867,8 @@ def _render_hero(stats: dict, filtered_count: int = 0, has_filters: bool = False
         ),
         # Metric Strip - marketing-focused metrics from DB
         Div(
-            # Total/Filtered creators - smart display based on filter state
+            # Total/Filtered creators — no-filter shows full DB size for marketing impact;
+            # filtered view shows matching synced creators vs. the browseable synced pool.
             Div(
                 P(
                     "Filtered Results" if has_filters else "Total Creators",
@@ -876,7 +878,7 @@ def _render_hero(stats: dict, filtered_count: int = 0, has_filters: bool = False
                     (
                         f"{format_number(filtered_count)} of {format_number(total_creators)}"
                         if has_filters
-                        else format_number(total_creators)
+                        else format_number(total_db_creators)
                     ),
                     cls="text-2xl font-bold text-foreground mt-1",
                 ),
@@ -2050,7 +2052,11 @@ def _render_bio(bio: str | None, max_chars: int = 130) -> P | None:
 
 
 def _build_card_footer(
-    last_updated: str, channel_url: str, creator_id: str = "", is_favourited: bool = False
+    last_updated: str,
+    channel_url: str,
+    creator_id: str = "",
+    is_favourited: bool = False,
+    last_synced: str = "",
 ) -> Div:
     """Card footer: last-updated timestamp + optional heart + YouTube link.
 
@@ -2333,8 +2339,7 @@ def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
     views_change = int(views_change_raw) if views_change_raw is not None else None
     engagement_score = float(safe_get_value(creator, "engagement_score", 0) or 0)
     last_updated = safe_get_value(creator, "last_updated_at", "")
-
-    # === CALCULATIONS ===
+    last_synced_card = safe_get_value(creator, "last_synced_at", "")
     avg_views_per_video = calculate_avg_views_per_video(current_views, current_videos)
     growth_rate = calculate_growth_rate(subs_change, current_subs)
     views_per_sub = calculate_views_per_subscriber(current_views, current_subs)
@@ -2451,6 +2456,7 @@ def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
             channel_url,
             creator_id=safe_get_value(creator, "id", ""),
             is_favourited=is_favourited,
+            last_synced=last_synced_card,
         ),
         body_cls="space-y-3",
         cls=(

--- a/views/creators.py
+++ b/views/creators.py
@@ -845,7 +845,8 @@ def _render_hero(stats: dict, filtered_count: int = 0, has_filters: bool = False
     """
     # Extract only the metrics actually used in hero rendering
     total_creators = stats.get("total_creators", 0)  # synced-only (filter denominator)
-    total_db_creators = stats.get("total_db_creators") or total_creators  # all rows in DB
+    _total_db_val = stats.get("total_db_creators")
+    total_db_creators = total_creators if _total_db_val is None else _total_db_val  # all rows in DB
     total_countries = stats.get("total_countries", 0)
     total_languages = stats.get("total_languages", 0)
     total_categories = stats.get("total_categories", 0)


### PR DESCRIPTION
…creators/get_creator_stats

- Wrap get_creator_stats() and get_creators() bare .execute() calls with _db_execute() so transient HTTP/2 server-disconnect errors are retried once instead of propagating to the user

- Add total_db_creators to mv_hero_stats (migration 044) so the full creator count (all sync_status values, ~802K) is pre-computed alongside the synced-only total_creators; update get_creator_hero_stats() RPC to return the new column

- Remove _fetch_total_db_creators() live HEAD query (would have caused statement timeouts on every /creators page load — exactly the problem the materialized view system was built to prevent)

- Hero headline now shows total_db_creators when no filters are active; filtered view continues to use synced total_creators as denominator

- Add is_data_stale() helper to utils/dates.py (unused in UI for now)

## Summary by Sourcery

Surface the full creators database size in the /creators hero stats while hardening creator queries against transient DB errors and adding a helper for detecting stale data.

New Features:
- Expose total_db_creators from the mv_hero_stats materialized view and get_creator_hero_stats() RPC for use in the /creators hero headline.
- Add an is_data_stale() helper to detect when timestamps are older than a configurable day threshold.

Bug Fixes:
- Wrap get_creator_stats() and get_creators() Supabase calls in the shared _db_execute() helper so transient HTTP/2 disconnects are retried instead of surfacing to users.

Enhancements:
- Update the /creators hero to show the full database creator count when no filters are applied while retaining the synced-only total_creators as the filtered search denominator.
- Plumb last_synced data into creator card footer construction in preparation for future UI staleness indicators.

Deployment:
- Add a database migration to recreate mv_hero_stats with a total_db_creators column, update the get_creator_hero_stats() RPC signature, and trigger an immediate refresh so the new metric is populated.