### PR TITLE
feat: replace placeholder content and add creator counts to page titles

### DIFF
--- a/components/cards.py
+++ b/components/cards.py
@@ -234,9 +234,9 @@ def _product_switcher() -> Div:
             Span("🇺🇸 United States", style="font-size:0.65rem;color:rgba(255,255,255,0.3);"),
             style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.75rem;",
         ),
-        _creator_row(1, "Creator A", "Entertainment", 9.4),
-        _creator_row(2, "Creator B", "Science", 8.1),
-        _creator_row(3, "Creator C", "Tech", 7.6),
+        _creator_row(1, "MrBeast", "Entertainment", 9.4),
+        _creator_row(2, "Mark Rober", "Science", 8.1),
+        _creator_row(3, "Marques Brownlee", "Tech", 7.6),
         Div(
             UkIcon("trending-up", cls="w-3 h-3"),
             Span("Updated 2h ago"),
@@ -261,7 +261,7 @@ def _product_switcher() -> Div:
 
     creator_panel = Div(
         Div(
-            Div("Creator B", style="font-size:0.85rem;font-weight:700;color:#fff;"),
+            Div("Veritasium", style="font-size:0.85rem;font-weight:700;color:#fff;"),
             Span(
                 "Science & Education",
                 style="font-size:0.6rem;background:rgba(239,68,68,0.15);color:#f87171;border-radius:9999px;padding:0.15rem 0.5rem;",

--- a/constants.py
+++ b/constants.py
@@ -255,26 +255,30 @@ LISTS_FEATURE_TABS = [
 # =============================================================================
 # TESTIMONIALS
 # =============================================================================
+# TODO: Replace these with verified quotes from real users before launch.
 TESTIMONIALS = [
     (
-        "ViralVibes helped me decode my channel's growth patterns. The dashboard is a game changer!",
+        "We cut our creator shortlisting time from two days to under an hour. "
+        "The engagement-rate filtering alone changed how we evaluate campaigns.",
         "Alex Kim",
-        "YouTube Creator",
-        "TechExplained",
+        "Brand Partnerships Lead",
+        "CampaignHQ",
         "/static/testimonials/alex-kim.png",
     ),
     (
-        "The playlist analytics are incredibly detailed and easy to understand. Highly recommended.",
+        "Finally a tool that surfaces ROAS-relevant signals, not just subscriber counts. "
+        "We found three mid-tier creators from the country lists that outperformed our usual picks.",
         "Priya Singh",
-        "Content Strategist",
-        "MediaPulse",
+        "Paid Social Manager",
+        "Outreach Co.",
         "/static/testimonials/priya-singh.png",
     ),
     (
-        "I love how ViralVibes visualizes engagement and controversy. It's a must-have for creators.",
+        "The country and category lists are how I now start every brief. "
+        "233 creators from Germany sorted by engagement \u2014 that\u2019s the first 30 minutes of my old research done instantly.",
         "Jordan Lee",
-        "Growth Hacker",
-        "ViralBoost",
+        "Influencer Marketing Consultant",
+        "IndieAgency",
         "/static/testimonials/jordan-lee.png",
     ),
 ]

--- a/main.py
+++ b/main.py
@@ -194,6 +194,46 @@ def _list_seo_tags(title: str, desc: str, path: str) -> tuple:
     )
 
 
+# ---------------------------------------------------------------------------
+# Page rendering helper — used when a route must return HTMLResponse directly
+# (e.g. to attach Cache-Control headers) while still producing a complete HTML
+# document that includes the app-level CSS/JS headers (hdrs).
+#
+# Root-cause note: Titled() returns a *tuple* of FT nodes.  FastHTML's internal
+# _resp() assembles these into Html(Head(*hdrs, *head_nodes), Body(*body_nodes))
+# before serialising.  Calling to_xml() on the raw tuple bypasses that step, so
+# the output lacks all CSS and JS from hdrs — non-authenticated users receive a
+# bare HTML fragment with no styles.
+# ---------------------------------------------------------------------------
+# Tag names that belong in <head>, not <body>.
+# FastHTML elements are all instances of FT (not their own classes), so we
+# identify them by their .tag string rather than with isinstance().
+_HEAD_TAG_NAMES = frozenset({"title", "meta", "link", "script", "style"})
+
+
+def _is_head_elem(x) -> bool:
+    return hasattr(x, "tag") and isinstance(x.tag, str) and x.tag.lower() in _HEAD_TAG_NAMES
+
+
+def _render_page(ft_response) -> str:
+    """Convert a Titled() result to a complete, standalone HTML page string.
+
+    Replicates what FastHTML's response pipeline does internally so that
+    CDN-cached HTMLResponse objects are structurally identical to responses
+    served through the normal FastHTML path.
+    """
+    if not isinstance(ft_response, tuple):
+        ft_response = (ft_response,)
+    head_items = [x for x in ft_response if _is_head_elem(x)]
+    body_items = [x for x in ft_response if not _is_head_elem(x)]
+    return "<!DOCTYPE html>" + to_xml(
+        Html(
+            Head(*hdrs, *head_items),
+            Body(*body_items),
+        )
+    )
+
+
 # ============================================================================
 # Safety Constants
 # ============================================================================
@@ -1292,7 +1332,7 @@ def creators(req, sess):
     )
     if not sess.get("auth") and not is_filtered:
         return HTMLResponse(
-            to_xml(response),
+            _render_page(response),
             headers={
                 "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120",
                 "Vary": "Cookie",
@@ -1436,7 +1476,7 @@ def lists(req, sess):
     # cookie presence, so logged-in users always get a fresh response.
     if not sess.get("auth"):
         return HTMLResponse(
-            to_xml(response),
+            _render_page(response),
             headers={
                 "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
                 "Vary": "Cookie",
@@ -1468,12 +1508,13 @@ def lists_more_languages(req, sess):
 def lists_country_detail(req, sess, country_code: str):
     """Detailed creator rankings for a specific country."""
     country_name = get_country_name(country_code)
-    _title = f"Top YouTube Creators from {country_name} | ViralVibes"
+    page_content, total_count = country_detail_route(req, country_code)
+    _count_suffix = f" ({total_count:,} channels)" if total_count else ""
+    _title = f"Top YouTube Creators from {country_name}{_count_suffix} | ViralVibes"
     _desc = (
         f"Browse the top YouTube creators from {country_name}, ranked by subscriber count. "
         "Discover channels, engagement rates and contact info."
     )
-    page_content = country_detail_route(req, country_code)
     return Titled(
         _title,
         Container(
@@ -1553,12 +1594,13 @@ def lists_languages_explorer(req, sess):
 def lists_category_detail(req, sess, category_slug: str):
     """Detailed creator rankings for a specific topic category."""
     display_name = resolve_category_slug(category_slug) or _unslugify(category_slug).title()
-    _title = f"Top {display_name} YouTube Channels | ViralVibes"
+    page_content, total_count = category_detail_route(req, category_slug)
+    _count_suffix = f" ({total_count:,} channels)" if total_count else ""
+    _title = f"Top {display_name} YouTube Channels{_count_suffix} | ViralVibes"
     _desc = (
         f"Browse the top {display_name} YouTube creators, ranked by subscriber count. "
         "Discover channels, engagement rates and contact info."
     )
-    page_content = category_detail_route(req, category_slug)
     return Titled(
         _title,
         Container(

--- a/routes/lists.py
+++ b/routes/lists.py
@@ -315,7 +315,7 @@ def country_detail_route(request, country_code: str):
 
     creators, total_count, total_pages = _fetch_country_page(country_code, page)
 
-    return render_country_detail_page(
+    page_content = render_country_detail_page(
         country_code=country_code,
         creators=creators,
         page=page,
@@ -323,6 +323,7 @@ def country_detail_route(request, country_code: str):
         total_count=total_count,
         page_size=DETAIL_PAGE_LIMIT,
     )
+    return page_content, total_count
 
 
 def country_detail_more_route(request):
@@ -417,7 +418,7 @@ def category_detail_route(request, category_slug: str):
 
     creators, total_count, total_pages, category_name = _fetch_category_page(category_slug, page)
 
-    return render_category_detail_page(
+    page_content = render_category_detail_page(
         category_slug=category_slug,
         category_name=category_name,
         creators=creators,
@@ -426,6 +427,7 @@ def category_detail_route(request, category_slug: str):
         total_count=total_count,
         page_size=DETAIL_PAGE_LIMIT,
     )
+    return page_content, total_count
 
 
 def category_detail_more_route(request):

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -107,6 +107,90 @@ class TestPublicEndpoints:
 
 
 # ============================================================
+# Test Class: CDN caching paths produce complete HTML pages
+# ============================================================
+
+
+class TestCachingPaths:
+    """Guard against the HTMLResponse(to_xml(...)) regression.
+
+    Titled() returns a tuple of FT nodes.  FastHTML's response pipeline
+    assembles these into Html(Head(*hdrs, ...), Body(...)) before serialising,
+    which is what injects the app-level CSS/JS.  When a route bypasses the
+    pipeline by calling HTMLResponse(to_xml(response)) directly it must use
+    _render_page() instead of to_xml() — otherwise non-authenticated visitors
+    receive a bare HTML fragment with no stylesheets.
+    """
+
+    def test_creators_anon_returns_complete_html(self, client):
+        """Non-authenticated GET /creators must be a full HTML page, not a fragment."""
+        r = client.get("/creators")
+        assert r.status_code == 200
+        html = r.text.lower()
+        assert "<html" in html, "Response missing <html> — to_xml() fragment path active"
+        assert "stylesheet" in html, "Response missing CSS link — app hdrs not injected"
+
+    def test_lists_anon_returns_complete_html(self, client):
+        """Non-authenticated GET /lists must be a full HTML page, not a fragment."""
+        r = client.get("/lists")
+        assert r.status_code == 200
+        html = r.text.lower()
+        assert "<html" in html, "Response missing <html> — to_xml() fragment path active"
+        assert "stylesheet" in html, "Response missing CSS link — app hdrs not injected"
+
+
+# ============================================================
+# Test Class: Country/category detail page title count suffix
+# ============================================================
+
+
+class TestListPageTitleCounts:
+    """Guard the conditional count-suffix in country and category detail titles.
+
+    The route handlers inject ' (N,NNN channels)' into the <title> when the
+    DB returns a non-zero creator count, and omit it entirely when the count
+    is zero.  These tests monkeypatch the route functions to control the
+    returned count without hitting the database.
+    """
+
+    def test_country_title_includes_count_when_nonzero(self, client, monkeypatch):
+        """Title must contain the comma-formatted count when route returns > 0."""
+        monkeypatch.setattr(main, "country_detail_route", lambda req, code: ("", 233))
+        r = client.get("/lists/country/LT")
+        assert r.status_code == 200
+        assert "233" in r.text
+        assert "Lithuania" in r.text
+
+    def test_country_title_omits_suffix_when_count_zero(self, client, monkeypatch):
+        """Title must NOT include '(0 channels)' when route returns 0."""
+        monkeypatch.setattr(main, "country_detail_route", lambda req, code: ("", 0))
+        r = client.get("/lists/country/LT")
+        assert r.status_code == 200
+        assert "(0 channels)" not in r.text
+
+    def test_country_title_formats_count_with_commas(self, client, monkeypatch):
+        """Thousands separator must be applied — 4821 renders as '4,821'."""
+        monkeypatch.setattr(main, "country_detail_route", lambda req, code: ("", 4821))
+        r = client.get("/lists/country/US")
+        assert r.status_code == 200
+        assert "4,821" in r.text
+
+    def test_category_title_includes_count_when_nonzero(self, client, monkeypatch):
+        """Category title must contain count suffix when route returns > 0."""
+        monkeypatch.setattr(main, "category_detail_route", lambda req, slug: ("", 1500))
+        r = client.get("/lists/category/gaming")
+        assert r.status_code == 200
+        assert "1,500" in r.text
+
+    def test_category_title_omits_suffix_when_count_zero(self, client, monkeypatch):
+        """Category title must NOT include '(0 channels)' when route returns 0."""
+        monkeypatch.setattr(main, "category_detail_route", lambda req, slug: ("", 0))
+        r = client.get("/lists/category/gaming")
+        assert r.status_code == 200
+        assert "(0 channels)" not in r.text
+
+
+# ============================================================
 # Test Class 2: URL Validation & Preview
 # ============================================================
 

--- a/tests/test_lists_category_endpoints.py
+++ b/tests/test_lists_category_endpoints.py
@@ -203,6 +203,36 @@ def test_category_detail_route_renders_with_slug_resolution(monkeypatch):
     assert total_count == 21
 
 
+def test_country_detail_route_returns_tuple(monkeypatch):
+    """country_detail_route must return (page_content, total_count).
+
+    Mirrors test_category_detail_route_renders_with_slug_resolution to
+    confirm both detail routes share the same tuple-return contract.
+    """
+    monkeypatch.setattr(
+        lists_routes,
+        "_fetch_country_page",
+        lambda code, page: ([{"channel_name": "A"}], 47, 2),
+    )
+
+    captured = {}
+
+    def _render(**kwargs):
+        captured.update(kwargs)
+        return captured
+
+    monkeypatch.setattr(lists_routes, "render_country_detail_page", _render)
+
+    page_content, total_count = lists_routes.country_detail_route(
+        _req(query_params={"page": "1"}), "LT"
+    )
+
+    assert page_content["country_code"] == "LT"
+    assert page_content["total_count"] == 47
+    assert page_content["total_pages"] == 2
+    assert total_count == 47
+
+
 def test_category_detail_more_route_requires_slug(monkeypatch):
     monkeypatch.setattr(lists_routes, "Div", lambda text, cls=None: {"text": text, "cls": cls})
 

--- a/tests/test_lists_category_endpoints.py
+++ b/tests/test_lists_category_endpoints.py
@@ -192,14 +192,15 @@ def test_category_detail_route_renders_with_slug_resolution(monkeypatch):
 
     monkeypatch.setattr(lists_routes, "render_category_detail_page", _render)
 
-    out = lists_routes.category_detail_route(
+    page_content, total_count = lists_routes.category_detail_route(
         _req(query_params={"page": "1"}), "lifestyle-sociology"
     )
 
-    assert out["category_slug"] == "lifestyle-sociology"
-    assert out["category_name"] == "Lifestyle (sociology)"
-    assert out["total_count"] == 21
-    assert out["total_pages"] == 2
+    assert page_content["category_slug"] == "lifestyle-sociology"
+    assert page_content["category_name"] == "Lifestyle (sociology)"
+    assert page_content["total_count"] == 21
+    assert page_content["total_pages"] == 2
+    assert total_count == 21
 
 
 def test_category_detail_more_route_requires_slug(monkeypatch):


### PR DESCRIPTION
- components/cards.py: replace "Creator A/B/C" hero mockup names with real YouTubers (MrBeast, Mark Rober, Marques Brownlee, Veritasium)

- constants.py: rewrite testimonials to target brand/agency audience; reference engagement filtering, country lists, and ROAS signals; update roles to Brand Partnerships Lead, Paid Social Manager, Influencer Marketing Consultant; add TODO to replace with real quotes

- routes/lists.py: country_detail_route and category_detail_route now return (page_content, total_count) instead of just the FT component

- main.py: unpack count from both route functions and interpolate into title tags — "Top YouTube Creators from Lithuania (233 channels)" — suffix omitted when count is zero or unavailable

- tests/test_lists_category_endpoints.py: update assertion to unpack tuple return and verify total_count == 21

## Summary by Sourcery

Update list detail pages to expose creator counts for use in SEO titles, refresh testimonial and card copy to use realistic creator/brand examples, and fix HTML rendering for cached list pages so they include full app styling.

New Features:
- Include creator total counts in country and category list page titles when available.

Enhancements:
- Return both rendered content and total creator count from country and category detail routes for easier reuse.
- Replace placeholder homepage card names with well-known YouTube creators.
- Retarget testimonial copy toward brand and agency users with engagement, country list, and ROAS-focused messaging.
- Introduce a helper to render FastHTML Titled responses into full HTML documents so CDN-cached pages include CSS/JS headers.

Tests:
- Adjust category detail route tests to account for the new (page_content, total_count) return signature and separately assert the total count value.