### PR TITLE
seo: add per-page meta descriptions and OG/Twitter tags to 4 core pages

### DIFF
--- a/db/migrations/052_quality_grade_rank.sql
+++ b/db/migrations/052_quality_grade_rank.sql
@@ -21,9 +21,26 @@
 -- Implementation note: GENERATED ALWAYS AS STORED causes a full table rewrite
 -- which times out on large tables via the Supabase SQL editor. Instead we use:
 --   1. ADD COLUMN (instant — no rewrite)
---   2. Batched UPDATE to backfill existing rows
---   3. BEFORE INSERT/UPDATE trigger to keep it in sync going forward
---   4. Partial indexes for the ORDER BY query plans
+--   2. BEFORE INSERT/UPDATE trigger to keep new rows in sync going forward
+--   3. Partial indexes for the ORDER BY query plans
+--
+-- Out-of-band backfill required (not part of this migration):
+--   After applying this file, populate existing NULL rows by running the
+--   following statement in batches until 0 rows are affected:
+--
+--   UPDATE public.creators
+--   SET quality_grade_rank = CASE quality_grade
+--       WHEN 'A+' THEN 1 WHEN 'A'  THEN 2
+--       WHEN 'B+' THEN 3 WHEN 'B'  THEN 4
+--       WHEN 'C'  THEN 5 ELSE 99
+--   END
+--   WHERE id IN (
+--       SELECT id FROM public.creators
+--       WHERE quality_grade_rank IS NULL
+--       LIMIT 5000
+--   );
+--
+--   Verify with: SELECT COUNT(*) FROM public.creators WHERE quality_grade_rank IS NULL;
 --
 -- db.py sort_map uses quality_grade_rank.
 --
@@ -33,20 +50,7 @@
 ALTER TABLE public.creators
     ADD COLUMN IF NOT EXISTS quality_grade_rank INT2;
 
--- Step 2: Backfill existing rows in batches.
--- Run this statement repeatedly in the Supabase SQL editor until it reports
--- "0 rows affected" (each run updates up to 5 000 rows).
---
--- UPDATE public.creators
--- SET quality_grade_rank = CASE quality_grade
---     WHEN 'A+' THEN 1 WHEN 'A'  THEN 2
---     WHEN 'B+' THEN 3 WHEN 'B'  THEN 4
---     WHEN 'C'  THEN 5 ELSE 99
--- END
--- WHERE quality_grade_rank IS NULL
--- LIMIT 5000;
-
--- Step 3: Trigger to keep quality_grade_rank in sync on every INSERT/UPDATE.
+-- Step 2: Trigger to keep quality_grade_rank in sync on every INSERT/UPDATE.
 CREATE OR REPLACE FUNCTION public.sync_quality_grade_rank()
 RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
@@ -63,7 +67,7 @@ CREATE OR REPLACE TRIGGER trg_sync_quality_grade_rank
 BEFORE INSERT OR UPDATE OF quality_grade ON public.creators
 FOR EACH ROW EXECUTE FUNCTION public.sync_quality_grade_rank();
 
--- Step 4: Partial indexes (run after the backfill in Step 2 is complete).
+-- Step 3: Partial indexes for the ORDER BY query plans.
 
 -- Partial index for synced creators sorted by quality rank
 CREATE INDEX IF NOT EXISTS idx_creators_quality_rank_synced
@@ -79,10 +83,9 @@ CREATE INDEX IF NOT EXISTS idx_creators_quality_rank_synced_partial
       AND channel_name IS NOT NULL
       AND current_subscribers > 0;
 
--- Verification (run after backfill):
+-- Verification query:
 -- SELECT quality_grade, quality_grade_rank, COUNT(*)
 -- FROM public.creators
 -- WHERE sync_status = 'synced'
 -- GROUP BY quality_grade, quality_grade_rank
--- ORDER BY quality_grade_rank;
 -- ORDER BY quality_grade_rank;

--- a/db/migrations/052_quality_grade_rank.sql
+++ b/db/migrations/052_quality_grade_rank.sql
@@ -1,4 +1,4 @@
--- Migration 052: Add quality_grade_rank generated column for correct quality sort
+-- Migration 052: Add quality_grade_rank column for correct quality sort
 --
 -- Problem: quality_grade stores text values 'A+', 'A', 'B+', 'B', 'C'.
 -- Alphabetical ordering of these values does not match quality tier order:
@@ -8,8 +8,7 @@
 -- The correct order for "best quality first" is: A+, A, B+, B, C
 -- (matching the grade_options display order on the /creators page).
 --
