### PR TITLE
perf: add CDN cache headers for polling endpoints and public pages

### DIFF
--- a/controllers/job_progress.py
+++ b/controllers/job_progress.py
@@ -372,6 +372,6 @@ def render_job_progress_ui(
         id="preview-box",
         # 🔄 Continue polling
         hx_get=f"/job-progress?playlist_url={quote_plus(playlist_url)}",
-        hx_trigger="every 5s",
+        hx_trigger="every 10s",
         hx_swap="outerHTML",
     )

--- a/main.py
+++ b/main.py
@@ -953,7 +953,7 @@ def submit_job(playlist_url: str, req, sess):
     # Instead of polling instruction, show the full engagement screen
     return Div(
         hx_get=f"/job-progress?playlist_url={quote_plus(playlist_url)}",
-        hx_trigger="load, every 5s",
+        hx_trigger="load, every 10s",
         hx_swap="outerHTML",
         id="preview-box",
         children=[
@@ -1026,7 +1026,7 @@ def check_job_status(playlist_url: str, req, sess):
             ),
             # Continue polling this endpoint
             hx_get=f"/check-job-status?playlist_url={quote_plus(playlist_url)}",
-            hx_trigger="every 8s",  # Poll every 8 seconds
+            hx_trigger="every 15s",
             hx_swap="outerHTML",  # Replace the entire div with the new response
         )
 
@@ -1198,13 +1198,35 @@ def creators(req, sess):
         return page_content
 
     # Render with navigation
-    return Titled(
+    response = Titled(
         "Top Creators - YouTube",
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
     )
+
+    # Cache at the CDN edge for logged-out visitors (no search query) only.
+    # Vary: Cookie keeps logged-in responses separate.
+    is_filtered = bool(
+        req.query_params.get("search")
+        or req.query_params.get("category")
+        or req.query_params.get("country")
+        or req.query_params.get("language")
+    )
+    if not sess.get("auth") and not is_filtered:
+        from starlette.responses import HTMLResponse
+        from fasthtml.common import to_xml
+
+        return HTMLResponse(
+            to_xml(response),
+            headers={
+                "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120",
+                "Vary": "Cookie",
+            },
+        )
+
+    return response
 
 
 @rt("/creators/request")
@@ -1329,13 +1351,30 @@ def lists(req, sess):
     page_content = lists_route(req)
 
     # Render with navigation
-    return Titled(
+    response = Titled(
         "Creator Lists - YouTube",
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
     )
+
+    # Cache at the CDN edge for logged-out visitors only.
+    # Vary: Cookie tells the CDN to keep separate cache entries per
+    # cookie presence, so logged-in users always get a fresh response.
+    if not sess.get("auth"):
+        from starlette.responses import HTMLResponse
+        from fasthtml.common import to_xml
+
+        return HTMLResponse(
+            to_xml(response),
+            headers={
+                "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+                "Vary": "Cookie",
+            },
+        )
+
+    return response
 
 
 @rt("/lists/more-countries")

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,91 @@
     "deploymentEnabled": {
       "gh-pages": false
     }
-  }
+  },
+  "headers": [
+    {
+      "source": "/static/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/css/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/js/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/favicon.ico",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400" }
+      ]
+    },
+    {
+      "source": "/robots.txt",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400" }
+      ]
+    },
+    {
+      "source": "/sitemap.xml",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=86400, stale-while-revalidate=3600" }
+      ]
+    },
+    {
+      "source": "/job-progress",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex" }
+      ]
+    },
+    {
+      "source": "/check-job-status",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex" }
+      ]
+    },
+    {
+      "source": "/creators/add-status",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex" }
+      ]
+    },
+    {
+      "source": "/creators/suggest",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex" }
+      ]
+    },
+    {
+      "source": "/lists/more-(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex" }
+      ]
+    },
+    {
+      "source": "/admin(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex" }
+      ]
+    }
+  ]
 }

--- a/views/creators.py
+++ b/views/creators.py
@@ -379,7 +379,7 @@ def render_add_creator_result(
             status_url = f"/creators/add-status?{urlencode({'q': input_query})}"
             poll_attrs = dict(
                 hx_get=status_url,
-                hx_trigger="load, every 8s",
+                hx_trigger="load, every 15s",
                 hx_target="this",
                 hx_swap="outerHTML",
             )
@@ -485,7 +485,7 @@ def render_add_creator_status_result(
     status_url = f"/creators/add-status?{urlencode({'q': input_query})}"
     poll_attrs = dict(
         hx_get=status_url,
-        hx_trigger="every 8s",
+        hx_trigger="every 15s",
         hx_target="this",
         hx_swap="outerHTML",
     )

--- a/views/job_progress.py
+++ b/views/job_progress.py
@@ -215,7 +215,7 @@ def render_job_progress_view(state: JobProgressViewState) -> Div:
             if state.is_complete
             else f"/job-progress?playlist_url={quote_plus(state.playlist_url)}"
         ),
-        hx_trigger=None if state.is_complete else "every 2s",
+        hx_trigger=None if state.is_complete else "every 5s",
         hx_swap=None if state.is_complete else "outerHTML",
         cls="max-w-2xl mx-auto",
     )


### PR DESCRIPTION
vercel.json:
- Add no-store + X-Robots-Tag: noindex to HTMX polling endpoints (/job-progress, /check-job-status, /creators/add-status, /creators/suggest, /lists/more-*, /admin/*) so CDN never caches partial UI fragments or admin pages

main.py:
- /lists: return HTMLResponse with s-maxage=60, stale-while-revalidate=300, Vary: Cookie for logged-out users — CDN serves cached HTML to bots/crawlers while logged-in users always get a fresh response
- /creators: same pattern with s-maxage=30, stale-while-revalidate=120, skipped when search/category/country/language filters are active

## Summary by Sourcery

Optimize polling behavior and edge caching for public pages to reduce load while keeping logged-in and filtered views fresh.

Enhancements:
- Adjust HTMX polling intervals for job progress and creator status endpoints to reduce request frequency.
- Serve cached HTML responses for /creators and /lists to logged-out users with appropriate CDN cache-control and cookie-based variance.
- Configure CDN and robots headers for polling and admin endpoints to prevent caching of partial UI fragments and indexing of non-public pages.