### PR TITLE
seo: add title tags, canonical, meta description and OG tags to list …

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,7 +100,13 @@ from db import (
     find_creator_by_handle,
 )
 from services.playlist_loader import load_cached_or_stub, load_dashboard_by_id
-from utils import compute_dashboard_id, get_columns, get_language_name, sort_dataframe
+from utils import (
+    compute_dashboard_id,
+    get_columns,
+    get_country_name,
+    get_language_name,
+    sort_dataframe,
+)
 from validators import YoutubePlaylist, YoutubePlaylistValidator
 from views.dashboard import render_full_dashboard
 from views.favourites import render_favourites_page
@@ -108,7 +114,7 @@ from views.my_dashboards import (
     render_my_dashboards_page,
     render_dashboard_page_partial,
 )
-from views.lists import _list_heart_btn, get_country_name
+from views.lists import _list_heart_btn
 from views.table import DISPLAY_HEADERS, get_sort_col, render_playlist_table
 from routes.analysis import analysis_page_content
 from routes.creators import (
@@ -177,6 +183,16 @@ from views.lists import _unslugify
 
 # Get logger instance
 logger = logging.getLogger(__name__)
+
+
+def _list_seo_tags(title: str, desc: str, path: str) -> tuple:
+    """Return (Canonical, MetaDescription, *OgTags) head tags for list detail pages."""
+    return (
+        Canonical(path),
+        MetaDescription(desc),
+        *OgTags(title=title, description=desc, path=path),
+    )
+
 
 # ============================================================================
 # Safety Constants
@@ -1451,7 +1467,7 @@ def lists_more_languages(req, sess):
 @rt("/lists/country/{country_code}")
 def lists_country_detail(req, sess, country_code: str):
     """Detailed creator rankings for a specific country."""
-    country_name = get_country_name(country_code.upper())
+    country_name = get_country_name(country_code)
     _title = f"Top YouTube Creators from {country_name} | ViralVibes"
     _desc = (
         f"Browse the top YouTube creators from {country_name}, ranked by subscriber count. "
@@ -1464,9 +1480,7 @@ def lists_country_detail(req, sess, country_code: str):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        Canonical(f"/lists/country/{country_code.upper()}"),
-        MetaDescription(_desc),
-        *OgTags(title=_title, description=_desc, path=f"/lists/country/{country_code.upper()}"),
+        *_list_seo_tags(_title, _desc, f"/lists/country/{country_code.lower()}"),
     )
 
 
@@ -1493,9 +1507,7 @@ def lists_categories_explorer(req, sess):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        Canonical("/lists/categories"),
-        MetaDescription(_desc),
-        *OgTags(title=_title, description=_desc, path="/lists/categories"),
+        *_list_seo_tags(_title, _desc, "/lists/categories"),
     )
 
 
@@ -1514,9 +1526,7 @@ def lists_countries_explorer(req, sess):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        Canonical("/lists/countries"),
-        MetaDescription(_desc),
-        *OgTags(title=_title, description=_desc, path="/lists/countries"),
+        *_list_seo_tags(_title, _desc, "/lists/countries"),
     )
 
 
@@ -1535,9 +1545,7 @@ def lists_languages_explorer(req, sess):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        Canonical("/lists/languages"),
-        MetaDescription(_desc),
-        *OgTags(title=_title, description=_desc, path="/lists/languages"),
+        *_list_seo_tags(_title, _desc, "/lists/languages"),
     )
 
 
@@ -1557,9 +1565,7 @@ def lists_category_detail(req, sess, category_slug: str):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        Canonical(f"/lists/category/{category_slug}"),
-        MetaDescription(_desc),
-        *OgTags(title=_title, description=_desc, path=f"/lists/category/{category_slug}"),
+        *_list_seo_tags(_title, _desc, f"/lists/category/{category_slug}"),
     )
 
 
@@ -1586,9 +1592,7 @@ def lists_language_detail(req, sess, language_code: str):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        Canonical(f"/lists/language/{language_code.lower()}"),
-        MetaDescription(_desc),
-        *OgTags(title=_title, description=_desc, path=f"/lists/language/{language_code.lower()}"),
+        *_list_seo_tags(_title, _desc, f"/lists/language/{language_code.lower()}"),
     )
 
 

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ from views.my_dashboards import (
     render_my_dashboards_page,
     render_dashboard_page_partial,
 )