--- Fix: Add a stored generated column quality_grade_rank (INT2) that maps each
--- grade text value to a sort-safe integer:
+-- Fix: Add quality_grade_rank (INT2) that maps each grade to a sort-safe integer:
 --   A+ → 1 (best)
 --   A  → 2
 --   B+ → 3
@@ -18,26 +17,53 @@
 --   NULL / other → 99 (ungraded creators sort last)
 --
 -- Then ORDER BY quality_grade_rank ASC gives A+ first, C last.
--- Add partial indexes matching the existing browseable partial index pattern
--- (migrations 008, 043, 045) so the planner can use Merge Append.
 --
--- db.py sort_map is updated in the same PR to use quality_grade_rank.
+-- Implementation note: GENERATED ALWAYS AS STORED causes a full table rewrite
+-- which times out on large tables via the Supabase SQL editor. Instead we use:
+--   1. ADD COLUMN (instant — no rewrite)
+--   2. Batched UPDATE to backfill existing rows
+--   3. BEFORE INSERT/UPDATE trigger to keep it in sync going forward
+--   4. Partial indexes for the ORDER BY query plans
+--
+-- db.py sort_map uses quality_grade_rank.
 --
 -- Prerequisites: migrations 008, 043, 045 (partial index foundations).
 
--- Add the generated column (PostgreSQL 12+ syntax, supported by Supabase)
+-- Step 1: Add plain nullable column (instant metadata change, no table rewrite)
 ALTER TABLE public.creators
-    ADD COLUMN IF NOT EXISTS quality_grade_rank INT2
-    GENERATED ALWAYS AS (
-        CASE quality_grade
-            WHEN 'A+' THEN 1
-            WHEN 'A'  THEN 2
-            WHEN 'B+' THEN 3
-            WHEN 'B'  THEN 4
-            WHEN 'C'  THEN 5
-            ELSE 99
-        END
-    ) STORED;
+    ADD COLUMN IF NOT EXISTS quality_grade_rank INT2;
+
+-- Step 2: Backfill existing rows in batches.
+-- Run this statement repeatedly in the Supabase SQL editor until it reports
+-- "0 rows affected" (each run updates up to 5 000 rows).
+--
+-- UPDATE public.creators
+-- SET quality_grade_rank = CASE quality_grade
+--     WHEN 'A+' THEN 1 WHEN 'A'  THEN 2
+--     WHEN 'B+' THEN 3 WHEN 'B'  THEN 4
+--     WHEN 'C'  THEN 5 ELSE 99
+-- END
+-- WHERE quality_grade_rank IS NULL
+-- LIMIT 5000;
+
+-- Step 3: Trigger to keep quality_grade_rank in sync on every INSERT/UPDATE.
+CREATE OR REPLACE FUNCTION public.sync_quality_grade_rank()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.quality_grade_rank := CASE NEW.quality_grade
+        WHEN 'A+' THEN 1 WHEN 'A'  THEN 2
+        WHEN 'B+' THEN 3 WHEN 'B'  THEN 4
+        WHEN 'C'  THEN 5 ELSE 99
+    END;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER trg_sync_quality_grade_rank
+BEFORE INSERT OR UPDATE OF quality_grade ON public.creators
+FOR EACH ROW EXECUTE FUNCTION public.sync_quality_grade_rank();
+
+-- Step 4: Partial indexes (run after the backfill in Step 2 is complete).
 
 -- Partial index for synced creators sorted by quality rank
 CREATE INDEX IF NOT EXISTS idx_creators_quality_rank_synced
@@ -53,9 +79,10 @@ CREATE INDEX IF NOT EXISTS idx_creators_quality_rank_synced_partial
       AND channel_name IS NOT NULL
       AND current_subscribers > 0;
 
--- Verification:
+-- Verification (run after backfill):
 -- SELECT quality_grade, quality_grade_rank, COUNT(*)
 -- FROM public.creators
 -- WHERE sync_status = 'synced'
 -- GROUP BY quality_grade, quality_grade_rank
+-- ORDER BY quality_grade_rank;
 -- ORDER BY quality_grade_rank;

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ from fasthtml.common import *
 from fasthtml.common import RedirectResponse, Response
 from fasthtml.core import HtmxHeaders
 from monsterui.all import *
