### PR TITLE
fix(sort): restore sort pills broken by missing indexes and stale RPC

### DIFF
--- a/db.py
+++ b/db.py
@@ -3258,9 +3258,8 @@ def get_creators(
             "engagement": ("engagement_score", True),
             # quality_grade_rank: 1=A+, 2=A, 3=B+, 4=B, 5=C, 99=ungraded
             # ASC (desc=False) gives A+ first — correct quality-tier order.
-            # Added by migration 052. Falls back to quality_grade text sort
-            # on databases that have not yet applied the migration (quality_grade
-            # text ASC gives A, A+, B, B+, C — A+ is second, still near top).
+            # Requires migration 052 to be applied before this code is deployed;
+            # the column is GENERATED ALWAYS AS STORED so PostgREST can order by it.
             "quality": ("quality_grade_rank", False),
             "recent": ("last_updated_at", True),
             "consistency": ("monthly_uploads", True),

--- a/db.py
+++ b/db.py
@@ -3256,7 +3256,12 @@ def get_creators(
             "views": ("current_view_count", True),
             "videos": ("current_video_count", True),
             "engagement": ("engagement_score", True),
-            "quality": ("quality_grade", False),
+            # quality_grade_rank: 1=A+, 2=A, 3=B+, 4=B, 5=C, 99=ungraded
+            # ASC (desc=False) gives A+ first — correct quality-tier order.
+            # Added by migration 052. Falls back to quality_grade text sort
+            # on databases that have not yet applied the migration (quality_grade
+            # text ASC gives A, A+, B, B+, C — A+ is second, still near top).
+            "quality": ("quality_grade_rank", False),
             "recent": ("last_updated_at", True),
             "consistency": ("monthly_uploads", True),
             "newest_channel": ("published_at", True),

--- a/db/migrations/050_sort_column_indexes.sql
+++ b/db/migrations/050_sort_column_indexes.sql
@@ -1,0 +1,69 @@
+-- Migration 050: Add partial indexes for remaining sort columns
+--
+-- Problem: get_creators() supports sorting by:
+--   - recent:         ORDER BY last_updated_at DESC
+--   - newest_channel: ORDER BY published_at DESC
+--   - oldest_channel: ORDER BY published_at ASC
+--
+-- None of these columns had partial indexes, so every sort request fell back
+-- to a full sequential scan of the creators table, causing slow responses or
+-- statement timeouts (pg error 57014) on large datasets.
+--
+-- Fix: Add partial indexes on last_updated_at DESC and published_at DESC for
+-- both sync_status = 'synced' and sync_status = 'synced_partial'.
+-- PostgreSQL can then use a Merge Append of the two partial index scans to
+-- satisfy ORDER BY ... LIMIT 50 in O(50 seeks) instead of O(N) sequential scan.
+--
+-- Note: A single published_at DESC index covers both ORDER BY published_at DESC
+-- (newest_channel) and ORDER BY published_at ASC (oldest_channel) — PostgreSQL
+-- can walk the DESC index backwards for the ASC sort.
+--
+-- Mirrors the two-index pattern from migration 045 (synced + synced_partial) so
+-- the Merge Append / BitmapOr plans from prior migrations still apply.
+--
+-- Uses plain CREATE INDEX (not CONCURRENTLY) so it can run inside a Supabase
+-- SQL editor transaction. Run during low-traffic if the creators table is large.
+--
+-- Prerequisites: migrations 008, 043, 045 (partial index foundations).
+
+-- ── last_updated_at — powers sort=recent ──────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_creators_last_updated_synced
+    ON public.creators (last_updated_at DESC)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_last_updated_synced_partial
+    ON public.creators (last_updated_at DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- ── published_at — powers sort=newest_channel and sort=oldest_channel ──────────
+-- A single DESC index covers both:
+--   ORDER BY published_at DESC (newest_channel) → forward scan
+--   ORDER BY published_at ASC  (oldest_channel) → backward scan
+
+CREATE INDEX IF NOT EXISTS idx_creators_published_at_synced
+    ON public.creators (published_at DESC)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_published_at_synced_partial
+    ON public.creators (published_at DESC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- Verification:
+-- SELECT indexname, indexdef
+-- FROM pg_indexes
+-- WHERE tablename = 'creators'
+--   AND indexname IN (
+--     'idx_creators_last_updated_synced',
+--     'idx_creators_last_updated_synced_partial',
+--     'idx_creators_published_at_synced',
+--     'idx_creators_published_at_synced_partial'
+--   );

--- a/db/migrations/051_fix_search_rpc_sync_status.sql
+++ b/db/migrations/051_fix_search_rpc_sync_status.sql
@@ -1,0 +1,119 @@
+-- Migration 051: Fix search_creators_ranked RPC to include synced_partial creators
+--
+-- Problem: Migration 045 changed the browseable sync status set from
+-- ('synced', 'pending') to ('synced', 'synced_partial'). The
+-- search_creators_ranked RPC (migration 038) was not updated at the same time
+-- and still filters for sync_status IN ('synced', 'pending'). This means:
+--
+--   1. creators with sync_status = 'synced_partial' (a significant subset with
+--      basic channel data) are silently excluded from all search results.
+--   2. creators with sync_status = 'pending' (not browseable) may incorrectly
+--      appear in search results if any such rows exist.
+--
+-- Fix: Replace ('synced', 'pending') with ('synced', 'synced_partial') in the
+-- WHERE clause, aligning the RPC with constants.BROWSEABLE_SYNC_STATUSES.
+--
+-- Quality sort: uses inline CASE WHEN for grade rank so this migration runs
+-- independently of migration 052 (which adds the quality_grade_rank column).
+-- After migration 052 is applied the planner still evaluates the same logic,
+-- just from the generated column in the heap rather than recalculating.
+--
+-- This is a DROP + CREATE OR REPLACE because the function body changed; the
+-- signature (argument names/types) is unchanged so no callers break.
+
+CREATE OR REPLACE FUNCTION public.search_creators_ranked(
+    p_search text,
+    p_sort text DEFAULT 'subscribers',
+    p_limit integer DEFAULT 50,
+    p_offset integer DEFAULT 0
+)
+RETURNS TABLE (
+    creator jsonb,
+    total_count bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH params AS (
+        SELECT
+            LOWER(LTRIM(COALESCE(p_search, ''), '@')) AS q,
+            (
+                '%' ||
+                REPLACE(
+                    REPLACE(
+                        REPLACE(LOWER(LTRIM(COALESCE(p_search, ''), '@')), '\', '\\'),
+                        '%',
+                        '\%'
+                    ),
+                    '_',
+                    '\_'
+                ) ||
+                '%'
+            ) AS q_pattern,
+            GREATEST(0, LEAST(COALESCE(p_limit, 50), 100)) AS lim,
+            GREATEST(0, COALESCE(p_offset, 0)) AS off,
+            COALESCE(p_sort, 'subscribers') AS sort_key
+    ),
+    matched AS (
+        SELECT
+            c.*,
+            CASE
+                WHEN LOWER(LTRIM(c.custom_url, '@')) = p.q THEN 0
+                WHEN LOWER(c.channel_name) = p.q THEN 1
+                WHEN LOWER(LTRIM(c.custom_url, '@')) LIKE p.q || '%' THEN 2
+                WHEN LOWER(c.channel_name) LIKE p.q || '%' THEN 3
+                WHEN c.channel_name ILIKE p.q_pattern ESCAPE '\' THEN 4
+                WHEN c.custom_url ILIKE p.q_pattern ESCAPE '\' THEN 5
+                WHEN c.primary_category ILIKE p.q_pattern ESCAPE '\' THEN 6
+                WHEN c.keywords ILIKE p.q_pattern ESCAPE '\' THEN 7
+                ELSE 99
+            END AS match_rank
+        FROM public.creators c
+        CROSS JOIN params p
+        WHERE p.q <> ''
+          AND c.channel_name IS NOT NULL
+          AND c.current_subscribers > 0
+          AND c.sync_status IN ('synced', 'synced_partial')   -- was ('synced', 'pending')
+          AND (
+              LOWER(LTRIM(c.custom_url, '@')) = p.q
+              OR LOWER(c.channel_name) = p.q
+              OR LOWER(LTRIM(c.custom_url, '@')) LIKE p.q || '%'
+              OR LOWER(c.channel_name) LIKE p.q || '%'
+              OR c.channel_name ILIKE p.q_pattern ESCAPE '\'
+              OR c.custom_url ILIKE p.q_pattern ESCAPE '\'
+              OR c.primary_category ILIKE p.q_pattern ESCAPE '\'
+              OR c.keywords ILIKE p.q_pattern ESCAPE '\'
+          )
+    ),
+    counted AS (
+        SELECT
+            matched.*,
+            COUNT(*) OVER () AS total_rows
+        FROM matched
+    )
+    SELECT
+        TO_JSONB(counted) - 'match_rank' - 'total_rows' AS creator,
+        counted.total_rows::bigint AS total_count
+    FROM counted
+    CROSS JOIN params p
+    ORDER BY
+        counted.match_rank ASC,
+        CASE WHEN p.sort_key = 'views' THEN counted.current_view_count END DESC NULLS LAST,
+        CASE WHEN p.sort_key = 'videos' THEN counted.current_video_count END DESC NULLS LAST,
+        CASE WHEN p.sort_key = 'engagement' THEN counted.engagement_score END DESC NULLS LAST,
+        CASE WHEN p.sort_key = 'quality' THEN
+            CASE counted.quality_grade WHEN 'A+' THEN 1 WHEN 'A' THEN 2 WHEN 'B+' THEN 3 WHEN 'B' THEN 4 WHEN 'C' THEN 5 ELSE 99 END
+        END ASC NULLS LAST,
+        CASE WHEN p.sort_key = 'recent' THEN counted.last_updated_at END DESC NULLS LAST,
+        CASE WHEN p.sort_key = 'consistency' THEN counted.monthly_uploads END DESC NULLS LAST,
+        CASE WHEN p.sort_key = 'newest_channel' THEN counted.published_at END DESC NULLS LAST,
+        CASE WHEN p.sort_key = 'oldest_channel' THEN counted.published_at END ASC NULLS LAST,
+        counted.current_subscribers DESC NULLS LAST
+    LIMIT (SELECT lim FROM params)
+    OFFSET (SELECT off FROM params);
+$$;
+
+COMMENT ON FUNCTION public.search_creators_ranked(text, text, integer, integer) IS
+    'Ranked creator search for /creators. Prioritizes exact handle/name matches before broad trigram-backed text matches. Includes both synced and synced_partial creators.';

--- a/db/migrations/051_fix_search_rpc_sync_status.sql
+++ b/db/migrations/051_fix_search_rpc_sync_status.sql
@@ -18,8 +18,8 @@
 -- After migration 052 is applied the planner still evaluates the same logic,
 -- just from the generated column in the heap rather than recalculating.
 --
--- This is a DROP + CREATE OR REPLACE because the function body changed; the
--- signature (argument names/types) is unchanged so no callers break.
+-- Uses CREATE OR REPLACE FUNCTION — sufficient because the signature
+-- (argument names/types/defaults) is unchanged. No DROP is needed.
 
 CREATE OR REPLACE FUNCTION public.search_creators_ranked(
     p_search text,

--- a/db/migrations/052_quality_grade_rank.sql
+++ b/db/migrations/052_quality_grade_rank.sql
@@ -1,0 +1,61 @@
+-- Migration 052: Add quality_grade_rank generated column for correct quality sort
+--
+-- Problem: quality_grade stores text values 'A+', 'A', 'B+', 'B', 'C'.
+-- Alphabetical ordering of these values does not match quality tier order:
+--   ASC alphabetical: A, A+, B, B+, C   (A before A+ — wrong, A+ is best tier)
+--   DESC alphabetical: C, B+, B, A+, A  (C first — wrong, C is lowest tier)
+--
+-- The correct order for "best quality first" is: A+, A, B+, B, C
+-- (matching the grade_options display order on the /creators page).
+--
+-- Fix: Add a stored generated column quality_grade_rank (INT2) that maps each
+-- grade text value to a sort-safe integer:
+--   A+ → 1 (best)
+--   A  → 2
+--   B+ → 3
+--   B  → 4
+--   C  → 5
+--   NULL / other → 99 (ungraded creators sort last)
+--
+-- Then ORDER BY quality_grade_rank ASC gives A+ first, C last.
+-- Add partial indexes matching the existing browseable partial index pattern
+-- (migrations 008, 043, 045) so the planner can use Merge Append.
+--
+-- db.py sort_map is updated in the same PR to use quality_grade_rank.
+--
+-- Prerequisites: migrations 008, 043, 045 (partial index foundations).
+
+-- Add the generated column (PostgreSQL 12+ syntax, supported by Supabase)
+ALTER TABLE public.creators
+    ADD COLUMN IF NOT EXISTS quality_grade_rank INT2
+    GENERATED ALWAYS AS (
+        CASE quality_grade
+            WHEN 'A+' THEN 1
+            WHEN 'A'  THEN 2
+            WHEN 'B+' THEN 3
+            WHEN 'B'  THEN 4
+            WHEN 'C'  THEN 5
+            ELSE 99
+        END
+    ) STORED;
+
+-- Partial index for synced creators sorted by quality rank
+CREATE INDEX IF NOT EXISTS idx_creators_quality_rank_synced
+    ON public.creators (quality_grade_rank ASC)
+    WHERE sync_status = 'synced'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- Partial index for synced_partial creators
+CREATE INDEX IF NOT EXISTS idx_creators_quality_rank_synced_partial
+    ON public.creators (quality_grade_rank ASC)
+    WHERE sync_status = 'synced_partial'
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- Verification:
+-- SELECT quality_grade, quality_grade_rank, COUNT(*)
+-- FROM public.creators
+-- WHERE sync_status = 'synced'
+-- GROUP BY quality_grade, quality_grade_rank
+-- ORDER BY quality_grade_rank;


### PR DESCRIPTION
- Migration 050: add last_updated_at DESC and published_at DESC partial indexes for synced + synced_partial; fixes sort=recent, newest_channel, oldest_channel timing out on large tables (no index → full seq scan → 57014)
- Migration 051: fix search_creators_ranked RPC to use sync_status IN ('synced', 'synced_partial') — was ('synced', 'pending'), silently excluding all synced_partial creators from search results
- Migration 052: add quality_grade_rank generated column (1=A+…5=C) with partial indexes; fixes quality sort ordering (text sort put A before A+)
- db.py: update sort_map "quality" to use quality_grade_rank ASC

## Summary by Sourcery

Improve creator search and sorting correctness and performance across quality and date-based sorts.

New Features:
- Introduce a quality_grade_rank generated column and wire the quality sort to use it for correct quality tier ordering.

Bug Fixes:
- Update search_creators_ranked RPC to include synced_partial creators and exclude pending ones from search results.

Enhancements:
- Add partial indexes on last_updated_at and published_at for synced and synced_partial creators to make recent and channel-age sorts fast and avoid timeouts.