### PR TITLE
fix: restore full HTML rendering for anonymous /creators and /lists r…

### DIFF
--- a/main.py
+++ b/main.py
@@ -194,6 +194,39 @@ def _list_seo_tags(title: str, desc: str, path: str) -> tuple:
     )
 
 
+# ---------------------------------------------------------------------------
+# Page rendering helper — used when a route must return HTMLResponse directly
+# (e.g. to attach Cache-Control headers) while still producing a complete HTML
+# document that includes the app-level CSS/JS headers (hdrs).
+#
+# Root-cause note: Titled() returns a *tuple* of FT nodes.  FastHTML's internal
+# _resp() assembles these into Html(Head(*hdrs, *head_nodes), Body(*body_nodes))
+# before serialising.  Calling to_xml() on the raw tuple bypasses that step, so
+# the output lacks all CSS and JS from hdrs — non-authenticated users receive a
+# bare HTML fragment with no styles.
+# ---------------------------------------------------------------------------
+_HEAD_ELEM_TYPES = (Title, Meta, Link, Script, Style)
+
+
+def _render_page(ft_response) -> str:
+    """Convert a Titled() result to a complete, standalone HTML page string.
+
+    Replicates what FastHTML's response pipeline does internally so that
+    CDN-cached HTMLResponse objects are structurally identical to responses
+    served through the normal FastHTML path.
+    """
+    if not isinstance(ft_response, tuple):
+        ft_response = (ft_response,)
+    head_items = [x for x in ft_response if isinstance(x, _HEAD_ELEM_TYPES)]
+    body_items = [x for x in ft_response if not isinstance(x, _HEAD_ELEM_TYPES)]
+    return "<!DOCTYPE html>" + to_xml(
+        Html(
+            Head(*hdrs, *head_items),
+            Body(*body_items),
+        )
+    )
+
+
 # ============================================================================
 # Safety Constants
 # ============================================================================
@@ -1292,7 +1325,7 @@ def creators(req, sess):
     )
     if not sess.get("auth") and not is_filtered:
         return HTMLResponse(
-            to_xml(response),
+            _render_page(response),
             headers={
                 "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120",
                 "Vary": "Cookie",
@@ -1436,7 +1469,7 @@ def lists(req, sess):
     # cookie presence, so logged-in users always get a fresh response.
     if not sess.get("auth"):
         return HTMLResponse(
-            to_xml(response),
+            _render_page(response),
             headers={
                 "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
                 "Vary": "Cookie",

--- a/main.py
+++ b/main.py
@@ -205,7 +205,14 @@ def _list_seo_tags(title: str, desc: str, path: str) -> tuple:
 # the output lacks all CSS and JS from hdrs — non-authenticated users receive a
 # bare HTML fragment with no styles.
 # ---------------------------------------------------------------------------
-_HEAD_ELEM_TYPES = (Title, Meta, Link, Script, Style)
+# Tag names that belong in <head>, not <body>.
+# FastHTML elements are all instances of FT (not their own classes), so we
+# identify them by their .tag string rather than with isinstance().
+_HEAD_TAG_NAMES = frozenset({"title", "meta", "link", "script", "style"})
+
+
+def _is_head_elem(x) -> bool:
+    return hasattr(x, "tag") and isinstance(x.tag, str) and x.tag.lower() in _HEAD_TAG_NAMES
 
 
 def _render_page(ft_response) -> str:
@@ -217,8 +224,8 @@ def _render_page(ft_response) -> str:
     """
     if not isinstance(ft_response, tuple):
         ft_response = (ft_response,)
-    head_items = [x for x in ft_response if isinstance(x, _HEAD_ELEM_TYPES)]
-    body_items = [x for x in ft_response if not isinstance(x, _HEAD_ELEM_TYPES)]
+    head_items = [x for x in ft_response if _is_head_elem(x)]
+    body_items = [x for x in ft_response if not _is_head_elem(x)]
     return "<!DOCTYPE html>" + to_xml(
         Html(
             Head(*hdrs, *head_items),

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -107,6 +107,39 @@ class TestPublicEndpoints:
 
 
 # ============================================================
+# Test Class: CDN caching paths produce complete HTML pages
+# ============================================================
+
+
+class TestCachingPaths:
+    """Guard against the HTMLResponse(to_xml(...)) regression.
+
+    Titled() returns a tuple of FT nodes.  FastHTML's response pipeline
+    assembles these into Html(Head(*hdrs, ...), Body(...)) before serialising,
+    which is what injects the app-level CSS/JS.  When a route bypasses the
+    pipeline by calling HTMLResponse(to_xml(response)) directly it must use
+    _render_page() instead of to_xml() — otherwise non-authenticated visitors
+    receive a bare HTML fragment with no stylesheets.
+    """
+
+    def test_creators_anon_returns_complete_html(self, client):
+        """Non-authenticated GET /creators must be a full HTML page, not a fragment."""
+        r = client.get("/creators")
+        assert r.status_code == 200
+        html = r.text.lower()
+        assert "<html" in html, "Response missing <html> — to_xml() fragment path active"
+        assert "stylesheet" in html, "Response missing CSS link — app hdrs not injected"
+
+    def test_lists_anon_returns_complete_html(self, client):
+        """Non-authenticated GET /lists must be a full HTML page, not a fragment."""
+        r = client.get("/lists")
+        assert r.status_code == 200
+        html = r.text.lower()
+        assert "<html" in html, "Response missing <html> — to_xml() fragment path active"
+        assert "stylesheet" in html, "Response missing CSS link — app hdrs not injected"
+
+
+# ============================================================
 # Test Class 2: URL Validation & Preview
 # ============================================================
 


### PR DESCRIPTION
…esponses

HTMLResponse(to_xml(response)) bypassed FastHTML's response pipeline, producing a bare HTML fragment with no <html>, <head>, or stylesheet links from hdrs. Non-authenticated users saw unstyled pages because the CDN-caching path was skipping the Html(Head(*hdrs,...),Body(...)) assembly step that FastHTML normally handles internally.

Add _render_page() helper that replicates FastHTML's page assembly so CDN-cached responses are structurally identical to normally-rendered ones. Fix both caching paths (/creators, /lists) to use _render_page() instead of to_xml(). Add TestCachingPaths regression tests that assert <html> and stylesheet links are present in anonymous responses.

## Summary by Sourcery

Ensure CDN-cached anonymous responses for /creators and /lists are rendered as full HTML pages with app-level headers instead of bare fragments.

Bug Fixes:
- Fix anonymous /creators and /lists responses returning unstyled HTML fragments by restoring full page rendering with app headers.

Enhancements:
- Introduce a shared _render_page helper to assemble complete HTML documents for routes that return HTMLResponse directly.

Tests:
- Add TestCachingPaths regression tests to verify anonymous /creators and /lists return complete HTML pages with <html> and stylesheet links.