-from starlette.responses import Response as StarletteResponse, StreamingResponse
+from starlette.responses import HTMLResponse, Response as StarletteResponse, StreamingResponse
 
 from auth.auth_service import (
     AUTH_SKIP_ROUTE_PATTERNS,
@@ -53,7 +53,7 @@ from components import (
     how_it_works_section,
 )
 from components.modals import ExportModal, ShareModal
-from components.seo import JsonLd
+from components.seo import Canonical, JsonLd, MetaDescription, OgTags
 from constants import (
     CONTACT_EMAIL,
     JobStatus,
@@ -113,6 +113,8 @@ from views.table import DISPLAY_HEADERS, get_sort_col, render_playlist_table
 from routes.analysis import analysis_page_content
 from routes.creators import (
     CreatorProfileResult,
+    CreatorsLikeResult,
+    CreatorsTopResult,
     blueprint_route,
     compare_creators_route,
     creator_add_status_route,
@@ -124,6 +126,14 @@ from routes.creators import (
     creators_suggest_route,
     creators_top_route,
     toggle_favourite_route,
+)
+from views.creators import (
+    creator_profile_head,
+    creator_profile_page_title,
+    creators_like_head,
+    creators_like_page_title,
+    creators_top_head,
+    creators_top_page_title,
 )
 from routes.mentions import mentions_route
 from routes.about import about_page_content
@@ -361,8 +371,13 @@ def index(req, sess):
     # Filter out any None/False values
     sections = [s for s in sections if s is not None and s is not False]
 
+    _homepage_title = "YouTube Creator Intelligence for Brands & Agencies | ViralVibes"
+    _homepage_desc = (
+        "Discover and vet YouTube creators at scale. Filter by engagement rate, niche, "
+        "country and audience quality. Built for brands and agencies."
+    )
     return Titled(
-        "ViralVibes",
+        _homepage_title,
         Container(
             TopAlertBar(),
             NavComponent(oauth, req, sess),
@@ -371,6 +386,9 @@ def index(req, sess):
                 cls=f"{ContainerT.xl} uk-container-expand",
             ),
         ),
+        Canonical("/"),
+        MetaDescription(_homepage_desc),
+        *OgTags(title=_homepage_title, description=_homepage_desc, path="/"),
         JsonLd(
             {
                 "@context": "https://schema.org",
@@ -1198,13 +1216,21 @@ def export_json(dashboard_id: str, req, sess):
 def analysis(req, sess):
     """Playlist analysis page — PUBLIC route"""
     user_id = sess.get("user_id") if sess else None
+    _analysis_title = "YouTube Playlist Analyzer — Instant Engagement & Viral Score | ViralVibes"
+    _analysis_desc = (
+        "Paste any YouTube playlist URL and instantly see engagement rate, viral score, "
+        "view distribution and top-performing videos. Free, no sign-up required."
+    )
     return Titled(
-        "Analyze a Playlist - ViralVibes",
+        _analysis_title,
         Container(
             NavComponent(oauth, req, sess),
             analysis_page_content(user_id=user_id),
             cls=ContainerT.xl,
         ),
+        Canonical("/analysis"),
+        MetaDescription(_analysis_desc),
+        *OgTags(title=_analysis_title, description=_analysis_desc, path="/analysis"),
     )
 
 
@@ -1223,13 +1249,21 @@ def creators(req, sess):
     if isinstance(page_content, RedirectResponse):
         return page_content
 
+    _creators_title = "Find YouTube Creators by Engagement Rate, Niche & Country | ViralVibes"
+    _creators_desc = (
+        "Browse 700,000+ verified YouTube creators. Filter by engagement rate, category, "
+        "country and language. Export contacts and build outreach lists in minutes."
+    )
     # Render with navigation
     response = Titled(
-        "Top Creators - YouTube",
+        _creators_title,
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
+        Canonical("/creators"),
+        MetaDescription(_creators_desc),
+        *OgTags(title=_creators_title, description=_creators_desc, path="/creators"),
     )
 
     # Cache at the CDN edge for logged-out visitors (no search query) only.
@@ -1241,9 +1275,6 @@ def creators(req, sess):
         or req.query_params.get("language")
     )
     if not sess.get("auth") and not is_filtered:
-        from starlette.responses import HTMLResponse
-        from fasthtml.common import to_xml
-
         return HTMLResponse(
             to_xml(response),
             headers={
@@ -1282,13 +1313,8 @@ def creators_suggest(req):
 
 def _render_creators_top(req, sess, category_slug: str | None):
     """Shared body for the global and category-scoped A+ landing pages."""
-    from starlette.responses import Response as _Response
-
-    from routes.creators import CreatorsTopResult
-    from views.creators import creators_top_head, creators_top_page_title
-
     result = creators_top_route(req, category_slug=category_slug)
-    if isinstance(result, _Response):
+    if isinstance(result, StarletteResponse):
         return result  # 404 for unknown slug or 302 redirect for out-of-range page
     if not isinstance(result, CreatorsTopResult):
         # Defensive: any future redirect/response shape passes through.
@@ -1336,13 +1362,8 @@ def creators_top_category(req, sess, slug: str):
 @rt("/creators/like/{handle}")
 def creators_like(req, sess, handle: str):
     """GET /creators/like/{handle} — 20 most-similar creators + contacts."""
-    from starlette.responses import Response as _Response
-
-    from routes.creators import CreatorsLikeResult
-    from views.creators import creators_like_head, creators_like_page_title
-
     result = creators_like_route(req, handle=handle)
-    if isinstance(result, _Response):
+    if isinstance(result, StarletteResponse):
         return result  # 404 for unknown handle or missing peer list
     if not isinstance(result, CreatorsLikeResult):
         return result  # defensive passthrough for future redirect shapes
@@ -1377,22 +1398,27 @@ def lists(req, sess):
     # Call the route handler
     page_content = lists_route(req)
 
+    _lists_title = "Top YouTube Creator Lists by Country, Category & Language | ViralVibes"
+    _lists_desc = (
+        "Curated YouTube creator rankings organised by country, category and language. "
+        "Find the right creators for your campaign with one click."
+    )
     # Render with navigation
     response = Titled(
-        "Creator Lists - YouTube",
+        _lists_title,
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
+        Canonical("/lists"),
+        MetaDescription(_lists_desc),
+        *OgTags(title=_lists_title, description=_lists_desc, path="/lists"),
     )
 
     # Cache at the CDN edge for logged-out visitors only.
     # Vary: Cookie tells the CDN to keep separate cache entries per
     # cookie presence, so logged-in users always get a fresh response.
     if not sess.get("auth"):
-        from starlette.responses import HTMLResponse
-        from fasthtml.common import to_xml
-
         return HTMLResponse(
             to_xml(response),
             headers={
@@ -1557,9 +1583,6 @@ def creator_profile(req, sess, creator_id: str):
     if not _CREATOR_UUID_RE.match(creator_id):
         creator = find_creator_by_handle(creator_id)
         if not creator:
-            from starlette.responses import HTMLResponse
-            from fasthtml.common import to_xml
-
             # Normalise handle for display: strip any leading '@' then re-add
             # it so the message always shows the canonical "@handle" shape.
             display_handle = f"@{creator_id.lstrip('@')}"
@@ -1592,8 +1615,6 @@ def creator_profile(req, sess, creator_id: str):
     result = creator_profile_route(req, creator_id, user_id=sess.get("user_id") if sess else None)
 
     if isinstance(result, CreatorProfileResult):
-        from views.creators import creator_profile_head, creator_profile_page_title
-
         head_tags = creator_profile_head(result.creator)
         return Titled(
             creator_profile_page_title(result.creator),

--- a/views/creators.py
+++ b/views/creators.py
@@ -5050,8 +5050,6 @@ def _render_top_drill_in_cta(*, category_label: str | None) -> Div:
     pre-applied. Encoded with ``quote`` because ``A+`` contains a reserved
     character.
     """
-    from urllib.parse import urlencode
-
     params = {"grade": "A+"}
     if category_label is not None:
         params["category"] = category_label


### PR DESCRIPTION
- Homepage, /analysis, /creators, /lists each get a unique <meta name="description">, Open Graph, and Twitter card tags
- Canonical URLs added for all four pages
- Reuses existing Canonical/MetaDescription/OgTags helpers from components/seo.py (same pattern as /creators/top landing pages)
- Extend import: JsonLd → Canonical, JsonLd, MetaDescription, OgTags

## Summary by Sourcery

Add SEO metadata (titles, descriptions, OG/Twitter tags, canonicals) to core marketing pages and adjust a quality grade ranking migration to use a trigger-based integer column instead of a generated column.

New Features:
- Introduce per-page meta descriptions, Open Graph, and Twitter card tags for the homepage, analysis, creators, and lists pages.
- Add canonical URL tags for the homepage, analysis, creators, and lists pages.

Enhancements:
- Refactor creators routes to reuse imported result types and head/title helpers from views instead of ad hoc imports inside handlers.
- Update the quality_grade_rank migration to use a plain column plus trigger and indexes for safer rollout on large tables.