### PR TITLE
fix: stabilise db layer against H2 and Cloudflare transient errors

### DIFF
--- a/db.py
+++ b/db.py
@@ -74,7 +74,16 @@ def _is_transient_disconnect(exc: BaseException) -> bool:
     """
 
     def _matches(e: BaseException) -> bool:
-        return type(e).__name__ == "RemoteProtocolError" or "Server disconnected" in str(e)
+        if type(e).__name__ == "RemoteProtocolError" or "Server disconnected" in str(e):
+            return True
+        # h2 concurrent-stream thread-safety errors: the vendored h2 library
+        # mutates its stream dict while another thread is iterating it.  These
+        # RuntimeErrors are NOT wrapped into RemoteProtocolError so they bypass
+        # the check above.  After such a failure httpcore drops the broken
+        # connection; a retry gets a fresh one.
+        if isinstance(e, RuntimeError) and "iteration" in str(e) and "dictionary" in str(e):
+            return True
+        return False
 
     return _matches(exc) or (exc.__cause__ is not None and _matches(exc.__cause__))
 
@@ -1655,8 +1664,8 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
         return _default
 
     try:
-        resp = (
-            supabase_client.table(CREATOR_TABLE)
+        resp = _db_execute(
+            lambda: supabase_client.table(CREATOR_TABLE)
             .select(
                 "current_view_count,"
                 "current_video_count,"
@@ -1720,10 +1729,16 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
                 exc,
             )
             return _default
-        # Supabase / PostgREST API errors have a status_code; treat all as
-        # swallowed since they represent valid "no data" server responses.
-        if getattr(exc, "status_code", None) is not None:
-            logger.exception("get_category_peer_benchmarks: API error for '%s'", category)
+        # Supabase / PostgREST API errors carry a .code attribute (e.g. 400,
+        # 500).  The previous check used .status_code which does NOT exist on
+        # postgrest.exceptions.APIError — causing these to fall through to the
+        # re-raise path and crash the ASGI request with a 500.
+        if getattr(exc, "code", None) is not None or getattr(exc, "status_code", None) is not None:
+            logger.warning(
+                "get_category_peer_benchmarks: API error for '%s': %s",
+                category,
+                exc,
+            )
             return _default
         # Unexpected programming error — re-raise so it's caught in tests.
         logger.exception("get_category_peer_benchmarks: unexpected error for '%s'", category)

--- a/db.py
+++ b/db.py
@@ -1729,11 +1729,11 @@ def get_category_peer_benchmarks(category: str) -> dict[str, float]:
                 exc,
             )
             return _default
-        # Supabase / PostgREST API errors carry a .code attribute (e.g. 400,
-        # 500).  The previous check used .status_code which does NOT exist on
-        # postgrest.exceptions.APIError — causing these to fall through to the
-        # re-raise path and crash the ASGI request with a 500.
-        if getattr(exc, "code", None) is not None or getattr(exc, "status_code", None) is not None:
+        # postgrest.exceptions.APIError carries a .code attribute (e.g. 400,
+        # 500).  Match by type name — consistent with the _is_transient_disconnect
+        # pattern — so only PostgREST errors are swallowed, not any exception
+        # that happens to have a .code attribute.
+        if type(exc).__name__ == "APIError" and getattr(exc, "code", None) is not None:
             logger.warning(
                 "get_category_peer_benchmarks: API error for '%s': %s",
                 category,


### PR DESCRIPTION
- Extend _is_transient_disconnect to also retry on h2 RuntimeErrors ("dictionary changed/keys changed during iteration") — vendored h2 library races when multiple threads share the same HTTP/2 connection; httpcore drops the broken conn so the retry gets a fresh one

- Fix get_category_peer_benchmarks crashing ASGI requests on Cloudflare 400s: postgrest.exceptions.APIError carries .code (not .status_code), so the old guard never matched, fell through to raise, and produced 500s on creator profile pages for affected categories (Entertainment, News & Politics, Autos & Vehicles observed in logs)

- Wrap bare .execute() in get_category_peer_benchmarks with _db_execute so it gets the same disconnect-retry as every other query in db.py

## Summary by Sourcery

Stabilise database access against transient HTTP/2 and Supabase/PostgREST errors and prevent creator peer benchmark lookups from crashing requests.

Bug Fixes:
- Treat specific h2 RuntimeError iteration/dictionary failures as transient disconnects eligible for retry.
- Handle Supabase/PostgREST API errors in get_category_peer_benchmarks by correctly checking the error code attribute and returning defaults instead of crashing ASGI requests.
- Ensure get_category_peer_benchmarks queries benefit from the standard database execute wrapper with disconnect retry semantics.

Enhancements:
- Improve logging for API errors in get_category_peer_benchmarks by downgrading expected API failures from exception logs to warnings.