### PR TITLE
feat(db): add creator transcript keywords storage and keyword search RPC

### DIFF
--- a/db/migrations/046_creator_transcript_keywords.sql
+++ b/db/migrations/046_creator_transcript_keywords.sql
@@ -1,0 +1,65 @@
+-- Migration 046: Add transcript_keywords to creators table
+-- Stores KeyBERT-extracted keyword profiles from video transcripts.
+-- Computed offline via Kaggle (notebooks/creator_keyword_poc.ipynb).
+-- The notebook runs on a schedule, picking a random sample of creators each
+-- run so every niche is covered evenly (not just high-engagement creators).
+--
+-- Format: JSONB array of {kw: text, score: float}, e.g.:
+--   [{"kw": "budget mechanical keyboard", "score": 0.7812}, ...]
+--
+-- Two use cases drive the index design:
+--   1. Profile display   — simple SELECT, no index needed.
+--   2. Keyword search    — user types "keyboards", should match
+--                          "budget mechanical keyboard", "mechanical switches", etc.
+--                          Requires full-text search (stemming, partial match).
+--                          RPC wrapper in migration 047.
+
+-- ── Column: keyword payload ───────────────────────────────────────────────────
+ALTER TABLE public.creators
+    ADD COLUMN IF NOT EXISTS transcript_keywords JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN public.creators.transcript_keywords IS
+    'Top keyword phrases extracted via KeyBERT from recent video transcripts. '
+    'Array of {kw: text, score: float} sorted by relevance score desc. '
+    'Computed offline in Kaggle (notebooks/creator_keyword_poc.ipynb). '
+    'Covers mid-tier creators (50K–2M subs). Null = not yet processed.';
+
+-- ── Column: refresh timestamp ─────────────────────────────────────────────────
+-- Tracks when keywords were last computed. The Kaggle pipeline (Cell 15 in the
+-- notebook) sets this on every write-back. Once all creators are processed the
+-- scheduler re-runs on creators with the oldest updated_at so keywords stay fresh.
+ALTER TABLE public.creators
+    ADD COLUMN IF NOT EXISTS transcript_keywords_updated_at TIMESTAMPTZ DEFAULT NULL;
+
+COMMENT ON COLUMN public.creators.transcript_keywords_updated_at IS
+    'Timestamp of the most recent keyword extraction write-back from Kaggle. '
+    'Used by the pipeline to schedule refresh runs on stale creators. '
+    'NULL = never processed.';
+
+-- ── Index 1: Exact containment @> (programmatic / tag-click filtering) ────────
+-- Use case: "find all creators whose keywords include 'mechanical keyboards'".
+-- jsonb_path_ops variant is ~30% smaller — supports @> only, which is all we need.
+-- Query:    WHERE transcript_keywords @> '[{"kw": "mechanical keyboards"}]'
+CREATE INDEX IF NOT EXISTS idx_creators_transcript_keywords_gin
+    ON public.creators USING gin (transcript_keywords jsonb_path_ops)
+    WHERE transcript_keywords IS NOT NULL;
+
+-- ── Index 2: Full-text search @@ (user-facing search box) ────────────────────
+-- jsonb_to_tsvector extracts the "kw" string values and builds an English-stemmed
+-- tsvector. "keyboard" matches "budget mechanical keyboard", "mechanical switches".
+-- The search_creators_by_keyword() RPC in migration 047 uses this index.
+-- Query:    WHERE jsonb_to_tsvector('english', transcript_keywords, '["string"]')
+--                 @@ plainto_tsquery('english', 'mechanical keyboard')
+CREATE INDEX IF NOT EXISTS idx_creators_transcript_keywords_fts
+    ON public.creators
+    USING gin (jsonb_to_tsvector('english', transcript_keywords, '["string"]'))
+    WHERE transcript_keywords IS NOT NULL;
+
+-- ── Index 3: Refresh scheduling ───────────────────────────────────────────────
+-- The Kaggle pipeline orders refresh runs by oldest updated_at so no creator
+-- stays stale indefinitely. NULLS FIRST puts unprocessed creators at the front.
+CREATE INDEX IF NOT EXISTS idx_creators_transcript_keywords_updated_at
+    ON public.creators (transcript_keywords_updated_at ASC NULLS FIRST)
+    WHERE sync_status = 'synced'
+      AND current_subscribers >= 50000
+      AND current_subscribers <= 2000000;

