### PR TITLE
fix(creators): prevent 57014 timeout on grade+activity+category+sort=…

### DIFF
--- a/db.py
+++ b/db.py
@@ -3433,17 +3433,26 @@ def get_creators(
                         return CreatorsResult([], 0)
                     return []
 
-            if _is_statement_timeout_error(e):
+            if not no_extra_filters and _is_statement_timeout_error(e):
                 # A filter+sort combination hit a statement timeout — most likely
                 # a multi-filter query whose index coverage was insufficient.
                 # Apply migration 048 (grade_sort_composite_indexes) to fix the root
                 # cause. Return empty gracefully so the UI shows "no results" rather
                 # than a 500 error.
+                #
+                # Guard: only degrade gracefully when at least one non-default filter
+                # is active (no_extra_filters=False). A timeout on a plain unfiltered
+                # browse is a genuine outage and should propagate as an error, not
+                # silently return empty results.
                 logger.warning(
                     "get_creators timed out (57014) — returning empty. "
-                    "Sort: %s, Filters: [grade=%s, lang=%s, activity=%s, age=%s, "
+                    "Sort: %s, Limit: %s, Offset: %s, Search: %r, "
+                    "Filters: [grade=%s, lang=%s, activity=%s, age=%s, "
                     "country=%s, category=%s]. Apply migration 048 to fix.",
                     sort,
+                    limit,
+                    offset,
+                    search[:256] if isinstance(search, str) else search,
                     grade_filter,
                     language_filter,
                     activity_filter,

--- a/db.py
+++ b/db.py
@@ -3433,6 +3433,28 @@ def get_creators(
                         return CreatorsResult([], 0)
                     return []
 
+            if _is_statement_timeout_error(e):
+                # A filter+sort combination hit a statement timeout — most likely
+                # a multi-filter query whose index coverage was insufficient.
+                # Apply migration 048 (grade_sort_composite_indexes) to fix the root
+                # cause. Return empty gracefully so the UI shows "no results" rather
+                # than a 500 error.
+                logger.warning(
+                    "get_creators timed out (57014) — returning empty. "
+                    "Sort: %s, Filters: [grade=%s, lang=%s, activity=%s, age=%s, "
+                    "country=%s, category=%s]. Apply migration 048 to fix.",
+                    sort,
+                    grade_filter,
+                    language_filter,
+                    activity_filter,
+                    age_filter,
+                    country_filter,
+                    category_filter,
+                )
+                if return_count:
+                    return CreatorsResult([], 0)
+                return []
+
             logger.error(
                 f"Query execution failed: {type(e).__name__}: {str(e)}\n"
                 f"Sort: {sort}, Search: {search!r}, Filters: "

--- a/db/migrations/048_grade_sort_composite_indexes.sql
+++ b/db/migrations/048_grade_sort_composite_indexes.sql
@@ -1,0 +1,85 @@
+-- Migration 048: Composite indexes for grade-filtered + sort-by-views queries
+--
+-- Problem: get_creators() with quality_grade + activity (monthly_uploads) + category
+-- + ORDER BY current_view_count caused a statement timeout (57014).
+--
+-- Example failing query:
+--   quality_grade = 'A'
+--   AND monthly_uploads < 1      (activity=dormant)
+--   AND primary_category ILIKE '%Jazz%'
+--   ORDER BY current_view_count DESC
+--   LIMIT 50
+--
+-- Root cause: No composite index combined the grade equality predicate with the
+-- views sort column. Postgres had to:
+--   1. Scan all grade=A rows via idx_creators_grade_synced (many rows)
+--   2. Apply the monthly_uploads and ILIKE filters as residual conditions
+--   3. Sort ALL matching rows by current_view_count (expensive)
+-- The sort step on a large intermediate result caused the 57014 timeout.
+--
+-- Fix: composite indexes on (quality_grade, current_view_count DESC) let Postgres:
+--   1. Seek to quality_grade = 'A' in the index
+--   2. Walk rows in current_view_count DESC order (already sorted — no sort step)
+--   3. Apply monthly_uploads < 1 and ILIKE as cheap row-level filters
+--   4. Stop after 50 matches
+-- This is an index-ordered scan: O(rows scanned until 50 match), not O(all matching).
+--
+-- Mirrors the two-index pattern from migration 045 (synced + synced_partial) so
+-- the BitmapOr(idx_synced, idx_synced_partial) plan from migration 045 still works.
+--
+-- Uses plain CREATE INDEX (not CONCURRENTLY) so it can run inside a Supabase
+-- SQL editor transaction. Run during low-traffic if the creators table is large.
+--
+-- Prerequisites: migrations 008, 043, 045 (partial index foundations).
+
+-- ── synced creators ───────────────────────────────────────────────────────────
+
+-- Grade + views sort: covers quality_grade=X ORDER BY current_view_count DESC.
+-- Most impactful for the grade + activity + category + sort=views combination.
+CREATE INDEX IF NOT EXISTS idx_creators_grade_views_synced
+    ON public.creators (quality_grade, current_view_count DESC)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- Grade + subscribers sort: covers quality_grade=X ORDER BY current_subscribers DESC.
+-- Handles the common "grade=A sort=subscribers" filter without a sort step.
+CREATE INDEX IF NOT EXISTS idx_creators_grade_subs_synced
+    ON public.creators (quality_grade, current_subscribers DESC)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- Grade + engagement sort.
+CREATE INDEX IF NOT EXISTS idx_creators_grade_engagement_synced
+    ON public.creators (quality_grade, engagement_score DESC)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- ── synced_partial creators ───────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_creators_grade_views_synced_partial
+    ON public.creators (quality_grade, current_view_count DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_grade_subs_synced_partial
+    ON public.creators (quality_grade, current_subscribers DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_grade_engagement_synced_partial
+    ON public.creators (quality_grade, engagement_score DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- Verification:
+-- SELECT indexname, indexdef
+-- FROM pg_indexes
+-- WHERE tablename = 'creators'
+--   AND indexname LIKE 'idx_creators_grade_%'
+-- ORDER BY indexname;

--- a/db/migrations/048_grade_sort_composite_indexes.sql
+++ b/db/migrations/048_grade_sort_composite_indexes.sql
@@ -27,6 +27,15 @@
 -- Mirrors the two-index pattern from migration 045 (synced + synced_partial) so
 -- the BitmapOr(idx_synced, idx_synced_partial) plan from migration 045 still works.
 --
+-- Why not a 3-column composite (quality_grade, current_view_count DESC, monthly_uploads)?
+-- monthly_uploads appears only as a trailing range predicate (< 1 / > 5). In PostgreSQL
+-- a range predicate on a trailing index column does not extend the ordered scan: once
+-- Postgres begins walking the index in current_view_count order it cannot constrain
+-- monthly_uploads from the index key. Additionally, get_creators() always selects all
+-- columns (SELECT *), so heap fetches happen regardless — there is no index-only scan
+-- benefit. Adding monthly_uploads would increase the size of all 6 indexes with no
+-- planner gain for the common filter patterns.
+--
 -- Uses plain CREATE INDEX (not CONCURRENTLY) so it can run inside a Supabase
 -- SQL editor transaction. Run during low-traffic if the creators table is large.
 --


### PR DESCRIPTION
…views queries

Add composite indexes (quality_grade, sort_col DESC) so grade-filtered queries get their sort column from the index — no separate sort step.

The failing combo was grade=A + activity=dormant + category=Jazz + sort=views: Postgres scanned all grade=A rows, applied residual filters, then sorted the full result by current_view_count → 57014 timeout.

With (quality_grade, current_view_count DESC), the planner seeks to quality_grade='A' and walks rows in views order, checking monthly_uploads and ILIKE inline, stopping after 50 matches.

New indexes (synced + synced_partial mirrors):
- idx_creators_grade_views_synced(_partial)
- idx_creators_grade_subs_synced(_partial)
- idx_creators_grade_engagement_synced(_partial)

Safe: composite indexes starting with quality_grade are ineligible for queries without a grade predicate — no impact on unfiltered browse.

Also extend db.py timeout handler so any 57014 on a filtered query returns CreatorsResult([], 0) gracefully instead of raising a 500.

## Summary by Sourcery

Add database optimizations and timeout handling to make grade-filtered creator queries with sorting more reliable and avoid 57014 timeouts.

Bug Fixes:
- Handle Postgres statement timeout (57014) in get_creators by returning an empty result instead of raising a 500 error for filtered queries.

Enhancements:
- Introduce composite indexes on creators for grade-filtered queries combined with sort-by-views, sort-by-subscribers, and sort-by-engagement for both synced and synced_partial rows to eliminate expensive sort steps.