### PR TITLE
fix(db): eliminate PGRST116 noise and topic_categories cs. always-fail

### DIFF
--- a/db.py
+++ b/db.py
@@ -1625,17 +1625,21 @@ def get_creator_stats(creator_id: str) -> Optional[Dict[str, Any]]:
         return None
 
     try:
+        # Use .limit(1) + list check rather than .single() — the latter sends
+        # Accept: application/vnd.pgrst.object+json which PostgREST answers
+        # with 406/PGRST116 when 0 rows are returned, causing a noisy
+        # exception log for every legitimate "creator not found" case.
         response = _db_execute(
             lambda: supabase_client.table(CREATOR_TABLE)
             .select("*")
             .eq("id", creator_id)
-            .single()
+            .limit(1)
             .execute()
         )
 
         if response.data:
             logger.info(f"Retrieved stats for creator {creator_id}")
-            return response.data
+            return response.data[0]
         else:
             logger.debug(f"No stats found for creator {creator_id}")
             return None

--- a/db/migrations/049_topic_categories_trgm_indexes.sql
+++ b/db/migrations/049_topic_categories_trgm_indexes.sql
@@ -1,0 +1,28 @@
+-- Migration 049: GIN trigram index on topic_categories for fast ilike
+--
+-- Problem
+-- -------
+-- topic_categories is a text column storing JSON arrays as strings
+-- (e.g. '["Volleyball", "Sports"]').  The PostgREST containment operator
+-- (cs.) requires jsonb; on a text column it always fails with:
+--   42883: operator does not exist: text @> unknown
+--
+-- The ilike fallback (e.g. '%Volleyball%') works correctly but requires
+-- a full table scan → 57014 statement timeout on large categories.
+--
+-- Fix
+-- ---
+-- pg_trgm is pre-installed in Supabase.  A GIN trigram index enables
+-- fast case-insensitive substring matching, turning the full-table scan
+-- into an index seek.
+--
+-- Note: CONCURRENTLY is not supported inside a transaction block (e.g. the
+-- Supabase SQL editor).  Run without it; the build will briefly lock the
+-- table for writes but completes quickly on typical dataset sizes.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_creators_topic_categories_trgm
+    ON creators
+    USING GIN (topic_categories gin_trgm_ops)
+    WHERE topic_categories IS NOT NULL;

--- a/db_lists.py
+++ b/db_lists.py
@@ -368,24 +368,18 @@ def get_topic_category_creators(
         return query.execute()
 
     response = None
+    # topic_categories is a text column (not jsonb/text[]), so the PostgREST
+    # containment operator cs. always fails with 42883 ("operator does not
+    # exist: text @> unknown"). Skip the exact attempt entirely and go straight
+    # to the ilike fallback to avoid a guaranteed-failed round-trip.
     try:
-        response = _run()
+        response = _run(use_text_fallback=True)
     except Exception:
-        logger.info(
-            "Exact topic category query failed for %r; trying text fallback",
+        logger.exception(
+            "Error fetching topic category creators for %r via text fallback",
             category_label,
-            exc_info=True,
         )
-
-    if response is None or not response.data:
-        try:
-            response = _run(use_text_fallback=True)
-        except Exception:
-            logger.exception(
-                "Error fetching topic category creators for %r via text fallback",
-                category_label,
-            )
-            response = None
+        response = None
 
     creators = response.data if response and response.data else []
     total_count = (getattr(response, "count", 0) or 0) if return_count and response else 0

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -194,9 +194,10 @@ def test_get_topic_category_creators_empty_category_returns_empty(monkeypatch):
     assert result.total_count == 0
 
 
-def test_get_topic_category_creators_exact_failure_falls_back_once(monkeypatch):
+def test_get_topic_category_creators_always_uses_ilike_directly(monkeypatch):
+    # cs. containment filter always fails on the text column; the function
+    # now skips the exact attempt and goes straight to the ilike path.
     fake_client = _FakeSupabaseClient(
-        RuntimeError("jsonb path failed"),
         {
             "data": [{"channel_name": "Fallback Channel", "current_subscribers": 123}],
             "count": 1,
@@ -212,14 +213,13 @@ def test_get_topic_category_creators_exact_failure_falls_back_once(monkeypatch):
 
     assert result.total_count == 1
     assert result.creators[0]["channel_name"] == "Fallback Channel"
-    assert len(fake_client.calls) == 2
-    assert "filter" in fake_client.calls[0]
-    assert "ilike" in fake_client.calls[1]
+    assert len(fake_client.calls) == 1
+    assert "ilike" in fake_client.calls[0]
+    assert "filter" not in fake_client.calls[0]
 
 
-def test_get_topic_category_creators_empty_exact_result_uses_text_fallback(monkeypatch):
+def test_get_topic_category_creators_ilike_returns_count_and_creators(monkeypatch):
     fake_client = _FakeSupabaseClient(
-        {"data": [], "count": 0},
         {
             "data": [{"channel_name": "Legacy Match", "current_subscribers": 456}],
             "count": 1,
@@ -231,9 +231,8 @@ def test_get_topic_category_creators_empty_exact_result_uses_text_fallback(monke
 
     assert result.total_count == 1
     assert result.creators[0]["channel_name"] == "Legacy Match"
-    assert len(fake_client.calls) == 2
-    assert "filter" in fake_client.calls[0]
-    assert "ilike" in fake_client.calls[1]
+    assert len(fake_client.calls) == 1
+    assert "ilike" in fake_client.calls[0]
 
 
 def test_get_topic_category_creators_applies_offset_to_rank(monkeypatch):


### PR DESCRIPTION
- get_creator_stats: replace .single() with .limit(1) to avoid 406/PGRST116 on missing creators (same pattern already used in get_cached_category_box_stats)
- get_topic_category_creators: skip the exact cs. filter entirely — topic_categories is a text column so the containment operator always fails with 42883; go directly to the ilike fallback and drop the guaranteed-failed round-trip
- migration 049: GIN trigram index on topic_categories to prevent 57014 timeouts on the ilike fallback for large categories

## Summary by Sourcery

Reduce noisy database errors when fetching creators and improve topic category query performance.

Bug Fixes:
- Prevent 406/PGRST116 errors from being logged as exceptions when creator records are legitimately missing.
- Avoid guaranteed 42883 errors from using the PostgREST containment operator on the topic_categories text column.

Enhancements:
- Route topic category creator lookups directly to the text-based fallback instead of attempting an exact containment query.
- Add a GIN trigram index on creators.topic_categories to speed up ilike-based searches and avoid timeouts on large categories.

Build:
- Introduce migration 049 to create the pg_trgm extension and GIN trigram index on topic_categories.