### PR TITLE
fix(db): wrap get_category_leaderboard query in _db_execute for disco…

### DIFF
--- a/db.py
+++ b/db.py
@@ -1749,8 +1749,8 @@ def get_category_leaderboard(category: str, limit: int = 5) -> list[dict]:
 
     safe_limit = max(1, min(10, limit))
     try:
-        resp = (
-            supabase_client.table(CREATOR_TABLE)
+        resp = _db_execute(
+            lambda: supabase_client.table(CREATOR_TABLE)
             .select(
                 "id,"
                 "channel_name,"
@@ -2562,8 +2562,8 @@ def get_embedding_peers(
         return None
     try:
         # Step 1: look up peer list
-        resp = (
-            supabase_client.table(_CREATOR_PEERS_TABLE)
+        resp = _db_execute(
+            lambda: supabase_client.table(_CREATOR_PEERS_TABLE)
             .select("peer_list")
             .eq("creator_id", creator_id)
             .eq("peer_type", peer_type)
@@ -2580,8 +2580,11 @@ def get_embedding_peers(
 
         # Step 2: hydrate creator rows for those IDs
         fields = _PEER_CREATOR_FIELDS_WITH_CONTACT if include_contacts else _PEER_CREATOR_FIELDS
-        creators_resp = (
-            supabase_client.table(CREATOR_TABLE).select(fields).in_("id", peer_ids).execute()
+        creators_resp = _db_execute(
+            lambda: supabase_client.table(CREATOR_TABLE)
+            .select(fields)
+            .in_("id", peer_ids)
+            .execute()
         )
         creators_by_id = {c["id"]: c for c in (creators_resp.data or [])}
 


### PR DESCRIPTION
…nnect retry

Bare .execute() caused RemoteProtocolError when the HTTP/2 connection was reused after a prior query (e.g. rank lookup) idled it past Supabase's server-side timeout. Same root cause as get_embedding_peers.

## Summary by Sourcery

Wrap Supabase leaderboard and peer lookup queries in the shared database execution helper to improve robustness against connection issues.

Bug Fixes:
- Ensure get_category_leaderboard uses the _db_execute helper to avoid HTTP/2 connection errors on idle Supabase connections.
- Route both steps of get_embedding_peers through _db_execute so peer list and creator hydration queries benefit from automatic retry and reconnect handling.