### PR TITLE
feat(admin): add users, revenue, and engagement sections to dashboard

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1041,12 +1041,15 @@
     radial-gradient(ellipse 60% 50% at 80% 90%, rgba(139, 92, 246, 0.10) 0%, transparent 55%),
     radial-gradient(ellipse 50% 70% at 70% 20%, rgba(236, 72, 153, 0.07) 0%, transparent 50%),
     radial-gradient(ellipse 70% 40% at 10% 80%, rgba(59, 130, 246, 0.08) 0%, transparent 55%);
-  animation: auth-bg-shift 12s ease-in-out infinite alternate;
 }
 
 @keyframes auth-bg-shift {
   0%   { background-position: 0% 0%, 100% 100%, 100% 0%, 0% 100%; }
   100% { background-position: 5% 8%, 95% 92%, 97% 5%, 3% 95%; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .auth-page-wrapper { animation: auth-bg-shift 12s ease-in-out infinite alternate; }
 }
 
 .auth-container {

--- a/css/main.css
+++ b/css/main.css
@@ -1035,10 +1035,18 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  /* Subtle dot-grid background — used by Notion, Linear, Clerk */
-  background-color: #f9fafb;
-  background-image: radial-gradient(#e2e6ea 1px, transparent 1px);
-  background-size: 22px 22px;
+  background-color: #f0f4ff;
+  background-image:
+    radial-gradient(ellipse 80% 60% at 20% 10%, rgba(99, 102, 241, 0.12) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 50% at 80% 90%, rgba(139, 92, 246, 0.10) 0%, transparent 55%),
+    radial-gradient(ellipse 50% 70% at 70% 20%, rgba(236, 72, 153, 0.07) 0%, transparent 50%),
+    radial-gradient(ellipse 70% 40% at 10% 80%, rgba(59, 130, 246, 0.08) 0%, transparent 55%);
+  animation: auth-bg-shift 12s ease-in-out infinite alternate;
+}
+
+@keyframes auth-bg-shift {
+  0%   { background-position: 0% 0%, 100% 100%, 100% 0%, 0% 100%; }
+  100% { background-position: 5% 8%, 95% 92%, 97% 5%, 3% 95%; }
 }
 
 .auth-container {

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -107,20 +107,31 @@ _FRESHNESS_TIERS: tuple[tuple[str, int, int | None], ...] = (
 )
 
 
-def _count_creators(sc, *, status: str | None = None, extra_filters=None) -> int:
-    """Return a COUNT(*) for the creators table with optional sync_status filter.
+def _count(sc, table: str, extra_filters=None) -> int:
+    """Generic COUNT(*) helper for any table.
 
     Args:
         sc: Supabase client.
-        status: If given, adds .eq("sync_status", status).
+        table: Table name.
         extra_filters: Optional callable(query) -> query for additional filters.
     """
-    q = sc.table("creators").select("id", count="exact")
-    if status is not None:
-        q = q.eq("sync_status", status)
+    q = sc.table(table).select("id", count="exact")
     if extra_filters is not None:
         q = extra_filters(q)
     return q.execute().count or 0
+
+
+def _count_creators(sc, *, status: str | None = None, extra_filters=None) -> int:
+    """Return a COUNT(*) for the creators table with optional sync_status filter."""
+
+    def _f(q):
+        if status is not None:
+            q = q.eq("sync_status", status)
+        if extra_filters is not None:
+            q = extra_filters(q)
+        return q
+
+    return _count(sc, "creators", _f)
 
 
 def _fetch_admin_data() -> dict:
@@ -450,121 +461,50 @@ def _fetch_admin_data() -> dict:
 
     # ── Users & Growth ────────────────────────────────────────────────────────
     try:
-        data["total_users"] = sc.table("users").select("id", count="exact").execute().count or 0
-        data["users_new_7d"] = (
-            sc.table("users")
-            .select("id", count="exact")
-            .gte("created_at", cutoff_7d)
-            .execute()
-            .count
-            or 0
-        )
-        data["users_new_30d"] = (
-            sc.table("users")
-            .select("id", count="exact")
-            .gte("created_at", cutoff_30d)
-            .execute()
-            .count
-            or 0
-        )
-        data["users_completed_oauth"] = (
-            sc.table("auth_providers").select("id", count="exact").execute().count or 0
-        )
-        data["users_active_30d"] = (
-            sc.table("users")
-            .select("id", count="exact")
-            .gte("last_login_at", cutoff_30d)
-            .execute()
-            .count
-            or 0
-        )
-        data["users_never_returned"] = (
-            sc.table("users")
-            .select("id", count="exact")
-            .is_("last_login_at", "null")
-            .execute()
-            .count
-            or 0
-        )
+        data["total_users"] = _count(sc, "users")
+        data["users_new_7d"] = _count(sc, "users", lambda q: q.gte("created_at", cutoff_7d))
+        data["users_new_30d"] = _count(sc, "users", lambda q: q.gte("created_at", cutoff_30d))
+        data["users_completed_oauth"] = _count(sc, "auth_providers")
+        data["users_active_30d"] = _count(sc, "users", lambda q: q.gte("last_login_at", cutoff_30d))
+        data["users_never_returned"] = _count(sc, "users", lambda q: q.is_("last_login_at", "null"))
     except Exception:
         logger.exception("[Admin] Users & growth queries failed")
 
     # ── Revenue & Plans ───────────────────────────────────────────────────────
     try:
-        data["plan_active_paid"] = (
-            sc.table("subscriptions")
-            .select("id", count="exact")
-            .eq("status", "active")
-            .neq("plan", "free")
-            .execute()
-            .count
-            or 0
+        data["plan_active_paid"] = _count(
+            sc, "subscriptions", lambda q: q.eq("status", "active").neq("plan", "free")
         )
-        data["plan_pro_monthly"] = (
-            sc.table("subscriptions")
-            .select("id", count="exact")
-            .eq("status", "active")
-            .neq("plan", "free")
-            .eq("interval", "month")
-            .execute()
-            .count
-            or 0
+        data["plan_pro_monthly"] = _count(
+            sc,
+            "subscriptions",
+            lambda q: q.eq("status", "active").neq("plan", "free").eq("interval", "month"),
         )
-        data["plan_pro_annual"] = (
-            sc.table("subscriptions")
-            .select("id", count="exact")
-            .eq("status", "active")
-            .neq("plan", "free")
-            .eq("interval", "year")
-            .execute()
-            .count
-            or 0
+        data["plan_pro_annual"] = _count(
+            sc,
+            "subscriptions",
+            lambda q: q.eq("status", "active").neq("plan", "free").eq("interval", "year"),
         )
-        data["plan_trialing"] = (
-            sc.table("subscriptions")
-            .select("id", count="exact")
-            .eq("status", "trialing")
-            .execute()
-            .count
-            or 0
-        )
-        data["plan_past_due"] = (
-            sc.table("subscriptions")
-            .select("id", count="exact")
-            .eq("status", "past_due")
-            .execute()
-            .count
-            or 0
-        )
+        data["plan_trialing"] = _count(sc, "subscriptions", lambda q: q.eq("status", "trialing"))
+        data["plan_past_due"] = _count(sc, "subscriptions", lambda q: q.eq("status", "past_due"))
     except Exception:
         logger.exception("[Admin] Revenue & plans queries failed")
 
     # ── Engagement ────────────────────────────────────────────────────────────
     try:
-        data["total_favourites"] = (
-            sc.table("user_favourite_creators").select("id", count="exact").execute().count or 0
-        )
+        data["total_favourites"] = _count(sc, "user_favourite_creators")
     except Exception:
         logger.exception("[Admin] Engagement queries failed")
 
     # ── Contact inquiries inbox ───────────────────────────────────────────────
     try:
-        data["inquiries_new_7d"] = (
-            sc.table("contact_inquiries")
-            .select("id", count="exact")
-            .gte("created_at", cutoff_7d)
-            .execute()
-            .count
-            or 0
+        data["inquiries_new_7d"] = _count(
+            sc, "contact_inquiries", lambda q: q.gte("created_at", cutoff_7d)
         )
-        data["inquiries_unforwarded"] = (
-            sc.table("contact_inquiries")
-            .select("id", count="exact")
-            .is_("forwarded_at", "null")
-            .is_("forward_error", "null")
-            .execute()
-            .count
-            or 0
+        data["inquiries_unforwarded"] = _count(
+            sc,
+            "contact_inquiries",
+            lambda q: q.is_("forwarded_at", "null").is_("forward_error", "null"),
         )
     except Exception:
         logger.exception("[Admin] Contact inquiries queries failed")

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -132,8 +132,10 @@ def _fetch_admin_data() -> dict:
     query (e.g. missing column) degrades that section only, not the whole page.
     """
     now = datetime.now(timezone.utc)
-    cutoff_24h = (now - timedelta(hours=24)).isoformat()
     cutoff_1h = (now - timedelta(hours=1)).isoformat()
+    cutoff_24h = (now - timedelta(hours=24)).isoformat()
+    cutoff_7d = (now - timedelta(days=7)).isoformat()
+    cutoff_30d = (now - timedelta(days=30)).isoformat()
 
     # Freshness cutoffs derived from _FRESHNESS_TIERS so the two are always in sync.
     _tier_days = sorted({d for _, lo, hi in _FRESHNESS_TIERS for d in (lo, hi) if d is not None})
@@ -178,6 +180,24 @@ def _fetch_admin_data() -> dict:
         "creators_with_email": 0,
         "creators_with_instagram": 0,
         "last_contact_extracted_at": None,
+        # Users & growth
+        "total_users": 0,
+        "users_new_7d": 0,
+        "users_new_30d": 0,
+        "users_completed_oauth": 0,
+        "users_active_30d": 0,
+        "users_never_returned": 0,
+        # Revenue & plans
+        "plan_active_paid": 0,
+        "plan_pro_monthly": 0,
+        "plan_pro_annual": 0,
+        "plan_trialing": 0,
+        "plan_past_due": 0,
+        # Engagement
+        "total_favourites": 0,
+        # Contact inquiries inbox
+        "inquiries_new_7d": 0,
+        "inquiries_unforwarded": 0,
         # Recent jobs table
         "recent_jobs": [],
     }
@@ -427,6 +447,127 @@ def _fetch_admin_data() -> dict:
         )
     except Exception:
         logger.exception("[Admin] Failed job breakdown query failed")
+
+    # ── Users & Growth ────────────────────────────────────────────────────────
+    try:
+        data["total_users"] = sc.table("users").select("id", count="exact").execute().count or 0
+        data["users_new_7d"] = (
+            sc.table("users")
+            .select("id", count="exact")
+            .gte("created_at", cutoff_7d)
+            .execute()
+            .count
+            or 0
+        )
+        data["users_new_30d"] = (
+            sc.table("users")
+            .select("id", count="exact")
+            .gte("created_at", cutoff_30d)
+            .execute()
+            .count
+            or 0
+        )
+        data["users_completed_oauth"] = (
+            sc.table("auth_providers").select("id", count="exact").execute().count or 0
+        )
+        data["users_active_30d"] = (
+            sc.table("users")
+            .select("id", count="exact")
+            .gte("last_login_at", cutoff_30d)
+            .execute()
+            .count
+            or 0
+        )
+        data["users_never_returned"] = (
+            sc.table("users")
+            .select("id", count="exact")
+            .is_("last_login_at", "null")
+            .execute()
+            .count
+            or 0
+        )
+    except Exception:
+        logger.exception("[Admin] Users & growth queries failed")
+
+    # ── Revenue & Plans ───────────────────────────────────────────────────────
+    try:
+        data["plan_active_paid"] = (
+            sc.table("subscriptions")
+            .select("id", count="exact")
+            .eq("status", "active")
+            .neq("plan", "free")
+            .execute()
+            .count
+            or 0
+        )
+        data["plan_pro_monthly"] = (
+            sc.table("subscriptions")
+            .select("id", count="exact")
+            .eq("status", "active")
+            .neq("plan", "free")
+            .eq("interval", "month")
+            .execute()
+            .count
+            or 0
+        )
+        data["plan_pro_annual"] = (
+            sc.table("subscriptions")
+            .select("id", count="exact")
+            .eq("status", "active")
+            .neq("plan", "free")
+            .eq("interval", "year")
+            .execute()
+            .count
+            or 0
+        )
+        data["plan_trialing"] = (
+            sc.table("subscriptions")
+            .select("id", count="exact")
+            .eq("status", "trialing")
+            .execute()
+            .count
+            or 0
+        )
+        data["plan_past_due"] = (
+            sc.table("subscriptions")
+            .select("id", count="exact")
+            .eq("status", "past_due")
+            .execute()
+            .count
+            or 0
+        )
+    except Exception:
+        logger.exception("[Admin] Revenue & plans queries failed")
+
+    # ── Engagement ────────────────────────────────────────────────────────────
+    try:
+        data["total_favourites"] = (
+            sc.table("user_favourite_creators").select("id", count="exact").execute().count or 0
+        )
+    except Exception:
+        logger.exception("[Admin] Engagement queries failed")
+
+    # ── Contact inquiries inbox ───────────────────────────────────────────────
+    try:
+        data["inquiries_new_7d"] = (
+            sc.table("contact_inquiries")
+            .select("id", count="exact")
+            .gte("created_at", cutoff_7d)
+            .execute()
+            .count
+            or 0
+        )
+        data["inquiries_unforwarded"] = (
+            sc.table("contact_inquiries")
+            .select("id", count="exact")
+            .is_("forwarded_at", "null")
+            .is_("forward_error", "null")
+            .execute()
+            .count
+            or 0
+        )
+    except Exception:
+        logger.exception("[Admin] Contact inquiries queries failed")
 
     return data
 

--- a/views/admin.py
+++ b/views/admin.py
@@ -198,6 +198,81 @@ def _JobRow(job: dict) -> Tr:
 # ── Section builders ──────────────────────────────────────────────────────────
 
 
+def _UsersSection(data: dict) -> Div:
+    total = data.get("total_users", 0)
+    completed_oauth = data.get("users_completed_oauth", 0)
+    never_returned = data.get("users_never_returned", 0)
+    oauth_pct = f"{completed_oauth / total * 100:.0f}% of signups" if total else "—"
+
+    return Div(
+        H3(
+            "Users & Growth",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        Grid(
+            _StatCard("Total Users", total, "all-time signups", "blue"),
+            _StatCard("Completed OAuth", completed_oauth, oauth_pct, "green"),
+            _StatCard(
+                "Active (30d)",
+                data.get("users_active_30d", 0),
+                "logged in last 30 days",
+                "purple",
+            ),
+            _StatCard("New (7d)", data.get("users_new_7d", 0), "signed up this week", "blue"),
+            _StatCard("New (30d)", data.get("users_new_30d", 0), "signed up this month", "blue"),
+            _StatCard(
+                "Never Returned",
+                never_returned,
+                "signed up, no further login",
+                "orange",
+                warn=never_returned > 0,
+            ),
+            cols_md=3,
+            gap=4,
+        ),
+        cls="mb-6",
+    )
+
+
+def _RevenueSection(data: dict) -> Div:
+    total_users = data.get("total_users", 0)
+    active_paid = data.get("plan_active_paid", 0)
+    monthly = data.get("plan_pro_monthly", 0)
+    annual = data.get("plan_pro_annual", 0)
+    trialing = data.get("plan_trialing", 0)
+    past_due = data.get("plan_past_due", 0)
+    total_favs = data.get("total_favourites", 0)
+    inquiries_new = data.get("inquiries_new_7d", 0)
+    inquiries_unfwd = data.get("inquiries_unforwarded", 0)
+    conversion = f"{active_paid / total_users * 100:.1f}% conversion" if total_users else "—"
+
+    billing_card = Card(
+        H3(
+            "Revenue & Plans",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        _KVRow("Paid (active)", f"{active_paid:,}  ({conversion})"),
+        _KVRow("Pro Monthly", f"{monthly:,}"),
+        _KVRow("Pro Annual", f"{annual:,}"),
+        _KVRow("Trialing", f"{trialing:,}", warn=trialing > 0),
+        _KVRow("Past Due", f"{past_due:,}", warn=past_due > 0),
+        body_cls="p-5",
+    )
+
+    signals_card = Card(
+        H3(
+            "Engagement & Inbox",
+            cls="text-sm font-mono uppercase tracking-widest text-muted-foreground mb-4",
+        ),
+        _KVRow("Favourites saved (total)", f"{total_favs:,}"),
+        _KVRow("Contact inquiries (7d)", f"{inquiries_new:,}"),
+        _KVRow("Pending forward", f"{inquiries_unfwd:,}", warn=inquiries_unfwd > 0),
+        body_cls="p-5",
+    )
+
+    return Grid(billing_card, signals_card, cols_md=2, gap=4, cls="mb-6")
+
+
 def _QueueSection(data: dict) -> Div:
     pending = data["queue_pending"]
     oldest_str = _fmt_age(data.get("oldest_pending_secs"))
@@ -561,6 +636,8 @@ def AdminPage(data: dict, refreshed_at: str = "") -> FT:
             cls="flex items-center justify-between bg-background border-b border-border px-6 py-3 mb-6 sticky top-0 z-40 shadow-sm",
         ),
         Container(
+            _UsersSection(data),
+            _RevenueSection(data),
             _QueueSection(data),
             _InventorySection(data),
             _FreshnessSection(data),

--- a/views/admin.py
+++ b/views/admin.py
@@ -223,7 +223,7 @@ def _UsersSection(data: dict) -> Div:
             _StatCard(
                 "Never Returned",
                 never_returned,
-                "signed up, no further login",
+                "first OAuth only, never logged in again",
                 "orange",
                 warn=never_returned > 0,
             ),


### PR DESCRIPTION
- _fetch_admin_data: add Users & Growth block (total users, OAuth completions, active 30d, new 7d/30d, never returned), Revenue & Plans block (paid active + conversion %, pro monthly/annual, trialing, past due), Engagement block (total favourites), and Contact Inquiries block (new 7d, pending forward)
- Hoist cutoff_7d and cutoff_30d to top-level alongside cutoff_24h/1h to avoid duplicated timedelta computations
- inquiries_unforwarded: tighten filter to IS NULL on both forwarded_at AND forward_error to exclude failed-send rows from the pending count
- views/admin: add _UsersSection (6-stat grid) and _RevenueSection (billing + engagement/inbox 2-card row); wire both above _QueueSection in AdminPage
- All new fetch blocks are independent try/except — a missing permission or column degrades that section only, not the whole dashboard
- Verified all queried columns against live Supabase schema: public.users (created_at, last_login_at confirmed), auth_providers, subscriptions (migrations 017/022/030), user_favourite_creators (migration 019), contact_inquiries (migration 041)

## Summary by Sourcery

Add new users, revenue, engagement, and contact inbox metrics to the admin dashboard and surface them in dedicated UI sections.

New Features:
- Expose users & growth statistics in the admin data payload and render them in a Users & Growth grid section.
- Expose subscription revenue and plan statistics plus engagement and inbox signals in the admin data payload and render them in a combined Revenue & Plans and Engagement & Inbox section.
- Animate and restyle the auth layout background with a softer, multi-radial gradient theme.

Bug Fixes:
- Refine the pending contact inquiries count to exclude rows with forward errors from the unforwarded metric.

Enhancements:
- Hoist common time cutoffs (1h, 24h, 7d, 30d) to top-level in the admin data fetch to avoid duplicated timedelta calculations.
- Guard each new admin metrics block with its own try/except so failures degrade only the relevant dashboard section.