### PR TITLE
feat(seo): add Person + Organization JSON-LD and explicit robots.txt …

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,12 +53,15 @@ from components import (
     how_it_works_section,
 )
 from components.modals import ExportModal, ShareModal
+from components.seo import JsonLd
 from constants import (
+    CONTACT_EMAIL,
     JobStatus,
     PLAYLIST_STATS_TABLE,
     PLAYLIST_STEPS_CONFIG,
     SECTION_BASE,
     SIGNUPS_TABLE,
+    SITE_BASE_URL,
 )
 from controllers.auth_routes import (
     build_auth_redirect_page,
@@ -366,6 +369,27 @@ def index(req, sess):
                 *sections,
                 cls=f"{ContainerT.xl} uk-container-expand",
             ),
+        ),
+        JsonLd(
+            {
+                "@context": "https://schema.org",
+                "@type": "Organization",
+                "name": "ViralVibes",
+                "url": SITE_BASE_URL,
+                "logo": {
+                    "@type": "ImageObject",
+                    "url": f"{SITE_BASE_URL}/static/favicon.jpeg",
+                },
+                "description": (
+                    "YouTube creator intelligence platform — discover, analyse and rank "
+                    "creators by engagement, growth and audience quality."
+                ),
+                "contactPoint": {
+                    "@type": "ContactPoint",
+                    "email": CONTACT_EMAIL,
+                    "contactType": "customer support",
+                },
+            }
         ),
     )
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,6 +4,8 @@ Allow: /
 
 # Crawlable content — explicit for clarity
 Allow: /creators
+Allow: /creators/top/
+Allow: /creators/like/
 Allow: /creator/
 Allow: /lists
 Allow: /analysis

--- a/views/creators.py
+++ b/views/creators.py
@@ -56,7 +56,7 @@ from db import calculate_creator_stats, get_creator_hero_stats
 from services.contact_extractor import extract_social_links
 from components.category_stats import render_category_box_plots
 from views.mentions import render_mentions_placeholder
-from components.seo import Canonical, ItemListJsonLd, MetaDescription, OgTags
+from components.seo import Canonical, canonical_url, ItemListJsonLd, JsonLd, MetaDescription, OgTags
 
 logger = logging.getLogger(__name__)
 
@@ -4679,10 +4679,49 @@ def creator_profile_head(creator: dict) -> tuple:
     desc = f"{desc} Updated creator intelligence from ViralVibes."
 
     image = thumbnail if thumbnail.startswith(("http://", "https://")) else None
+
+    # ── schema.org/Person JSON-LD ─────────────────────────────────────────────
+    # sameAs links to the creator's YouTube channel(s); critical for
+    # Google Knowledge Panel eligibility and rich-result association.
+    channel_url = safe_get_value(creator, "channel_url", "")
+    channel_id = safe_get_value(creator, "channel_id", "")
+    custom_url_raw = safe_get_value(creator, "custom_url", "")
+
+    same_as: list[str] = []
+    if channel_url and channel_url.startswith("http"):
+        same_as.append(channel_url)
+    elif channel_id:
+        same_as.append(f"https://www.youtube.com/channel/{channel_id}")
+    if custom_url_raw:
+        handle = custom_url_raw.lstrip("@").lower()
+        handle_url = f"https://www.youtube.com/@{handle}"
+        if handle_url not in same_as:
+            same_as.append(handle_url)
+
+    person_ld: dict = {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": name,
+        "url": canonical_url(path),
+    }
+    if same_as:
+        person_ld["sameAs"] = same_as[0] if len(same_as) == 1 else same_as
+    if image:
+        person_ld["image"] = image
+    if category:
+        person_ld["knowsAbout"] = category
+    if subscribers:
+        person_ld["interactionStatistic"] = {
+            "@type": "InteractionCounter",
+            "interactionType": "https://schema.org/SubscribeAction",
+            "userInteractionCount": subscribers,
+        }
+
     return (
         Canonical(path),
         MetaDescription(desc),
         *OgTags(title=title, description=desc, path=path, image=image),
+        JsonLd(person_ld),
     )
 
 


### PR DESCRIPTION
…allows

- Emit schema.org/Person on every creator profile page (sameAs YouTube channel + handle URL, image, knowsAbout, subscriber interactionStatistic)
- Emit schema.org/Organization on homepage (name, url, logo, description, contactPoint with support email)
- Add explicit Allow: /creators/top/ and Allow: /creators/like/ to robots.txt

## Summary by Sourcery

Improve SEO metadata by adding structured data for creators and the site and adjusting crawl directives.

New Features:
- Emit schema.org Person JSON-LD on creator profile pages, including canonical URL, social channel links, profile image, interests, and subscriber interaction statistics.
- Emit schema.org Organization JSON-LD on the homepage with site URL, logo, description, and support contact details.

Enhancements:
- Extend robots.txt to explicitly allow crawling of key creators listing pages.