### PR TITLE
perf: move MV refresh to pg_cron, increase lists meta cache TTL

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -491,7 +491,7 @@ def _rpc_with_retry(
 # Channels created within this many days are considered "new".
 NEW_CHANNEL_MAX_AGE_DAYS = 365
 
-_LISTS_META_TTL_SECONDS = 60
+_LISTS_META_TTL_SECONDS = 600  # 10 min — data changes at most a few times/day
 _lists_meta_cache: tuple[float, dict[str, int]] | None = None
 
 

--- a/worker/creator_worker.py
+++ b/worker/creator_worker.py
@@ -56,7 +56,6 @@ from db import (
     queue_creator_sync,
     queue_creator_sync_bulk,
     queue_invalid_creators_for_retry,
-    refresh_hero_stats_cache,
     setup_logging,
     supabase_client,
 )
@@ -2277,21 +2276,7 @@ async def process_creator_syncs():
                     "(prevents httplib2 memory corruption)"
                 )
 
-                # Refresh hero stats cache after successful batch
-                try:
-                    result = refresh_hero_stats_cache()
-                    if result.get("success"):
-                        logger.info(
-                            "[Hero Stats Cache] ✅ Refreshed after batch: %s",
-                            result.get("materialized_views"),
-                        )
-                    else:
-                        logger.warning(
-                            "[Hero Stats Cache] ⚠️  Refresh failed: %s",
-                            result.get("error"),
-                        )
-                except Exception as e:
-                    logger.warning("[Hero Stats Cache] ⚠️  Refresh exception: %s", e)
+                # MV refresh is handled by pg_cron (every 30 min) — no per-job call needed.
 
                 global _worker_outcome
                 quota_hit = any(


### PR DESCRIPTION
- Remove per-job refresh_hero_stats_cache() call from creator_worker. With EXIT_AFTER_JOB=True the worker restarts per job, causing ~70K refresh_mv_* RPC calls/month and holding exclusive locks that blocked get_lists_meta readers for ~623ms avg.

- Schedule mv_hero_stats and mv_lists_meta refreshes via pg_cron (every 30 min, staggered) so they run independently of job throughput.

- Add CONCURRENTLY to refresh_mv_lists_meta() to eliminate the exclusive table lock that serialised all concurrent get_lists_meta reads.

- Raise _LISTS_META_TTL_SECONDS from 60s to 600s. Data changes only when creators are added/synced; 10min TTL reduces RPC call volume ~10x across all gunicorn workers with no meaningful staleness impact.

Expected reduction: ~140K refresh calls/month → ~2,880 (pg_cron 2x/hr), get_lists_meta mean latency 623ms → ~2ms.

## Summary by Sourcery

Reduce database load and improve list metadata performance by relying on scheduled MV refreshes instead of per-job cache refreshes and by extending the lists meta cache TTL.

Enhancements:
- Remove per-job hero stats materialized view refresh from the creator worker in favor of scheduled background refreshes.
- Increase the lists metadata cache TTL from 60 seconds to 10 minutes to lower RPC volume without materially impacting freshness.