--- a/db/migrations/047_search_creators_by_keyword.sql
+++ b/db/migrations/047_search_creators_by_keyword.sql
@@ -1,0 +1,98 @@
+-- Migration 047: Keyword search RPC for creator discovery
+--
+-- Provides full-text search over transcript_keywords added in migration 046.
+-- Uses the idx_creators_transcript_keywords_fts GIN index (tsvector over kw strings).
+--
+-- "keyboard" matches creators with keywords like "budget mechanical keyboard",
+-- "mechanical switches", "custom keyboards" — stemming handled by Postgres.
+--
+-- Called from the Supabase client:
+--   sb.rpc("search_creators_by_keyword", {
+--       "search_query": "mechanical keyboard",
+--       "p_category":   "Science & Technology",   -- optional
+--       "p_min_subs":   100000,                   -- optional
+--       "p_limit":      50,
+--   }).execute()
+
+CREATE OR REPLACE FUNCTION public.search_creators_by_keyword(
+    search_query  TEXT,
+    p_category    TEXT    DEFAULT NULL,
+    p_min_subs    BIGINT  DEFAULT NULL,
+    p_max_subs    BIGINT  DEFAULT NULL,
+    p_limit       INT     DEFAULT 50,
+    p_offset      INT     DEFAULT 0
+)
+RETURNS TABLE (
+    id                          UUID,
+    channel_name                TEXT,
+    channel_id                  TEXT,
+    custom_url                  TEXT,
+    primary_category            TEXT,
+    current_subscribers         BIGINT,
+    engagement_score            NUMERIC,
+    transcript_keywords         JSONB,
+    transcript_keywords_updated_at TIMESTAMPTZ,
+    total_count                 BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH matched AS (
+        SELECT
+            c.id,
+            c.channel_name,
+            c.channel_id,
+            c.custom_url,
+            c.primary_category,
+            c.current_subscribers,
+            c.engagement_score,
+            c.transcript_keywords,
+            c.transcript_keywords_updated_at,
+            -- Rank by relevance score: sum of keyword scores for matching phrases
+            -- so a creator whose top keyword IS the search term ranks above one
+            -- where it appears as a low-weight bigram.
+            (
+                SELECT COALESCE(SUM((kw_item->>'score')::NUMERIC), 0)
+                FROM jsonb_array_elements(c.transcript_keywords) AS kw_item
+                WHERE to_tsvector('english', kw_item->>'kw')
+                      @@ plainto_tsquery('english', search_query)
+            ) AS relevance
+        FROM public.creators c
+        WHERE
+            c.sync_status = 'synced'
+            AND c.transcript_keywords IS NOT NULL
+            -- FTS match — uses idx_creators_transcript_keywords_fts
+            AND jsonb_to_tsvector('english', c.transcript_keywords, '["string"]')
+                @@ plainto_tsquery('english', search_query)
+            -- Optional filters
+            AND (p_category IS NULL OR c.primary_category = p_category)
+            AND (p_min_subs IS NULL OR c.current_subscribers >= p_min_subs)
+            AND (p_max_subs IS NULL OR c.current_subscribers <= p_max_subs)
+    ),
+    counted AS (
+        SELECT *, COUNT(*) OVER () AS total_count
+        FROM matched
+        ORDER BY relevance DESC, current_subscribers DESC
+        LIMIT  GREATEST(1, LEAST(COALESCE(p_limit, 50), 200))
+        OFFSET GREATEST(0, COALESCE(p_offset, 0))
+    )
+    SELECT
+        id, channel_name, channel_id, custom_url,
+        primary_category, current_subscribers, engagement_score,
+        transcript_keywords, transcript_keywords_updated_at,
+        total_count
+    FROM counted;
+$$;
+
+-- Grant execute to the anon and authenticated roles used by Supabase client
+GRANT EXECUTE ON FUNCTION public.search_creators_by_keyword(
+    TEXT, TEXT, BIGINT, BIGINT, INT, INT
+) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.search_creators_by_keyword IS
+    'Full-text search over creator transcript keywords extracted by KeyBERT. '
+    '"keyboard" matches creators with keywords like "budget mechanical keyboard", '
+    '"mechanical switches", etc. Supports optional category and subscriber filters. '
+    'Returns results ranked by keyword relevance score then subscriber count.';

--- a/db/migrations/047_search_creators_by_keyword.sql
+++ b/db/migrations/047_search_creators_by_keyword.sql
@@ -37,9 +37,16 @@ RETURNS TABLE (
 LANGUAGE sql
 STABLE
 SECURITY DEFINER
-SET search_path = public
+SET search_path = public, pg_temp
 AS $$
-    WITH matched AS (
+    WITH
+    -- Parse the query string once so it is not re-evaluated in the WHERE clause,
+    -- the ts_rank() call, or any future references. Ensures consistency for multi-
+    -- word queries and avoids redundant parsing work on every matched row.
+    q AS (
+        SELECT plainto_tsquery('english', search_query) AS tsq
+    ),
+    matched AS (
         SELECT
             c.id,
             c.channel_name,
@@ -50,14 +57,13 @@ AS $$
             c.engagement_score,
             c.transcript_keywords,
             c.transcript_keywords_updated_at,
-            -- Rank by relevance score: sum of keyword scores for matching phrases
-            -- so a creator whose top keyword IS the search term ranks above one
-            -- where it appears as a low-weight bigram.
-            (
-                SELECT COALESCE(SUM((kw_item->>'score')::NUMERIC), 0)
-                FROM jsonb_array_elements(c.transcript_keywords) AS kw_item
-                WHERE to_tsvector('english', kw_item->>'kw')
-                      @@ plainto_tsquery('english', search_query)
+            -- ts_rank over the same jsonb_to_tsvector expression used by the GIN
+            -- index (idx_creators_transcript_keywords_fts). This reuses the index's
+            -- pre-tokenized tsvector instead of re-tokenizing each keyword element
+            -- row-by-row, which was CPU-heavy for creators with many keywords.
+            ts_rank(
+                jsonb_to_tsvector('english', c.transcript_keywords, '["string"]'),
+                (SELECT tsq FROM q)
             ) AS relevance
         FROM public.creators c
         WHERE
@@ -65,7 +71,7 @@ AS $$
             AND c.transcript_keywords IS NOT NULL
             -- FTS match — uses idx_creators_transcript_keywords_fts
             AND jsonb_to_tsvector('english', c.transcript_keywords, '["string"]')
-                @@ plainto_tsquery('english', search_query)
+                @@ (SELECT tsq FROM q)
             -- Optional filters
             AND (p_category IS NULL OR c.primary_category = p_category)
             AND (p_min_subs IS NULL OR c.current_subscribers >= p_min_subs)
@@ -75,7 +81,9 @@ AS $$
         SELECT *, COUNT(*) OVER () AS total_count
         FROM matched
         ORDER BY relevance DESC, current_subscribers DESC
-        LIMIT  GREATEST(1, LEAST(COALESCE(p_limit, 50), 200))
+        -- GREATEST(0, ...) rather than GREATEST(1, ...) so p_limit=0 is honored
+        -- literally rather than silently returning 1 row.
+        LIMIT  GREATEST(0, LEAST(COALESCE(p_limit, 50), 200))
         OFFSET GREATEST(0, COALESCE(p_offset, 0))
     )
     SELECT


### PR DESCRIPTION
Migration 046: add transcript_keywords (JSONB) and transcript_keywords_updated_at (TIMESTAMPTZ) columns to creators table. Three partial indexes: GIN jsonb_path_ops for exact containment, GIN tsvector for full-text search, and B-tree on updated_at for Kaggle refresh scheduling (oldest-first). All additive/non-locking.

Migration 047: add search_creators_by_keyword() RPC. Accepts search_query with optional category, subscriber range, limit, and offset filters. Ranks results by sum of matching keyword scores then subscriber count. SECURITY DEFINER, follows project RPC conventions (search_path, total_count via window function).

## Summary by Sourcery

Add storage and indexing for creator transcript keyword profiles and expose a full-text keyword search RPC for creator discovery.

New Features:
- Store KeyBERT-extracted transcript keyword profiles and refresh timestamps on creators for offline keyword processing.
- Provide a search_creators_by_keyword RPC that performs full-text search over creator transcript keywords with optional category and subscriber filters and ranked results.

Enhancements:
- Add GIN and B-tree indexes over transcript keyword data to support efficient containment queries, full-text search, and refresh scheduling.