-from views.lists import _list_heart_btn
+from views.lists import _list_heart_btn, get_country_name
 from views.table import DISPLAY_HEADERS, get_sort_col, render_playlist_table
 from routes.analysis import analysis_page_content
 from routes.creators import (
@@ -1451,13 +1451,22 @@ def lists_more_languages(req, sess):
 @rt("/lists/country/{country_code}")
 def lists_country_detail(req, sess, country_code: str):
     """Detailed creator rankings for a specific country."""
+    country_name = get_country_name(country_code.upper())
+    _title = f"Top YouTube Creators from {country_name} | ViralVibes"
+    _desc = (
+        f"Browse the top YouTube creators from {country_name}, ranked by subscriber count. "
+        "Discover channels, engagement rates and contact info."
+    )
     page_content = country_detail_route(req, country_code)
     return Titled(
-        f"{country_code} Creators - YouTube",
+        _title,
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
+        Canonical(f"/lists/country/{country_code.upper()}"),
+        MetaDescription(_desc),
+        *OgTags(title=_title, description=_desc, path=f"/lists/country/{country_code.upper()}"),
     )
 
 
@@ -1472,39 +1481,63 @@ def lists_country_more(req, sess, country_code: str):
 @rt("/lists/categories")
 def lists_categories_explorer(req, sess):
     """Visual bar-chart explorer of all content categories."""
+    _title = "YouTube Creators by Category | ViralVibes"
+    _desc = (
+        "Explore YouTube creators across every content category. "
+        "Find top channels by niche, ranked by subscriber count."
+    )
     page_content = categories_explorer_route()
     return Titled(
-        "Category Explorer - ViralVibes",
+        _title,
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
+        Canonical("/lists/categories"),
+        MetaDescription(_desc),
+        *OgTags(title=_title, description=_desc, path="/lists/categories"),
     )
 
 
 @rt("/lists/countries")
 def lists_countries_explorer(req, sess):
     """Visual bar-chart explorer of all countries with creator statistics."""
+    _title = "YouTube Creators by Country | ViralVibes"
+    _desc = (
+        "Explore YouTube creators from every country, ranked by audience size. "
+        "Find the top channels from any region."
+    )
     page_content = countries_explorer_route()
     return Titled(
-        "Country Explorer - ViralVibes",
+        _title,
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
+        Canonical("/lists/countries"),
+        MetaDescription(_desc),
+        *OgTags(title=_title, description=_desc, path="/lists/countries"),
     )
 
 
 @rt("/lists/languages")
 def lists_languages_explorer(req, sess):
     """Visual bar-chart explorer of all content languages."""
+    _title = "YouTube Creators by Language | ViralVibes"
+    _desc = (
+        "Explore YouTube creators who make content in any language. "
+        "Find top channels by language, ranked by subscriber count."
+    )
     page_content = languages_explorer_route()
     return Titled(
-        "Language Explorer - ViralVibes",
+        _title,
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
+        Canonical("/lists/languages"),
+        MetaDescription(_desc),
+        *OgTags(title=_title, description=_desc, path="/lists/languages"),
     )
 
 
@@ -1512,13 +1545,21 @@ def lists_languages_explorer(req, sess):
 def lists_category_detail(req, sess, category_slug: str):
     """Detailed creator rankings for a specific topic category."""
     display_name = resolve_category_slug(category_slug) or _unslugify(category_slug).title()
+    _title = f"Top {display_name} YouTube Channels | ViralVibes"
+    _desc = (
+        f"Browse the top {display_name} YouTube creators, ranked by subscriber count. "
+        "Discover channels, engagement rates and contact info."
+    )
     page_content = category_detail_route(req, category_slug)
     return Titled(
-        f"{display_name} Creators - YouTube",
+        _title,
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
+        Canonical(f"/lists/category/{category_slug}"),
+        MetaDescription(_desc),
+        *OgTags(title=_title, description=_desc, path=f"/lists/category/{category_slug}"),
     )
 
 
@@ -1533,13 +1574,21 @@ def lists_category_more(req, sess, category_slug: str):
 def lists_language_detail(req, sess, language_code: str):
     """Detailed creator rankings for a specific content language."""
     language_name = get_language_name(language_code.lower())
+    _title = f"Top {language_name}-Language YouTube Creators | ViralVibes"
+    _desc = (
+        f"Browse the top {language_name}-language YouTube creators, ranked by subscriber count. "
+        "Discover channels, engagement rates and contact info."
+    )
     page_content = language_detail_route(req, language_code)
     return Titled(
-        f"{language_name} Creators - YouTube",
+        _title,
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
+        Canonical(f"/lists/language/{language_code.lower()}"),
+        MetaDescription(_desc),
+        *OgTags(title=_title, description=_desc, path=f"/lists/language/{language_code.lower()}"),
     )
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -76,6 +76,7 @@ from .creator_metrics import (
     estimate_monthly_revenue_v4,
     format_channel_age,
     get_activity_badge,
+    get_country_name,
     get_grade_info,
     get_growth_signal,
     get_language_emoji,

--- a/utils/creator_metrics.py
+++ b/utils/creator_metrics.py
@@ -524,3 +524,47 @@ def get_country_flag(country_code: str) -> Optional[str]:
         return flag.flag(country_code.upper())
     except (ValueError, KeyError, ImportError):
         return None
+
+
+# Override entries where the official ISO name is too verbose or non-standard
+# for a UI context.  Everything else falls through to pycountry.
+_COUNTRY_NAME_OVERRIDES: dict[str, str] = {
+    "AE": "UAE",
+    "BO": "Bolivia",
+    "CD": "DR Congo",
+    "CF": "C. African Rep.",
+    "CZ": "Czech Republic",
+    "DO": "Dominican Rep.",
+    "GB": "United Kingdom",
+    "IR": "Iran",
+    "KP": "North Korea",
+    "KR": "South Korea",
+    "LA": "Laos",
+    "MD": "Moldova",
+    "MK": "North Macedonia",
+    "PS": "Palestine",
+    "RU": "Russia",
+    "SY": "Syria",
+    "TW": "Taiwan",
+    "TZ": "Tanzania",
+    "US": "United States",
+    "VA": "Vatican",
+    "VE": "Venezuela",
+    "VN": "Vietnam",
+}
+
+
+def get_country_name(country_code: str) -> str:
+    """Return a UI-friendly country name for a two-letter ISO 3166-1 alpha-2 code.
+
+    Checks a small overrides dict first (for cases where the official ISO name
+    is too verbose), then falls back to pycountry's database, preferring
+    ``common_name`` over the formal ``name`` when available.
+    """
+    code = country_code.upper()
+    if code in _COUNTRY_NAME_OVERRIDES:
+        return _COUNTRY_NAME_OVERRIDES[code]
+    country = pycountry.countries.get(alpha_2=code)
+    if not country:
+        return code
+    return getattr(country, "common_name", country.name)

--- a/views/lists.py
+++ b/views/lists.py
@@ -12,6 +12,7 @@ from urllib.parse import quote, urlencode
 from utils import format_number, safe_get_value, slugify
 from utils.creator_metrics import (
     get_country_flag,
+    get_country_name,
     get_grade_info,
     get_language_emoji,
     get_language_name,
@@ -56,53 +57,6 @@ def get_country_flag_emoji(country_code: str) -> str:
     """Get flag emoji for country code, fallback to 🌐 if not found."""
     flag = get_country_flag(country_code)
     return flag if flag else "🌐"
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# ISO 3166-1 country code → display name (via pycountry)
-# ─────────────────────────────────────────────────────────────────────────────
-# Override entries where the official ISO name is too verbose or non-standard
-# for a UI context.  Everything else falls through to pycountry.
-_COUNTRY_NAME_OVERRIDES: dict[str, str] = {
-    "AE": "UAE",
-    "BO": "Bolivia",
-    "CD": "DR Congo",
-    "CF": "C. African Rep.",
-    "CZ": "Czech Republic",
-    "DO": "Dominican Rep.",
-    "GB": "United Kingdom",
-    "IR": "Iran",
-    "KP": "North Korea",
-    "KR": "South Korea",
-    "LA": "Laos",
-    "MD": "Moldova",
-    "MK": "North Macedonia",
-    "PS": "Palestine",
-    "RU": "Russia",
-    "SY": "Syria",
-    "TW": "Taiwan",
-    "TZ": "Tanzania",
-    "US": "United States",
-    "VA": "Vatican",
-    "VE": "Venezuela",
-    "VN": "Vietnam",
-}
-
-
-def get_country_name(country_code: str) -> str:
-    """Return a UI-friendly country name for a two-letter ISO 3166-1 alpha-2 code.
-
-    Checks a small overrides dict first (for cases where the official ISO name
-    is too verbose), then falls back to pycountry's database, preferring
-    ``common_name`` over the formal ``name`` when available.
-    """
-    code = country_code.upper()
-    if code in _COUNTRY_NAME_OVERRIDES:
-        return _COUNTRY_NAME_OVERRIDES[code]
-    country = pycountry.countries.get(alpha_2=code)
-    if not country:
-        return code
-    return getattr(country, "common_name", country.name)
 
 
 def _unslugify(slug: str) -> str:


### PR DESCRIPTION
…detail pages

Country, category and language detail pages had generic or broken title tags ("LT Creators - YouTube") with no canonical, meta description or OG/Twitter tags. Fix all 6 page types:

- /lists/country/{code}: "Top YouTube Creators from {Country} | ViralVibes"
- /lists/category/{slug}: "Top {Category} YouTube Channels | ViralVibes"
- /lists/language/{code}: "Top {Language}-Language YouTube Creators | ViralVibes"
- /lists/countries: "YouTube Creators by Country | ViralVibes"
- /lists/categories: "YouTube Creators by Category | ViralVibes"
- /lists/languages: "YouTube Creators by Language | ViralVibes"

Add get_country_name import to main.py (from views.lists) to resolve ISO country codes to full names at the Titled() call site.

## Summary by Sourcery

Improve SEO metadata for country, category, and language list detail and explorer pages.

New Features:
- Add canonical URLs, meta descriptions, and Open Graph tags to country, category, and language list detail pages.
- Add canonical URLs, meta descriptions, and Open Graph tags to country, category, and language explorer pages.

Enhancements:
- Update page titles on all list detail and explorer pages to be descriptive and brand-consistent.
- Import country name resolution into the main routing module to display full country names in titles.