### PR TITLE
feat: show synced_partial creators on browse pages; enrich admin dash…

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -354,6 +354,11 @@ CREATOR_SYNC_JOBS_TABLE = "creator_sync_jobs"
 USER_FAVOURITE_CREATORS_TABLE = "user_favourite_creators"
 USER_FAVOURITE_LISTS_TABLE = "user_favourite_lists"
 
+# Sync statuses that produce browseable creator records (have channel_name,
+# current_subscribers and enough fields for cards and ranking pages).
+# Used by get_creators() and admin inventory counts.
+BROWSEABLE_SYNC_STATUSES: tuple[str, ...] = ("synced", "synced_partial")
+
 # Update frequency (frugal)
 CREATOR_WORKER_BATCH_SIZE = 2  # Process at a time
 CREATOR_WORKER_POLL_INTERVAL = 300  # 5 minutes

--- a/db.py
+++ b/db.py
@@ -26,6 +26,7 @@ from tenacity import (
 )
 
 from constants import (
+    BROWSEABLE_SYNC_STATUSES,
     CREATOR_REDISCOVERY_THRESHOLD_DAYS,
     CREATOR_SYNC_JOBS_TABLE,
     CREATOR_TABLE,
@@ -3274,7 +3275,7 @@ def get_creators(
         # mirror the synced ones (008, 028, 043). PostgreSQL satisfies the IN()
         # condition via BitmapOr(idx_synced, idx_synced_partial) rather than a
         # full table scan.
-        query = query.in_("sync_status", ["synced", "synced_partial"])
+        query = query.in_("sync_status", list(BROWSEABLE_SYNC_STATUSES))
 
         # Apply search filter
         if search:

--- a/db.py
+++ b/db.py
@@ -3264,13 +3264,17 @@ def get_creators(
         # Using .not_.is_() for NULL check - only works after .select() is called
         query = query.not_.is_("channel_name", "null")
         query = query.gt("current_subscribers", 0)
-        # Only show fully-synced creators — mirrors calculate_creator_stats() behaviour.
-        # Excludes "pending" / "error" rows that have no real stats yet, which would
-        # otherwise appear as blank cards and skew pagination counts.
-        # NOTE: must stay as .eq("synced") — partial indexes (migrations 008, 028, etc.)
-        # are all defined WHERE sync_status = 'synced'. Using IN ('synced', 'pending')
-        # disqualifies every partial index and forces a full table scan.
-        query = query.eq("sync_status", "synced")
+        # Include synced_partial creators alongside fully-synced ones so that
+        # creators with basic data (channel_name, subscribers, views) appear on
+        # browse and ranking pages.  synced_partial rows have all listing fields
+        # populated but may be missing engagement_score / quality_grade / recent
+        # performance columns — card components already degrade gracefully on None.
+        #
+        # Performance: migration 045 adds synced_partial partial indexes that
+        # mirror the synced ones (008, 028, 043). PostgreSQL satisfies the IN()
+        # condition via BitmapOr(idx_synced, idx_synced_partial) rather than a
+        # full table scan.
+        query = query.in_("sync_status", ["synced", "synced_partial"])
 
         # Apply search filter
         if search:

--- a/db/migrations/045_browseable_synced_partial_indexes.sql
+++ b/db/migrations/045_browseable_synced_partial_indexes.sql
@@ -1,0 +1,88 @@
+-- Migration 045: Add partial indexes so synced_partial creators can be included
+-- in the /creators browse page and ranking pages without forcing full table scans.
+--
+-- Context: get_creators() was restricted to sync_status = 'synced' because the
+-- existing partial indexes (migrations 008, 028, 043) are all defined with:
+--   WHERE sync_status = 'synced' AND channel_name IS NOT NULL AND current_subscribers > 0
+-- Using IN ('synced', 'synced_partial') would disqualify those indexes on a single-index
+-- query plan. With BOTH sets of partial indexes present, PostgreSQL can satisfy the
+-- combined condition via BitmapOr(IndexScan_synced, IndexScan_partial), which is
+-- efficient even for the full sort + filter + count queries.
+--
+-- synced_partial creators have basic fields populated (channel_name, current_subscribers,
+-- current_view_count) but may be missing engagement_score, quality_grade, and recent
+-- performance columns. They are browseable and should appear on ranking pages.
+-- The 1,073 synced_partial rows (~0.1% of the browseable pool) are unlikely to
+-- cause any index bloat concern.
+--
+-- Mirrors the exact set of indexes from migrations 008, 028, and 043 but with
+-- sync_status = 'synced_partial' in the WHERE predicate.
+
+-- ── Core listing index (mirrors idx_creators_listing_base from migration 008) ──
+CREATE INDEX IF NOT EXISTS idx_creators_listing_base_partial
+    ON public.creators (current_subscribers DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- ── Sort indexes (mirror migration 008) ──────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_creators_views_synced_partial
+    ON public.creators (current_view_count DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_engagement_synced_partial
+    ON public.creators (engagement_score DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- ── Country filter index (mirrors migration 008) ──────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_creators_country_synced_partial
+    ON public.creators (country_code)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- ── Primary category index (mirrors migration 028) ───────────────────────────
+-- Note: pg_trgm GIN index from 028 covers synced only; for synced_partial the
+-- planner will use this B-tree index for equality predicates.  The trgm GIN is
+-- still used for text-search ilike on synced rows via BitmapOr.
+CREATE INDEX IF NOT EXISTS idx_creators_primary_category_partial
+    ON public.creators (primary_category)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- ── Filter/sort column indexes (mirror migration 043) ────────────────────────
+CREATE INDEX IF NOT EXISTS idx_creators_language_synced_partial
+    ON public.creators (default_language)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_grade_synced_partial
+    ON public.creators (quality_grade)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_monthly_uploads_synced_partial
+    ON public.creators (monthly_uploads DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_channel_age_synced_partial
+    ON public.creators (channel_age_days)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- ── Verification ─────────────────────────────────────────────────────────────
+-- SELECT indexname, indexdef
+-- FROM pg_indexes
+-- WHERE tablename = 'creators'
+--   AND indexname LIKE '%_partial'
+-- ORDER BY indexname;

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -117,18 +117,29 @@ def _fetch_admin_data() -> dict:
     cutoff_1h = (now - timedelta(hours=1)).isoformat()
     cutoff_7d = (now - timedelta(days=7)).isoformat()
     cutoff_30d = (now - timedelta(days=30)).isoformat()
+    cutoff_90d = (now - timedelta(days=90)).isoformat()
 
     data: dict = {
         # Creator inventory
         "total_creators": 0,
         "synced": 0,
+        "synced_partial": 0,
         "pending_creators": 0,
         "failed_creators": 0,
         "invalid_creators": 0,
         "visible": 0,
         "fresh_7d": 0,
+        "fresh_7_30d": 0,
+        "stale_30_90d": 0,
+        "stale_90d": 0,
         "stale_30d": 0,
         "never_synced": 0,
+        # Data quality
+        "creators_with_engagement": 0,
+        "creators_with_grade": 0,
+        "creators_with_recent_perf": 0,
+        "distinct_categories": 0,
+        "distinct_countries": 0,
         # Job queue
         "queue_pending": 0,
         "queue_processing": 0,
@@ -163,6 +174,7 @@ def _fetch_admin_data() -> dict:
         )
         for col, status in [
             ("synced", "synced"),
+            ("synced_partial", "synced_partial"),
             ("pending_creators", "pending"),
             ("failed_creators", "failed"),
             ("invalid_creators", "invalid"),
@@ -178,7 +190,7 @@ def _fetch_admin_data() -> dict:
         data["visible"] = (
             sc.table("creators")
             .select("id", count="exact")
-            .eq("sync_status", "synced")
+            .in_("sync_status", ["synced", "synced_partial"])
             .not_.is_("channel_name", "null")
             .gt("current_subscribers", 0)
             .execute()
@@ -194,15 +206,37 @@ def _fetch_admin_data() -> dict:
             .count
             or 0
         )
-        data["stale_30d"] = (
+        data["fresh_7_30d"] = (
             sc.table("creators")
             .select("id", count="exact")
             .eq("sync_status", "synced")
-            .lt("last_synced_at", cutoff_30d)
+            .lt("last_synced_at", cutoff_7d)
+            .gte("last_synced_at", cutoff_30d)
             .execute()
             .count
             or 0
         )
+        data["stale_30_90d"] = (
+            sc.table("creators")
+            .select("id", count="exact")
+            .eq("sync_status", "synced")
+            .lt("last_synced_at", cutoff_30d)
+            .gte("last_synced_at", cutoff_90d)
+            .execute()
+            .count
+            or 0
+        )
+        data["stale_90d"] = (
+            sc.table("creators")
+            .select("id", count="exact")
+            .eq("sync_status", "synced")
+            .lt("last_synced_at", cutoff_90d)
+            .execute()
+            .count
+            or 0
+        )
+        # keep stale_30d as total stale (>30d) for backward compat with existing view
+        data["stale_30d"] = data["stale_30_90d"] + data["stale_90d"]
         data["never_synced"] = (
             sc.table("creators")
             .select("id", count="exact")
@@ -213,6 +247,50 @@ def _fetch_admin_data() -> dict:
         )
     except Exception:
         logger.exception("[Admin] Creator inventory queries failed")
+
+    # ── Data quality (synced pool) ─────────────────────────────────────────────
+    try:
+        data["creators_with_engagement"] = (
+            sc.table("creators")
+            .select("id", count="exact")
+            .eq("sync_status", "synced")
+            .gt("engagement_score", 0)
+            .execute()
+            .count
+            or 0
+        )
+        data["creators_with_grade"] = (
+            sc.table("creators")
+            .select("id", count="exact")
+            .eq("sync_status", "synced")
+            .not_.is_("quality_grade", "null")
+            .execute()
+            .count
+            or 0
+        )
+        data["creators_with_recent_perf"] = (
+            sc.table("creators")
+            .select("id", count="exact")
+            .eq("sync_status", "synced")
+            .not_.is_("avg_views_10", "null")
+            .execute()
+            .count
+            or 0
+        )
+        # Approximate category / country coverage via top-N RPCs
+        # (exact DISTINCT counts live in mv_lists_meta but may be stale)
+        try:
+            cat_resp = sc.rpc("get_top_categories_with_counts", {"p_limit": 200}).execute()
+            data["distinct_categories"] = len(cat_resp.data or [])
+        except Exception:
+            data["distinct_categories"] = 0
+        try:
+            cty_resp = sc.rpc("get_top_countries_with_counts", {"p_limit": 300}).execute()
+            data["distinct_countries"] = len(cty_resp.data or [])
+        except Exception:
+            data["distinct_countries"] = 0
+    except Exception:
+        logger.exception("[Admin] Data quality queries failed")
 
     # ── Job queue ──────────────────────────────────────────────────────────────
     try:

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -21,6 +21,7 @@ from fasthtml.common import *
 from starlette.responses import Response as StarletteResponse
 
 import db as _db
+from constants import BROWSEABLE_SYNC_STATUSES
 from services.contact_extractor import ContactExtractorService
 from views.admin import AdminPage, _JobsSection
 
@@ -103,6 +104,33 @@ def _auth_response():
 
 # -- Data fetching ------------------------------------------------------------
 
+# Freshness tier boundaries (days since last_synced_at).
+# Each entry is (data_key, label, ge_days, lt_days_or_None).
+# Boundaries are exclusive-lower / inclusive-upper so tiers are contiguous
+# with no overlap or gap: [0,7) → [7,30) → [30,90) → [90,∞).
+_FRESHNESS_TIERS: tuple[tuple[str, int, int | None], ...] = (
+    ("fresh_7d", 0, 7),
+    ("fresh_7_30d", 7, 30),
+    ("stale_30_90d", 30, 90),
+    ("stale_90d", 90, None),
+)
+
+
+def _count_creators(sc, *, status: str | None = None, extra_filters=None) -> int:
+    """Return a COUNT(*) for the creators table with optional sync_status filter.
+
+    Args:
+        sc: Supabase client.
+        status: If given, adds .eq("sync_status", status).
+        extra_filters: Optional callable(query) -> query for additional filters.
+    """
+    q = sc.table("creators").select("id", count="exact")
+    if status is not None:
+        q = q.eq("sync_status", status)
+    if extra_filters is not None:
+        q = extra_filters(q)
+    return q.execute().count or 0
+
 
 def _fetch_admin_data() -> dict:
     """
@@ -115,9 +143,10 @@ def _fetch_admin_data() -> dict:
     now = datetime.now(timezone.utc)
     cutoff_24h = (now - timedelta(hours=24)).isoformat()
     cutoff_1h = (now - timedelta(hours=1)).isoformat()
-    cutoff_7d = (now - timedelta(days=7)).isoformat()
-    cutoff_30d = (now - timedelta(days=30)).isoformat()
-    cutoff_90d = (now - timedelta(days=90)).isoformat()
+
+    # Freshness cutoffs derived from _FRESHNESS_TIERS so the two are always in sync.
+    _tier_days = sorted({d for _, lo, hi in _FRESHNESS_TIERS for d in (lo, hi) if d is not None})
+    _cutoffs: dict[int, str] = {d: (now - timedelta(days=d)).isoformat() for d in _tier_days}
 
     data: dict = {
         # Creator inventory
@@ -169,9 +198,7 @@ def _fetch_admin_data() -> dict:
 
     # ── Creator inventory ──────────────────────────────────────────────────────
     try:
-        data["total_creators"] = (
-            sc.table("creators").select("id", count="exact").execute().count or 0
-        )
+        data["total_creators"] = _count_creators(sc)
         for col, status in [
             ("synced", "synced"),
             ("synced_partial", "synced_partial"),
@@ -179,103 +206,49 @@ def _fetch_admin_data() -> dict:
             ("failed_creators", "failed"),
             ("invalid_creators", "invalid"),
         ]:
-            data[col] = (
-                sc.table("creators")
-                .select("id", count="exact")
-                .eq("sync_status", status)
-                .execute()
-                .count
-                or 0
-            )
-        data["visible"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .in_("sync_status", ["synced", "synced_partial"])
-            .not_.is_("channel_name", "null")
-            .gt("current_subscribers", 0)
-            .execute()
-            .count
-            or 0
+            data[col] = _count_creators(sc, status=status)
+
+        data["visible"] = _count_creators(
+            sc,
+            extra_filters=lambda q: (
+                q.in_("sync_status", list(BROWSEABLE_SYNC_STATUSES))
+                .not_.is_("channel_name", "null")
+                .gt("current_subscribers", 0)
+            ),
         )
-        data["fresh_7d"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .eq("sync_status", "synced")
-            .gte("last_synced_at", cutoff_7d)
-            .execute()
-            .count
-            or 0
-        )
-        data["fresh_7_30d"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .eq("sync_status", "synced")
-            .lt("last_synced_at", cutoff_7d)
-            .gte("last_synced_at", cutoff_30d)
-            .execute()
-            .count
-            or 0
-        )
-        data["stale_30_90d"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .eq("sync_status", "synced")
-            .lt("last_synced_at", cutoff_30d)
-            .gte("last_synced_at", cutoff_90d)
-            .execute()
-            .count
-            or 0
-        )
-        data["stale_90d"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .eq("sync_status", "synced")
-            .lt("last_synced_at", cutoff_90d)
-            .execute()
-            .count
-            or 0
-        )
+
+        # Freshness tiers — driven by _FRESHNESS_TIERS so boundaries stay consistent.
+        for key, lo_days, hi_days in _FRESHNESS_TIERS:
+
+            def _freshness_filter(q, lo=lo_days, hi=hi_days):
+                q = q.eq("sync_status", "synced")
+                if lo > 0:
+                    q = q.lt("last_synced_at", _cutoffs[lo])
+                if hi is not None:
+                    q = q.gte("last_synced_at", _cutoffs[hi])
+                return q
+
+            data[key] = _count_creators(sc, extra_filters=_freshness_filter)
+
         # keep stale_30d as total stale (>30d) for backward compat with existing view
         data["stale_30d"] = data["stale_30_90d"] + data["stale_90d"]
-        data["never_synced"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .is_("last_synced_at", "null")
-            .execute()
-            .count
-            or 0
+
+        data["never_synced"] = _count_creators(
+            sc, extra_filters=lambda q: q.is_("last_synced_at", "null")
         )
     except Exception:
         logger.exception("[Admin] Creator inventory queries failed")
 
     # ── Data quality (synced pool) ─────────────────────────────────────────────
     try:
-        data["creators_with_engagement"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .eq("sync_status", "synced")
-            .gt("engagement_score", 0)
-            .execute()
-            .count
-            or 0
+        data["creators_with_engagement"] = _count_creators(
+            sc, status="synced", extra_filters=lambda q: q.gt("engagement_score", 0)
         )
-        data["creators_with_grade"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .eq("sync_status", "synced")
-            .not_.is_("quality_grade", "null")
-            .execute()
-            .count
-            or 0
+        data["creators_with_grade"] = _count_creators(
+            sc, status="synced", extra_filters=lambda q: q.not_.is_("quality_grade", "null")
         )
-        data["creators_with_recent_perf"] = (
-            sc.table("creators")
-            .select("id", count="exact")
-            .eq("sync_status", "synced")
-            .not_.is_("avg_views_10", "null")
-            .execute()
-            .count
-            or 0
+        data["creators_with_recent_perf"] = _count_creators(
+            sc, status="synced", extra_filters=lambda q: q.not_.is_("avg_views_10", "null")
         )
         # Approximate category / country coverage via top-N RPCs
         # (exact DISTINCT counts live in mv_lists_meta but may be stale)

--- a/views/admin.py
+++ b/views/admin.py
@@ -37,6 +37,7 @@ _COLOR = {
 
 _BAR_COLOR = {
     "synced": "bg-green-500",
+    "synced_partial": "bg-blue-400",
     "pending": "bg-yellow-400",
     "failed": "bg-red-500",
     "invalid": "bg-gray-400",
@@ -276,7 +277,9 @@ def _InventorySection(data: dict) -> Div:
         ),
         Grid(
             _StatCard("Total in DB", total, "all records", "blue"),
-            _StatCard("Visible", data["visible"], "synced + named + has subscribers", "green"),
+            _StatCard(
+                "Visible", data["visible"], "synced + synced_partial + named + subs", "green"
+            ),
             _StatCard("Invisible", invisible, "not yet synced, failed, or invalid", "gray"),
             _StatCard("Fresh (<7d)", data["fresh_7d"], "synced within last 7 days", "green"),
             _StatCard(
@@ -350,6 +353,87 @@ def _WorkerSection(data: dict) -> Div:
     return Grid(throughput_card, drain_card, cols_md=2, gap=4, cls="mb-6")
 
 
+def _FreshnessSection(data: dict) -> Div:
+    """Four-tier freshness breakdown for synced creators."""
+    synced = data.get("synced", 0)
+    fresh_7d = data.get("fresh_7d", 0)
+    fresh_7_30d = data.get("fresh_7_30d", 0)
+    stale_30_90d = data.get("stale_30_90d", 0)
+    stale_90d = data.get("stale_90d", 0)
+
+    def _bar(label, count, color):
+        pct = round(count / synced * 100, 1) if synced else 0.0
+        bar_w = max(int(pct), 2) if count > 0 else 0
+        return Div(
+            Span(label, cls="text-sm font-medium w-36 inline-block"),
+            Div(
+                Div(cls=f"{color} h-3 rounded-full", style=f"width:{bar_w}%"),
+                cls="flex-1 bg-accent rounded-full mx-3 h-3",
+            ),
+            Span(f"{count:,}", cls="text-sm font-mono text-muted-foreground w-24 text-right"),
+            Span(f"{pct}%", cls="text-sm font-mono text-muted-foreground w-14 text-right"),
+            cls="flex items-center py-1",
+        )
+
+    return Card(
+        H3(
+            "Sync Freshness (synced creators)",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        _bar("< 7 days", fresh_7d, "bg-green-500"),
+        _bar("7 – 30 days", fresh_7_30d, "bg-lime-400"),
+        _bar("30 – 90 days", stale_30_90d, "bg-orange-400"),
+        _bar("> 90 days", stale_90d, "bg-red-500"),
+        body_cls="p-5 space-y-1",
+        cls="mb-6",
+    )
+
+
+def _DataQualitySection(data: dict) -> Div:
+    """Data completeness metrics for the synced creator pool."""
+    synced = data.get("synced", 0)
+
+    def _pct(n):
+        return f"{n / synced * 100:.1f}%" if synced else "—"
+
+    engagement = data.get("creators_with_engagement", 0)
+    grade = data.get("creators_with_grade", 0)
+    recent_perf = data.get("creators_with_recent_perf", 0)
+    categories = data.get("distinct_categories", 0)
+    countries = data.get("distinct_countries", 0)
+
+    quality_card = Card(
+        H3(
+            "Data Completeness (synced)",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        _KVRow(
+            "Engagement score",
+            f"{engagement:,}  ({_pct(engagement)})",
+            warn=engagement < synced * 0.5,
+        ),
+        _KVRow("Quality grade", f"{grade:,}  ({_pct(grade)})", warn=grade < synced * 0.5),
+        _KVRow(
+            "Recent perf (last 10 vids)",
+            f"{recent_perf:,}  ({_pct(recent_perf)})",
+            warn=recent_perf < synced * 0.3,
+        ),
+        body_cls="p-5",
+    )
+
+    coverage_card = Card(
+        H3(
+            "Taxonomy Coverage",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        _KVRow("Distinct categories", f"{categories:,}"),
+        _KVRow("Distinct countries", f"{countries:,}"),
+        body_cls="p-5",
+    )
+
+    return Grid(quality_card, coverage_card, cols_md=2, gap=4, cls="mb-6")
+
+
 def _OutreachSection(data: dict) -> Div:
     """
     Contact signals & outreach stats.
@@ -405,6 +489,7 @@ def _BreakdownSection(data: dict) -> Div:
     total = data["total_creators"]
     breakdown = {
         "synced": data["synced"],
+        "synced_partial": data.get("synced_partial", 0),
         "pending": data["pending_creators"],
         "failed": data["failed_creators"],
         "invalid": data["invalid_creators"],
@@ -416,7 +501,7 @@ def _BreakdownSection(data: dict) -> Div:
         ),
         *[
             _StatusBar(k, breakdown[k], total, _BAR_COLOR.get(k, "bg-gray-300"))
-            for k in ("synced", "pending", "failed", "invalid")
+            for k in ("synced", "synced_partial", "pending", "failed", "invalid")
         ],
         body_cls="p-5 space-y-1",
         cls="mb-6",
@@ -484,6 +569,8 @@ def AdminPage(data: dict, refreshed_at: str = "") -> FT:
         Container(
             _QueueSection(data),
             _InventorySection(data),
+            _FreshnessSection(data),
+            _DataQualitySection(data),
             _WorkerSection(data),
             _OutreachSection(data),
             _BreakdownSection(data),

--- a/views/creators.py
+++ b/views/creators.py
@@ -725,7 +725,7 @@ def render_creators_page(
     # NOTE: _filter_valid_creators is intentionally NOT called here.
     # db.get_creators() already applies the same conditions:
     #   channel_name IS NOT NULL, current_subscribers > 0,
-    #   sync_status IN ("synced", "synced_partial")
+    #   sync_status IN BROWSEABLE_SYNC_STATUSES  (constants.py)
     # Applying a second filter on the paginated list would silently reduce the page
     # size while total_count (used for pagination math) stays based on the DB count,
     # making some pages appear to have fewer results than expected.

--- a/views/creators.py
+++ b/views/creators.py
@@ -724,7 +724,8 @@ def render_creators_page(
 
     # NOTE: _filter_valid_creators is intentionally NOT called here.
     # db.get_creators() already applies the same conditions:
-    #   channel_name IS NOT NULL, current_subscribers > 0, sync_status = "synced"
+    #   channel_name IS NOT NULL, current_subscribers > 0,
+    #   sync_status IN ("synced", "synced_partial")
     # Applying a second filter on the paginated list would silently reduce the page
     # size while total_count (used for pagination math) stays based on the DB count,
     # making some pages appear to have fewer results than expected.


### PR DESCRIPTION
…board

Creator visibility
- Include sync_status='synced_partial' in get_creators() so creators with basic data appear on browse and ranking pages (was silently excluded)
- Migration 045: add partial indexes mirroring 008/028/043 for synced_partial rows so the planner uses BitmapOr(idx_synced, idx_synced_partial) rather than a full table scan

Admin dashboard
- Add synced_partial count to inventory section and breakdown bar chart
- Add 4-tier freshness breakdown: <7d / 7-30d / 30-90d / >90d with colour-coded bars (green → red)
- Add data completeness section: engagement score, quality grade, and recent-performance coverage % with warnings when <50%; taxonomy coverage (distinct categories, countries)
- Collect cutoff_90d, fresh_7_30d, stale_30_90d, stale_90d, synced_partial, creators_with_engagement/grade/recent_perf, distinct_categories/countries in _fetch_admin_data()
- Visible count now reflects synced + synced_partial pool

## Summary by Sourcery

Include partially synced creators in browse/ranking views and enrich the admin dashboard with freshness and data completeness metrics while adding supporting indexes and inventory stats.

New Features:
- Expose creators with sync_status='synced_partial' on creators browse and ranking pages alongside fully synced creators.
- Add admin dashboard sections for sync freshness breakdown and data completeness/taxonomy coverage of the synced creator pool.

Enhancements:
- Extend admin inventory and breakdown metrics to include synced_partial creators and refine visible creator counts.
- Collect additional admin stats for multi-tier freshness windows and data quality coverage, including engagement, quality grades, recent performance, and category/country diversity.
- Introduce partial indexes for synced_partial creators to maintain efficient browse and ranking queries without full table scans.

Documentation:
- Update internal comments to reflect inclusion of synced_partial creators in browse filters and document the purpose of the new partial indexes.