### PR TITLE
feat(seo): add BreadcrumbList JSON-LD to creator and category pages

### DIFF
--- a/components/seo.py
+++ b/components/seo.py
@@ -24,6 +24,7 @@ __all__ = [
     "Canonical",
     "OgTags",
     "JsonLd",
+    "BreadcrumbList",
     "ItemListJsonLd",
     "MetaDescription",
 ]
@@ -90,6 +91,40 @@ def JsonLd(data: dict[str, Any]) -> Script:
     """
     payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
     return Script(payload, type="application/ld+json")
+
+
+def BreadcrumbList(items: list[tuple[str, str | None]]) -> Script:
+    """Emit a ``BreadcrumbList`` JSON-LD block.
+
+    ``items`` is an ordered list of ``(name, url)`` pairs representing the
+    navigation trail from the site root to the current page.  The last item
+    is conventionally the current page and may omit the URL (pass ``None``).
+
+    Example::
+
+        BreadcrumbList([
+            ("Home",          "/"),
+            ("Top Creators",  "/creators/top"),
+            ("MrBeast",       None),   # current page — no URL required
+        ])
+    """
+    elements = []
+    for position, (name, url) in enumerate(items, start=1):
+        entry: dict[str, Any] = {
+            "@type": "ListItem",
+            "position": position,
+            "name": name,
+        }
+        if url is not None:
+            entry["item"] = canonical_url(url)
+        elements.append(entry)
+    return JsonLd(
+        {
+            "@context": "https://schema.org",
+            "@type": "BreadcrumbList",
+            "itemListElement": elements,
+        }
+    )
 
 
 def ItemListJsonLd(

--- a/views/creators.py
+++ b/views/creators.py
@@ -56,7 +56,15 @@ from db import calculate_creator_stats, get_creator_hero_stats
 from services.contact_extractor import extract_social_links
 from components.category_stats import render_category_box_plots
 from views.mentions import render_mentions_placeholder
-from components.seo import Canonical, canonical_url, ItemListJsonLd, JsonLd, MetaDescription, OgTags
+from components.seo import (
+    BreadcrumbList,
+    Canonical,
+    canonical_url,
+    ItemListJsonLd,
+    JsonLd,
+    MetaDescription,
+    OgTags,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -4717,11 +4725,20 @@ def creator_profile_head(creator: dict) -> tuple:
             "userInteractionCount": subscribers,
         }
 
+    breadcrumb = BreadcrumbList(
+        [
+            ("Home", "/"),
+            ("Top Creators", "/creators/top"),
+            (name, None),
+        ]
+    )
+
     return (
         Canonical(path),
         MetaDescription(desc),
         *OgTags(title=title, description=desc, path=path, image=image),
         JsonLd(person_ld),
+        breadcrumb,
     )
 
 
@@ -5103,10 +5120,24 @@ def creators_top_head(
     _, _, meta_desc = _top_intro_copy(category_label, total_count)
     page_title = creators_top_page_title(category_label)
 
+    if category_slug is None:
+        crumb_items: list[tuple[str, str | None]] = [
+            ("Home", "/"),
+            ("Top Creators", None),
+        ]
+    else:
+        crumb_label = category_label or category_slug
+        crumb_items = [
+            ("Home", "/"),
+            ("Top Creators", "/creators/top"),
+            (crumb_label, None),
+        ]
+
     tags: list = [
         Canonical(base_path),
         MetaDescription(meta_desc),
         *OgTags(title=page_title, description=meta_desc, path=base_path),
+        BreadcrumbList(crumb_items),
     ]
 
     if creators:


### PR DESCRIPTION
- Add BreadcrumbList() helper to components/seo.py (exported in __all__)
- Creator profiles: Home → Top Creators → {Name}
- /creators/top: Home → Top Creators
- /creators/top/{category}: Home → Top Creators → {Category Label}

Enables breadcrumb display in Google search results.

## Summary by Sourcery

Add JSON-LD breadcrumb metadata to creator profile and top creators pages to improve search engine presentation.

New Features:
- Introduce a reusable BreadcrumbList JSON-LD helper in the SEO components.
- Add breadcrumb trails for creator profiles, the global top creators page, and category-specific top creators pages.