### PR TITLE
fix: guard null creator_id UUID crash and rank query timeout; slow HT…

### DIFF
--- a/controllers/job_progress.py
+++ b/controllers/job_progress.py
@@ -372,6 +372,6 @@ def render_job_progress_ui(
         id="preview-box",
         # 🔄 Continue polling
         hx_get=f"/job-progress?playlist_url={quote_plus(playlist_url)}",
-        hx_trigger="every 2s",
+        hx_trigger="every 5s",
         hx_swap="outerHTML",
     )

--- a/db.py
+++ b/db.py
@@ -1610,6 +1610,11 @@ def get_creator_stats(creator_id: str) -> Optional[Dict[str, Any]]:
         logger.warning("Supabase client not available to get creator stats")
         return None
 
+    # Guard against string "null" / empty strings that crash the UUID column
+    if not creator_id or str(creator_id).strip().lower() in ("null", "none", ""):
+        logger.warning("get_creator_stats called with invalid creator_id: %r", creator_id)
+        return None
+
     try:
         response = _db_execute(
             lambda: supabase_client.table(CREATOR_TABLE)
@@ -1828,7 +1833,7 @@ def get_creator_rank(
     def _fetch_rank():
         resp = (
             supabase_client.table(CREATOR_TABLE)
-            .select("id", count="exact")
+            .select("id", count="estimated")
             .eq("sync_status", "synced")
             .not_.is_("channel_name", "null")
             .gt("current_subscribers", current_subscribers)

--- a/main.py
+++ b/main.py
@@ -953,7 +953,7 @@ def submit_job(playlist_url: str, req, sess):
     # Instead of polling instruction, show the full engagement screen
     return Div(
         hx_get=f"/job-progress?playlist_url={quote_plus(playlist_url)}",
-        hx_trigger="load, every 2s",
+        hx_trigger="load, every 5s",
         hx_swap="outerHTML",
         id="preview-box",
         children=[
@@ -1026,7 +1026,7 @@ def check_job_status(playlist_url: str, req, sess):
             ),
             # Continue polling this endpoint
             hx_get=f"/check-job-status?playlist_url={quote_plus(playlist_url)}",
-            hx_trigger="every 3s",  # Poll every 3 seconds
+            hx_trigger="every 8s",  # Poll every 8 seconds
             hx_swap="outerHTML",  # Replace the entire div with the new response
         )
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -9,6 +9,7 @@ Test Organization:
 5. Dashboard (/d/{id})
 """
 
+import re
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import Optional
@@ -401,7 +402,7 @@ class TestJobSubmission:
         assert (
             'hx-get="/job-progress' in html or 'hx-get="/job-progress' in html
         ), "Response missing HTMX polling trigger"
-        assert "hx-trigger" in html and "every" in html, "Response missing polling interval"
+        assert re.search(r'hx-trigger="[^"]*every \d+s', html), "Response missing polling interval"
 
     @pytest.mark.skip(reason="Temporarily disabled for debugging")
     def test_submit_job_handles_duplicate_submission(self, authenticated_client, monkeypatch):
@@ -512,7 +513,10 @@ class TestJobProgress:
 
         # Should continue polling
         assert 'hx-get="/job-progress' in r.text
-        assert "hx-trigger=" in r.text and "every" in r.text
+        assert re.search(
+            r'hx-trigger="[^"]*every \d+s',
+            r.text,
+        ), "Response missing polling interval for job-progress"
 
     def test_job_progress_redirects_on_completion(self, authenticated_client, monkeypatch):
         """

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -364,7 +364,7 @@ class TestJobSubmission:
         1. User clicks "Analyze" or auto-submit triggers
         2. POST /submit-job
         3. Job created in database
-        4. Returns div with hx-get="/job-progress" + hx-trigger="every 2s"
+        4. Returns div with hx-get="/job-progress" + hx-trigger with interval
         """
         called = {}
 
@@ -401,9 +401,7 @@ class TestJobSubmission:
         assert (
             'hx-get="/job-progress' in html or 'hx-get="/job-progress' in html
         ), "Response missing HTMX polling trigger"
-        assert (
-            'hx-trigger="load, every 2s"' in html or "every 2s" in html
-        ), "Response missing polling interval"
+        assert "hx-trigger" in html and "every" in html, "Response missing polling interval"
 
     @pytest.mark.skip(reason="Temporarily disabled for debugging")
     def test_submit_job_handles_duplicate_submission(self, authenticated_client, monkeypatch):
@@ -492,7 +490,7 @@ class TestJobProgress:
         1. GET /job-progress
         2. Job status = processing, progress = 25%
         3. Returns progress UI with stats
-        4. Includes hx-trigger="every 2s" for continued polling
+        4. Includes hx-trigger with polling interval for continued polling
         """
         monkeypatch.setattr(
             "controllers.job_progress.get_job_progress",
@@ -514,7 +512,7 @@ class TestJobProgress:
 
         # Should continue polling
         assert 'hx-get="/job-progress' in r.text
-        assert 'hx-trigger="every 2s"' in r.text
+        assert "hx-trigger=" in r.text and "every" in r.text
 
     def test_job_progress_redirects_on_completion(self, authenticated_client, monkeypatch):
         """
@@ -543,7 +541,7 @@ class TestJobProgress:
         assert "window.location.href" in r.text or "complete" in r.text.lower()
 
         # Should NOT have polling trigger
-        assert 'hx-trigger="every 2s"' not in r.text
+        assert 'hx-trigger="every' not in r.text
 
     @pytest.mark.skip(reason="Temporarily disabled for debugging")
     def test_job_progress_shows_error_on_failure(self, authenticated_client, monkeypatch):
@@ -576,7 +574,7 @@ class TestJobProgress:
         assert "Network timeout" in r.text
 
         # Should NOT poll
-        assert 'hx-trigger="every 2s"' not in r.text
+        assert 'hx-trigger="every' not in r.text
 
     def test_job_progress_shows_blocked_state(self, authenticated_client, monkeypatch):
         """Test blocked job shows appropriate warning message."""

--- a/views/admin.py
+++ b/views/admin.py
@@ -534,7 +534,7 @@ def _JobsSection(jobs: list[dict]) -> Div:
         body_cls="p-5",
         id="jobs-panel",
         hx_get="/admin/jobs",
-        hx_trigger="every 30s",
+        hx_trigger="every 5m",
         hx_swap="outerHTML",
     )
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -379,7 +379,7 @@ def render_add_creator_result(
             status_url = f"/creators/add-status?{urlencode({'q': input_query})}"
             poll_attrs = dict(
                 hx_get=status_url,
-                hx_trigger="load, every 3s",
+                hx_trigger="load, every 8s",
                 hx_target="this",
                 hx_swap="outerHTML",
             )
@@ -485,7 +485,7 @@ def render_add_creator_status_result(
     status_url = f"/creators/add-status?{urlencode({'q': input_query})}"
     poll_attrs = dict(
         hx_get=status_url,
-        hx_trigger="every 3s",
+        hx_trigger="every 8s",
         hx_target="this",
         hx_swap="outerHTML",
     )


### PR DESCRIPTION
…MX polls

- db.py: reject "null"/"none"/empty creator_id in get_creator_stats before it reaches the UUID column (fixes 22P02 invalid input syntax error)
- db.py: change count="exact" → count="estimated" in _fetch_rank to avoid full table scan that caused statement timeout (57014) on large datasets
- main.py, controllers/job_progress.py: slow job-progress polls 2s → 5s, check-job-status 3s → 8s to reduce Vercel function invocations
- views/creators.py: slow creator add-status polls 3s → 8s
- views/admin.py: slow admin jobs panel refresh 30s → 5m
- tests/test_endpoints.py: update polling interval assertions to be interval-agnostic instead of hardcoded "every 2s"

## Summary by Sourcery

Handle invalid creator IDs and reduce expensive database and polling operations to improve reliability and performance.

Bug Fixes:
- Ignore null, empty, and sentinel string creator IDs in creator stats queries to prevent UUID casting errors.
- Use estimated row counts instead of exact counts when fetching creator rank to avoid long-running queries and timeouts.

Enhancements:
- Slow down various HTMX polling intervals for job progress, job status, creator add-status, and admin jobs panel to reduce backend load and Vercel function invocations.
- Relax polling-related test assertions to be agnostic to specific intervals while still verifying the presence of polling triggers.