### PR TITLE
fix(db): wrap get_embedding_peers queries in _db_execute for disconne…

### DIFF
--- a/db.py
+++ b/db.py
@@ -2562,8 +2562,8 @@ def get_embedding_peers(
         return None
     try:
         # Step 1: look up peer list
-        resp = (
-            supabase_client.table(_CREATOR_PEERS_TABLE)
+        resp = _db_execute(
+            lambda: supabase_client.table(_CREATOR_PEERS_TABLE)
             .select("peer_list")
             .eq("creator_id", creator_id)
             .eq("peer_type", peer_type)
@@ -2580,8 +2580,11 @@ def get_embedding_peers(
 
         # Step 2: hydrate creator rows for those IDs
         fields = _PEER_CREATOR_FIELDS_WITH_CONTACT if include_contacts else _PEER_CREATOR_FIELDS
-        creators_resp = (
-            supabase_client.table(CREATOR_TABLE).select(fields).in_("id", peer_ids).execute()
+        creators_resp = _db_execute(
+            lambda: supabase_client.table(CREATOR_TABLE)
+            .select(fields)
+            .in_("id", peer_ids)
+            .execute()
         )
         creators_by_id = {c["id"]: c for c in (creators_resp.data or [])}
 


### PR DESCRIPTION
…ct retry

Both Supabase queries in get_embedding_peers were bare .execute() calls with no retry logic. The HTTP/2 connection succeeds for step 1 (peer list lookup) but the server-side idle timeout fires before step 2 (creator hydration), raising RemoteProtocolError and silently returning None — suppressing the "Similar creators" section for the user.

Wrap both calls in _db_execute, which retries on RemoteProtocolError with exponential backoff, matching the pattern used throughout db.py.

## Summary by Sourcery

Bug Fixes:
- Ensure get_embedding_peers retries Supabase peer list and creator hydration queries on RemoteProtocolError instead of failing silently.