### PR TITLE
feat: implement category/country ranking pages and associated functio…

### DIFF
--- a/components/seo.py
+++ b/components/seo.py
@@ -27,6 +27,7 @@ __all__ = [
     "BreadcrumbList",
     "ItemListJsonLd",
     "MetaDescription",
+    "page_seo_tags",
 ]
 
 
@@ -162,3 +163,22 @@ def ItemListJsonLd(
 def MetaDescription(description: str) -> Meta:
     """Standard ``<meta name="description">``."""
     return Meta(name="description", content=description)
+
+
+def page_seo_tags(title: str, description: str, path: str) -> tuple:
+    """Return the standard (Canonical, MetaDescription, OgTags) bundle for a page.
+
+    Splat into ``Titled()`` so every route that needs SEO head tags calls one
+    function instead of repeating the three-item pattern::
+
+        return Titled(
+            _title,
+            Container(...),
+            *page_seo_tags(_title, _desc, "/my-page"),
+        )
+    """
+    return (
+        Canonical(path),
+        MetaDescription(description),
+        *OgTags(title=title, description=description, path=path),
+    )

--- a/db_lists.py
+++ b/db_lists.py
@@ -392,6 +392,59 @@ def get_topic_category_creators(
     return creators
 
 
+def get_topic_category_country_creators(
+    category: str,
+    country_code: str,
+    *,
+    limit: int = 20,
+    offset: int = 0,
+    return_count: bool = False,
+) -> list[dict] | TopicCategoryPageResult:
+    """Paginated creator listing for a topic category within one country."""
+    if not category or not str(category).strip() or not country_code:
+        return TopicCategoryPageResult([], 0) if return_count else []
+
+    supabase_client = _get_supabase_client()
+    if not supabase_client:
+        return TopicCategoryPageResult([], 0) if return_count else []
+
+    category_label = _topic_category_label(category)
+    normalized_country = str(country_code or "").strip().upper()
+    if not category_label or len(normalized_country) != 2:
+        return TopicCategoryPageResult([], 0) if return_count else []
+
+    try:
+        query = supabase_client.table("creators").select(
+            "*", count="exact" if return_count else None
+        )
+        query = _apply_topic_category_text_filters(query, category_label)
+        query = (
+            query.eq("country_code", normalized_country)
+            .order("current_subscribers", desc=True)
+            .limit(limit)
+        )
+        if offset:
+            query = query.offset(offset)
+        response = query.execute()
+    except Exception:
+        logger.exception(
+            "Error fetching topic category creators for %r in %s",
+            category_label,
+            normalized_country,
+        )
+        return TopicCategoryPageResult([], 0) if return_count else []
+
+    creators = response.data if response and response.data else []
+    total_count = (getattr(response, "count", 0) or 0) if return_count and response else 0
+
+    for idx, creator in enumerate(creators, 1):
+        creator["_rank"] = offset + idx
+
+    if return_count:
+        return TopicCategoryPageResult(creators, total_count)
+    return creators
+
+
 # ---------------------------------------------------------------------------
 # Transient-transport retry for Supabase RPC calls
 # ---------------------------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -156,6 +156,7 @@ from routes.stripe_checkout import (
 )
 from services.plan_gate import gate_plan
 from services.sitemap import build_sitemap_xml, fetch_aplus_creators, fetch_synced_creators
+from services.rankings import ranking_path, resolve_country_slug, resolve_ranking_category_slug
 from routes.lists import (
     categories_explorer_route,
     countries_explorer_route,
@@ -170,6 +171,8 @@ from routes.lists import (
     lists_more_countries_route,
     lists_more_languages_route,
     lists_route,
+    ranking_detail_more_route,
+    ranking_detail_route,
 )
 from routes.outreach import outreach_export_route, outreach_import_list_route, outreach_route
 from routes.admin import (
@@ -1574,6 +1577,47 @@ def lists_category_more(req, sess, category_slug: str):
     """HTMX partial — load more creators for a specific category."""
     req.category_slug = category_slug.lower()
     return category_detail_more_route(req)
+
+
+@rt("/rankings/{category_slug}/{country_slug}")
+def rankings_category_country(req, sess, category_slug: str, country_slug: str):
+    """Public SEO landing page for a category/country creator ranking."""
+    display_name = (
+        resolve_ranking_category_slug(category_slug)
+        or resolve_category_slug(category_slug)
+        or _unslugify(category_slug).title()
+    )
+    country_code = resolve_country_slug(country_slug)
+    country_name = (
+        get_country_name(country_code) if country_code else _unslugify(country_slug).title()
+    )
+    canonical_path = (
+        ranking_path(display_name, country_code)
+        if country_code
+        else f"/rankings/{category_slug.lower()}/{country_slug.lower()}"
+    )
+    _title = f"Top {display_name} YouTube Creators in {country_name} | ViralVibes"
+    _desc = (
+        f"Find top {display_name} YouTube creators in {country_name}, ranked by subscriber count. "
+        "Compare channels, engagement signals and creator stats for outreach."
+    )
+    page_content = ranking_detail_route(req, category_slug, country_slug)
+    return Titled(
+        _title,
+        Container(
+            NavComponent(oauth, req, sess),
+            page_content,
+        ),
+        *_list_seo_tags(_title, _desc, canonical_path),
+    )
+
+
+@rt("/rankings/{category_slug}/{country_slug}/more")
+def rankings_category_country_more(req, sess, category_slug: str, country_slug: str):
+    """HTMX partial — load more creators for a category/country ranking."""
+    req.category_slug = category_slug.lower()
+    req.country_slug = country_slug.lower()
+    return ranking_detail_more_route(req)
 
 
 @rt("/lists/language/{language_code}")

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ from components import (
     how_it_works_section,
 )
 from components.modals import ExportModal, ShareModal
-from components.seo import Canonical, JsonLd, MetaDescription, OgTags
+from components.seo import Canonical, JsonLd, MetaDescription, OgTags, page_seo_tags
 from constants import (
     CONTACT_EMAIL,
     JobStatus,
@@ -188,12 +188,42 @@ from views.lists import _unslugify
 logger = logging.getLogger(__name__)
 
 
-def _list_seo_tags(title: str, desc: str, path: str) -> tuple:
-    """Return (Canonical, MetaDescription, *OgTags) head tags for list detail pages."""
-    return (
-        Canonical(path),
-        MetaDescription(desc),
-        *OgTags(title=title, description=desc, path=path),
+# ---------------------------------------------------------------------------
+# Page rendering helper — used when a route must return an HTMLResponse
+# (e.g. to attach Cache-Control headers) while still producing a complete page
+# that includes the app-level CSS/JS from hdrs.
+#
+# Root-cause: Titled() returns a *tuple* of FT nodes. FastHTML's internal
+# _resp() assembles Html(Head(*hdrs, *head_nodes), Body(*body_nodes)) before
+# serialising. Calling to_xml() directly on the raw tuple skips that step,
+# so the output is a bare fragment with no CSS or JS.
+#
+# FastHTML elements are factory functions, NOT classes — use .tag string,
+# never isinstance(x, Title).
+# ---------------------------------------------------------------------------
+_HEAD_TAG_NAMES = frozenset({"title", "meta", "link", "script", "style"})
+
+
+def _is_head_elem(x) -> bool:
+    return hasattr(x, "tag") and isinstance(x.tag, str) and x.tag.lower() in _HEAD_TAG_NAMES
+
+
+def _render_page(ft_response) -> str:
+    """Assemble a complete HTML page from a Titled() result.
+
+    Replicates FastHTML's response pipeline so that HTMLResponse objects
+    produced for CDN caching are structurally identical to pages served
+    through the normal FastHTML path.
+    """
+    if not isinstance(ft_response, tuple):
+        ft_response = (ft_response,)
+    head_items = [x for x in ft_response if _is_head_elem(x)]
+    body_items = [x for x in ft_response if not _is_head_elem(x)]
+    return "<!DOCTYPE html>" + to_xml(
+        Html(
+            Head(*hdrs, *head_items),
+            Body(*body_items),
+        )
     )
 
 
@@ -1247,9 +1277,7 @@ def analysis(req, sess):
             analysis_page_content(user_id=user_id),
             cls=ContainerT.xl,
         ),
-        Canonical("/analysis"),
-        MetaDescription(_analysis_desc),
-        *OgTags(title=_analysis_title, description=_analysis_desc, path="/analysis"),
+        *page_seo_tags(_analysis_title, _analysis_desc, "/analysis"),
     )
 
 
@@ -1280,9 +1308,7 @@ def creators(req, sess):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        Canonical("/creators"),
-        MetaDescription(_creators_desc),
-        *OgTags(title=_creators_title, description=_creators_desc, path="/creators"),
+        *page_seo_tags(_creators_title, _creators_desc, "/creators"),
     )
 
     # Cache at the CDN edge for logged-out visitors (no search query) only.
@@ -1295,7 +1321,7 @@ def creators(req, sess):
     )
     if not sess.get("auth") and not is_filtered:
         return HTMLResponse(
-            to_xml(response),
+            _render_page(response),
             headers={
                 "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120",
                 "Vary": "Cookie",
@@ -1429,9 +1455,7 @@ def lists(req, sess):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        Canonical("/lists"),
-        MetaDescription(_lists_desc),
-        *OgTags(title=_lists_title, description=_lists_desc, path="/lists"),
+        *page_seo_tags(_lists_title, _lists_desc, "/lists"),
     )
 
     # Cache at the CDN edge for logged-out visitors only.
@@ -1439,7 +1463,7 @@ def lists(req, sess):
     # cookie presence, so logged-in users always get a fresh response.
     if not sess.get("auth"):
         return HTMLResponse(
-            to_xml(response),
+            _render_page(response),
             headers={
                 "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
                 "Vary": "Cookie",
@@ -1483,7 +1507,7 @@ def lists_country_detail(req, sess, country_code: str):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        *_list_seo_tags(_title, _desc, f"/lists/country/{country_code.lower()}"),
+        *page_seo_tags(_title, _desc, f"/lists/country/{country_code.lower()}"),
     )
 
 
@@ -1510,7 +1534,7 @@ def lists_categories_explorer(req, sess):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        *_list_seo_tags(_title, _desc, "/lists/categories"),
+        *page_seo_tags(_title, _desc, "/lists/categories"),
     )
 
 
@@ -1529,7 +1553,7 @@ def lists_countries_explorer(req, sess):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        *_list_seo_tags(_title, _desc, "/lists/countries"),
+        *page_seo_tags(_title, _desc, "/lists/countries"),
     )
 
 
@@ -1548,7 +1572,7 @@ def lists_languages_explorer(req, sess):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        *_list_seo_tags(_title, _desc, "/lists/languages"),
+        *page_seo_tags(_title, _desc, "/lists/languages"),
     )
 
 
@@ -1568,7 +1592,7 @@ def lists_category_detail(req, sess, category_slug: str):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        *_list_seo_tags(_title, _desc, f"/lists/category/{category_slug}"),
+        *page_seo_tags(_title, _desc, f"/lists/category/{category_slug}"),
     )
 
 
@@ -1608,7 +1632,7 @@ def rankings_category_country(req, sess, category_slug: str, country_slug: str):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        *_list_seo_tags(_title, _desc, canonical_path),
+        *page_seo_tags(_title, _desc, canonical_path),
     )
 
 
@@ -1636,7 +1660,7 @@ def lists_language_detail(req, sess, language_code: str):
             NavComponent(oauth, req, sess),
             page_content,
         ),
-        *_list_seo_tags(_title, _desc, f"/lists/language/{language_code.lower()}"),
+        *page_seo_tags(_title, _desc, f"/lists/language/{language_code.lower()}"),
     )
 
 
@@ -1706,7 +1730,7 @@ def creator_profile(req, sess, creator_id: str):
                     ),
                 ),
             )
-            return HTMLResponse(to_xml(page), status_code=404)
+            return HTMLResponse(_render_page(page), status_code=404)
         canonical_id = creator["id"]
         return RedirectResponse(f"/creator/{canonical_id}", status_code=301)
     result = creator_profile_route(req, creator_id, user_id=sess.get("user_id") if sess else None)

--- a/routes/lists.py
+++ b/routes/lists.py
@@ -21,6 +21,7 @@ from db_lists import (
     get_top_categories_with_counts,
     get_top_countries_with_counts,
     get_top_languages_with_counts,
+    get_topic_category_country_creators,
     get_top_rated_creators,
     get_topic_category_creators,
     get_veteran_creators,
@@ -41,8 +42,11 @@ from views.lists import (
     render_category_creators_rows,
     render_language_detail_page,
     render_language_creators_rows,
+    render_ranking_detail_page,
+    render_ranking_creators_rows,
     _unslugify,
 )
+from services.rankings import resolve_country_slug, resolve_ranking_category_slug
 
 logger = logging.getLogger(__name__)
 
@@ -395,6 +399,93 @@ def _fetch_category_page(category_slug: str, page: int) -> tuple[list, int, int,
         (total_count + DETAIL_PAGE_LIMIT - 1) // DETAIL_PAGE_LIMIT if total_count > 0 else 1
     )
     return creators, total_count, total_pages, category_name
+
+
+def _fetch_ranking_page(
+    category_slug: str,
+    country_slug: str,
+    page: int,
+) -> tuple[list, int, int, str, str | None]:
+    """Fetch creators for a public category/country ranking landing page."""
+    decoded_slug = unquote(category_slug)
+    category_name = (
+        resolve_ranking_category_slug(decoded_slug)
+        or resolve_category_slug(decoded_slug)
+        or _unslugify(decoded_slug)
+    )
+    country_code = resolve_country_slug(country_slug)
+    if not country_code:
+        return [], 0, 1, category_name, None
+
+    result = get_topic_category_country_creators(
+        category_name,
+        country_code,
+        limit=DETAIL_PAGE_LIMIT,
+        offset=(page - 1) * DETAIL_PAGE_LIMIT,
+        return_count=True,
+    )
+    creators = result.creators if result else []
+    total_count = result.total_count if result else 0
+    total_pages = (
+        (total_count + DETAIL_PAGE_LIMIT - 1) // DETAIL_PAGE_LIMIT if total_count > 0 else 1
+    )
+    return creators, total_count, total_pages, category_name, country_code
+
+
+def ranking_detail_route(request, category_slug: str, country_slug: str):
+    """GET /rankings/{category}/{country} — SEO category/country ranking page."""
+    category_slug = category_slug.lower()
+    country_slug = country_slug.lower()
+    page = _parse_page(request)
+
+    creators, total_count, total_pages, category_name, country_code = _fetch_ranking_page(
+        category_slug,
+        country_slug,
+        page,
+    )
+
+    return render_ranking_detail_page(
+        category_slug=category_slug,
+        country_slug=country_slug,
+        category_name=category_name,
+        country_code=country_code,
+        creators=creators,
+        page=page,
+        total_pages=total_pages,
+        total_count=total_count,
+        page_size=DETAIL_PAGE_LIMIT,
+    )
+
+
+def ranking_detail_more_route(request):
+    """GET /rankings/{category}/{country}/more?page=N — HTMX creator rows."""
+    category_slug = getattr(request, "category_slug", "")
+    country_slug = getattr(request, "country_slug", "")
+    category_slug = category_slug.lower() if category_slug else ""
+    country_slug = country_slug.lower() if country_slug else ""
+
+    if not category_slug or not country_slug:
+        logger.warning("Missing category_slug/country_slug for ranking_detail_more_route")
+        return Div("Error: Invalid ranking", cls="text-red-500")
+
+    page = _parse_page(request)
+    creators, total_count, total_pages, category_name, country_code = _fetch_ranking_page(
+        category_slug,
+        country_slug,
+        page,
+    )
+
+    return render_ranking_creators_rows(
+        category_slug=category_slug,
+        country_slug=country_slug,
+        category_name=category_name,
+        country_code=country_code,
+        creators=creators,
+        page=page,
+        total_pages=total_pages,
+        total_count=total_count,
+        page_size=DETAIL_PAGE_LIMIT,
+    )
 
 
 def category_detail_route(request, category_slug: str):

--- a/services/rankings.py
+++ b/services/rankings.py
@@ -1,0 +1,132 @@
+"""Helpers for public programmatic ranking landing pages."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import pycountry
+
+from utils import slugify
+
+_CATEGORY_SLUG_ALIASES: dict[str, str] = {
+    "gaming": "Video game culture",
+    "games": "Video game culture",
+    "video-games": "Video game culture",
+    "lifestyle": "Lifestyle (sociology)",
+    "fitness": "Physical fitness",
+    "tech": "Technology",
+    "sports": "Sports game",
+}
+
+_CATEGORY_PUBLIC_SLUGS: dict[str, str] = {
+    "Video game culture": "gaming",
+    "Lifestyle (sociology)": "lifestyle",
+    "Physical fitness": "fitness",
+    "Technology": "technology",
+    "Sports game": "sports",
+}
+
+# Start with high-intent, broad niches that map to the existing YouTube topic
+# taxonomy. The route supports more combinations; the sitemap should stay
+# selective until live DB counts prove long-tail pages are non-empty.
+RANKING_SITEMAP_CATEGORIES: tuple[str, ...] = (
+    "Video game culture",
+    "Music",
+    "Entertainment",
+    "Technology",
+    "Fashion",
+    "Food",
+    "Physical fitness",
+    "Business",
+    "Sports game",
+    "Lifestyle (sociology)",
+)
+
+RANKING_SITEMAP_COUNTRY_CODES: tuple[str, ...] = (
+    "US",
+    "GB",
+    "CA",
+    "AU",
+    "IN",
+    "JP",
+    "KR",
+    "BR",
+    "MX",
+    "DE",
+    "FR",
+    "ES",
+)
+
+_COUNTRY_SLUG_ALIASES: dict[str, str] = {
+    "usa": "US",
+    "u-s": "US",
+    "united-states": "US",
+    "united-states-of-america": "US",
+    "uk": "GB",
+    "u-k": "GB",
+    "great-britain": "GB",
+    "united-kingdom": "GB",
+    "south-korea": "KR",
+    "korea-republic-of": "KR",
+    "russia": "RU",
+    "vietnam": "VN",
+}
+
+
+def resolve_ranking_category_slug(slug: str) -> str | None:
+    """Resolve an SEO-friendly ranking category slug to a canonical topic label."""
+    return _CATEGORY_SLUG_ALIASES.get(slugify(str(slug or "")))
+
+
+def ranking_category_slug(category_name: str) -> str:
+    """Return the public ranking slug for a canonical topic category label."""
+    return _CATEGORY_PUBLIC_SLUGS.get(str(category_name or ""), slugify(category_name))
+
+
+def country_slug(country_code: str) -> str:
+    """Return the canonical public URL slug for an ISO alpha-2 country code."""
+    country = pycountry.countries.get(alpha_2=str(country_code or "").upper())
+    if not country:
+        return slugify(str(country_code or ""))
+    display = getattr(country, "common_name", country.name)
+    return slugify(display)
+
+
+@lru_cache(maxsize=1)
+def _country_slug_map() -> dict[str, str]:
+    """Return a slug-to-alpha2 lookup for pycountry names plus common aliases."""
+    mapping = dict(_COUNTRY_SLUG_ALIASES)
+    for country in pycountry.countries:
+        code = country.alpha_2.upper()
+        for attr in ("name", "common_name", "official_name"):
+            value = getattr(country, attr, None)
+            if value:
+                mapping.setdefault(slugify(value), code)
+        mapping.setdefault(code.lower(), code)
+    return mapping
+
+
+def resolve_country_slug(slug: str) -> str | None:
+    """Resolve a public country slug or alpha-2 code to uppercase alpha-2."""
+    raw = str(slug or "").strip()
+    if not raw:
+        return None
+    if len(raw) == 2:
+        country = pycountry.countries.get(alpha_2=raw.upper())
+        if country:
+            return country.alpha_2.upper()
+    return _country_slug_map().get(slugify(raw))
+
+
+def ranking_path(category_name: str, country_code: str) -> str:
+    """Return the canonical ranking path for a category/country pair."""
+    return f"/rankings/{ranking_category_slug(category_name)}/{country_slug(country_code)}"
+
+
+def iter_ranking_sitemap_paths() -> list[str]:
+    """Return the bounded set of programmatic ranking URLs for the sitemap."""
+    return [
+        ranking_path(category, country_code)
+        for category in RANKING_SITEMAP_CATEGORIES
+        for country_code in RANKING_SITEMAP_COUNTRY_CODES
+    ]

--- a/services/sitemap.py
+++ b/services/sitemap.py
@@ -13,6 +13,7 @@ from urllib.parse import urljoin
 from xml.dom import minidom
 
 from constants import SITE_BASE_URL
+from services.rankings import iter_ranking_sitemap_paths
 
 BASE_URL = SITE_BASE_URL
 
@@ -116,6 +117,13 @@ def build_sitemap_xml(
         ET.SubElement(url_el, "lastmod").text = today
         ET.SubElement(url_el, "changefreq").text = changefreq
         ET.SubElement(url_el, "priority").text = priority
+
+    for path in iter_ranking_sitemap_paths():
+        url_el = ET.SubElement(urlset, "url")
+        ET.SubElement(url_el, "loc").text = urljoin(BASE_URL, path)
+        ET.SubElement(url_el, "lastmod").text = today
+        ET.SubElement(url_el, "changefreq").text = "weekly"
+        ET.SubElement(url_el, "priority").text = "0.7"
 
     for creator in creators:
         creator_id = creator.get("id")

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -19,6 +19,16 @@ sys.modules.setdefault("monsterui.all", monsterui_all)
 db_stub = types.ModuleType("db")
 db_stub.get_creators = lambda *args, **kwargs: None
 db_stub.get_user_favourite_list_keys = lambda *args, **kwargs: frozenset()
+db_stub.get_latest_playlist_job = lambda *args, **kwargs: None
+db_stub.get_or_create_creator_from_playlist = lambda *args, **kwargs: None
+db_stub.init_supabase = lambda *args, **kwargs: None
+db_stub.setup_logging = lambda *args, **kwargs: None
+db_stub.supabase_client = None
+db_stub.upsert_playlist_stats = lambda *args, **kwargs: None
+db_stub.get_cached_playlist_stats = lambda *args, **kwargs: None
+db_stub.get_dashboard_event_counts = lambda *args, **kwargs: {}
+db_stub.record_dashboard_event = lambda *args, **kwargs: None
+db_stub.PLAYLIST_STATS_TABLE = "playlist_stats"
 sys.modules.setdefault("db", db_stub)
 
 views_lists_stub = types.ModuleType("views.lists")
@@ -36,6 +46,8 @@ for _name in [
     "render_category_creators_rows",
     "render_language_detail_page",
     "render_language_creators_rows",
+    "render_ranking_detail_page",
+    "render_ranking_creators_rows",
 ]:
     setattr(views_lists_stub, _name, lambda *args, **kwargs: None)
 views_lists_stub._unslugify = lambda slug: slug.replace("-", " ").title()
@@ -260,6 +272,30 @@ def test_get_topic_category_creators_applies_offset_to_rank(monkeypatch):
     assert result.creators[1]["_rank"] == 12
 
 
+def test_get_topic_category_country_creators_filters_country_and_category(monkeypatch):
+    fake_client = _FakeSupabaseClient(
+        {
+            "data": [{"channel_name": "US Gaming", "current_subscribers": 100}],
+            "count": 1,
+        }
+    )
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+
+    result = db_lists.get_topic_category_country_creators(
+        "Video game culture",
+        "us",
+        limit=10,
+        return_count=True,
+    )
+
+    assert result.total_count == 1
+    assert result.creators[0]["_rank"] == 1
+    call = fake_client.calls[0]
+    assert call["ilike"][0] == "topic_categories"
+    assert ("country_code", "US") in call["eq"]
+    assert call["order"]["args"] == ("current_subscribers",)
+
+
 def test_fetch_category_page_uses_topic_categories_not_primary_category(monkeypatch):
     page_result = db_lists.TopicCategoryPageResult(
         creators=[{"channel_name": "Test Channel", "current_subscribers": 1000}],
@@ -282,5 +318,41 @@ def test_fetch_category_page_uses_topic_categories_not_primary_category(monkeypa
         "Lifestyle (sociology)",
         limit=20,
         offset=0,
+        return_count=True,
+    )
+
+
+def test_fetch_ranking_page_uses_topic_category_country_query(monkeypatch):
+    page_result = db_lists.TopicCategoryPageResult(
+        creators=[{"channel_name": "Gaming Channel", "current_subscribers": 1000}],
+        total_count=41,
+    )
+
+    monkeypatch.setattr(
+        lists_routes,
+        "resolve_ranking_category_slug",
+        lambda slug: "Video game culture" if slug == "gaming" else None,
+    )
+    mock_get = MagicMock(return_value=page_result)
+    monkeypatch.setattr(lists_routes, "get_topic_category_country_creators", mock_get)
+
+    creators, total_count, total_pages, category_name, country_code = (
+        lists_routes._fetch_ranking_page(
+            "gaming",
+            "united-states",
+            page=2,
+        )
+    )
+
+    assert category_name == "Video game culture"
+    assert country_code == "US"
+    assert total_count == 41
+    assert total_pages == 3
+    assert creators[0]["channel_name"] == "Gaming Channel"
+    mock_get.assert_called_once_with(
+        "Video game culture",
+        "US",
+        limit=20,
+        offset=20,
         return_count=True,
     )

--- a/tests/test_lists_category_endpoints.py
+++ b/tests/test_lists_category_endpoints.py
@@ -19,6 +19,16 @@ sys.modules.setdefault("monsterui.all", monsterui_all)
 db_stub = types.ModuleType("db")
 db_stub.get_creators = lambda *args, **kwargs: None
 db_stub.get_user_favourite_list_keys = lambda *args, **kwargs: frozenset()
+db_stub.get_latest_playlist_job = lambda *args, **kwargs: None
+db_stub.get_or_create_creator_from_playlist = lambda *args, **kwargs: None
+db_stub.init_supabase = lambda *args, **kwargs: None
+db_stub.setup_logging = lambda *args, **kwargs: None
+db_stub.supabase_client = None
+db_stub.upsert_playlist_stats = lambda *args, **kwargs: None
+db_stub.get_cached_playlist_stats = lambda *args, **kwargs: None
+db_stub.get_dashboard_event_counts = lambda *args, **kwargs: {}
+db_stub.record_dashboard_event = lambda *args, **kwargs: None
+db_stub.PLAYLIST_STATS_TABLE = "playlist_stats"
 sys.modules.setdefault("db", db_stub)
 
 views_lists_stub = types.ModuleType("views.lists")
@@ -36,6 +46,8 @@ for _name in [
     "render_category_creators_rows",
     "render_language_detail_page",
     "render_language_creators_rows",
+    "render_ranking_detail_page",
+    "render_ranking_creators_rows",
 ]:
     setattr(views_lists_stub, _name, lambda *args, **kwargs: None)
 views_lists_stub._unslugify = lambda slug: slug.replace("-", " ").title()
@@ -53,6 +65,13 @@ def _req(*, query_params=None, session=None, category_slug=None):
     )
     if category_slug is not None:
         req.category_slug = category_slug
+    return req
+
+
+def _ranking_req(*, query_params=None, session=None, category_slug=None, country_slug=None):
+    req = _req(query_params=query_params, session=session, category_slug=category_slug)
+    if country_slug is not None:
+        req.country_slug = country_slug
     return req
 
 
@@ -231,5 +250,85 @@ def test_category_detail_more_route_happy_path(monkeypatch):
 
     assert out["category_slug"] == "lifestyle-sociology"
     assert out["category_name"] == "Lifestyle (sociology)"
+    assert out["page"] == 1
+    assert out["total_pages"] == 2
+
+
+def test_ranking_detail_route_renders_category_country_page(monkeypatch):
+    monkeypatch.setattr(
+        lists_routes,
+        "_fetch_ranking_page",
+        lambda category_slug, country_slug, page: (
+            [{"channel_name": "A"}],
+            21,
+            2,
+            "Video game culture",
+            "US",
+        ),
+    )
+
+    captured = {}
+
+    def _render(**kwargs):
+        captured.update(kwargs)
+        return captured
+
+    monkeypatch.setattr(lists_routes, "render_ranking_detail_page", _render)
+
+    out = lists_routes.ranking_detail_route(
+        _req(query_params={"page": "1"}),
+        "gaming",
+        "united-states",
+    )
+
+    assert out["category_slug"] == "gaming"
+    assert out["country_slug"] == "united-states"
+    assert out["category_name"] == "Video game culture"
+    assert out["country_code"] == "US"
+    assert out["total_count"] == 21
+    assert out["total_pages"] == 2
+
+
+def test_ranking_detail_more_route_requires_slugs(monkeypatch):
+    monkeypatch.setattr(lists_routes, "Div", lambda text, cls=None: {"text": text, "cls": cls})
+
+    out = lists_routes.ranking_detail_more_route(_req())
+
+    assert out["text"] == "Error: Invalid ranking"
+
+
+def test_ranking_detail_more_route_happy_path(monkeypatch):
+    monkeypatch.setattr(
+        lists_routes,
+        "_fetch_ranking_page",
+        lambda category_slug, country_slug, page: (
+            [{"channel_name": "A"}],
+            21,
+            2,
+            "Video game culture",
+            "US",
+        ),
+    )
+
+    captured = {}
+
+    def _render(**kwargs):
+        captured.update(kwargs)
+        return captured
+
+    monkeypatch.setattr(lists_routes, "render_ranking_creators_rows", _render)
+
+    out = lists_routes.ranking_detail_more_route(
+        _ranking_req(
+            query_params={"page": "1"},
+            category_slug="gaming",
+            country_slug="united-states",
+        )
+    )
+
+    assert out["category_slug"] == "gaming"
+    assert out["country_slug"] == "united-states"
+    assert out["category_name"] == "Video game culture"
+    assert out["country_code"] == "US"
     assert out["page"] == 1
     assert out["total_pages"] == 2

--- a/tests/test_rankings.py
+++ b/tests/test_rankings.py
@@ -1,0 +1,24 @@
+from services.rankings import (
+    country_slug,
+    ranking_category_slug,
+    ranking_path,
+    resolve_country_slug,
+    resolve_ranking_category_slug,
+)
+
+
+def test_resolve_country_slug_handles_search_friendly_names():
+    assert resolve_country_slug("united-states") == "US"
+    assert resolve_country_slug("uk") == "GB"
+    assert resolve_country_slug("south-korea") == "KR"
+
+
+def test_ranking_path_uses_canonical_slugs():
+    assert ranking_path("Video game culture", "US") == "/rankings/gaming/united-states"
+    assert country_slug("GB") == "united-kingdom"
+
+
+def test_ranking_category_aliases_use_search_friendly_terms():
+    assert resolve_ranking_category_slug("gaming") == "Video game culture"
+    assert resolve_ranking_category_slug("fitness") == "Physical fitness"
+    assert ranking_category_slug("Lifestyle (sociology)") == "lifestyle"

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -7,6 +7,7 @@ because generate_sitemap.py falls back to empty lists when DB creds are absent.
 
 import xml.etree.ElementTree as ET
 
+from services.rankings import iter_ranking_sitemap_paths
 from services.sitemap import STATIC_ROUTES, build_sitemap_xml
 
 _NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
@@ -21,7 +22,11 @@ class TestBuildSitemapXml:
     def test_static_routes_only_when_no_creators(self):
         xml = build_sitemap_xml([])
         locs = _parse_locs(xml)
-        assert len(locs) == len(STATIC_ROUTES)
+        assert len(locs) == len(STATIC_ROUTES) + len(iter_ranking_sitemap_paths())
+
+    def test_programmatic_ranking_urls_included(self):
+        locs = _parse_locs(build_sitemap_xml([]))
+        assert "https://www.viralvibes.fyi/rankings/gaming/united-states" in locs
 
     def test_creator_urls_included(self):
         creators = [
@@ -57,19 +62,19 @@ class TestBuildSitemapXml:
         ]
         xml = build_sitemap_xml([], aplus_creators=aplus)
         locs = _parse_locs(xml)
-        assert len(locs) == len(STATIC_ROUTES)
+        assert len(locs) == len(STATIC_ROUTES) + len(iter_ranking_sitemap_paths())
 
     def test_creator_missing_id_skipped(self):
         """Creator rows without an 'id' key must not produce a URL entry."""
         creators = [{"last_updated_at": "2026-01-01T00:00:00+00:00"}]
         locs = _parse_locs(build_sitemap_xml(creators))
-        assert len(locs) == len(STATIC_ROUTES)
+        assert len(locs) == len(STATIC_ROUTES) + len(iter_ranking_sitemap_paths())
 
     def test_total_url_count(self):
         creators = [{"id": f"id-{i}", "last_updated_at": "2026-01-01"} for i in range(5)]
         aplus = [{"custom_url": f"handle{i}", "last_updated_at": "2026-01-01"} for i in range(3)]
         locs = _parse_locs(build_sitemap_xml(creators, aplus_creators=aplus))
-        assert len(locs) == len(STATIC_ROUTES) + 5 + 3
+        assert len(locs) == len(STATIC_ROUTES) + len(iter_ranking_sitemap_paths()) + 5 + 3
 
     def test_output_is_valid_xml(self):
         """Mixed input must produce well-formed XML that ET can parse."""

--- a/views/lists.py
+++ b/views/lists.py
@@ -1682,6 +1682,128 @@ def render_category_creators_rows(
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Programmatic Ranking Detail Page View
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def render_ranking_detail_page(
+    category_slug: str,
+    country_slug: str,
+    creators: list[dict],
+    page: int = 1,
+    total_pages: int = 1,
+    total_count: int = 0,
+    page_size: int = 20,
+    category_name: str | None = None,
+    country_code: str | None = None,
+) -> Div:
+    """Render a public category/country creator ranking landing page."""
+    display_name = category_name or _unslugify(category_slug).title()
+    country_name = (
+        get_country_name(country_code) if country_code else _unslugify(country_slug).title()
+    )
+    emoji = get_topic_category_emoji(display_name)
+    flag = get_country_flag(country_code) if country_code else ""
+
+    start_rank = (page - 1) * page_size + 1
+    end_rank = min(page * page_size, total_count)
+
+    return Div(
+        Div(
+            Div(
+                Span(emoji, cls="text-5xl mr-3"),
+                Span(flag or "", cls="text-5xl mr-4"),
+                Div(
+                    H1(
+                        f"Top {display_name} YouTube Creators in {country_name}",
+                        cls="text-3xl sm:text-4xl font-bold text-foreground",
+                    ),
+                    P(
+                        f"{format_number(total_count)} {display_name} creators in {country_name}, ranked by subscriber count.",
+                        cls="text-muted-foreground mt-1",
+                    ),
+                    cls="flex-1 min-w-0",
+                ),
+                cls="flex items-center gap-2 mb-6",
+            ),
+            Div(
+                A(
+                    "Browse category",
+                    href=f"/lists/category/{category_slug}",
+                    cls="text-sm text-primary hover:underline",
+                ),
+                Span("·", cls="text-muted-foreground"),
+                A(
+                    "Browse country",
+                    href=f"/lists/country/{country_code.lower()}" if country_code else "/lists",
+                    cls="text-sm text-primary hover:underline",
+                ),
+                cls="flex items-center gap-2",
+            ),
+            cls="pt-6 pb-4 border-b border-border",
+        ),
+        (
+            _empty_detail_state(f"No {display_name} creators in {country_name} yet.")
+            if not total_count
+            else Div(
+                P(
+                    f"Showing {format_number(start_rank)}-{format_number(end_rank)} of {format_number(total_count)} creators",
+                    cls="text-sm text-muted-foreground mb-6",
+                ),
+                Div(
+                    *[
+                        _creator_row(creator, rank=start_rank + i)
+                        for i, creator in enumerate(creators)
+                    ],
+                    id="ranking-creators-list",
+                    cls="space-y-3",
+                ),
+                cls="mt-6",
+            )
+        ),
+        (
+            Div(
+                Button(
+                    "Load More Creators",
+                    hx_get=f"/rankings/{category_slug}/{country_slug}/more?page={page + 1}",
+                    hx_target="#ranking-creators-list",
+                    hx_swap="beforeend",
+                    cls="w-full px-4 py-2 rounded-lg border border-border bg-background hover:bg-accent transition-colors",
+                ),
+                id="ranking-load-more-btn",
+                cls="mt-8 text-center",
+            )
+            if page < total_pages
+            else None
+        ),
+        cls="max-w-4xl mx-auto px-4 pb-16",
+    )
+
+
+def render_ranking_creators_rows(
+    category_slug: str,
+    country_slug: str,
+    creators: list[dict],
+    page: int = 1,
+    total_pages: int = 1,
+    total_count: int = 0,
+    page_size: int = 20,
+    category_name: str | None = None,
+    country_code: str | None = None,
+) -> Div:
+    """Render just creator rows for /rankings/{category}/{country}/more."""
+    start_rank = (page - 1) * page_size + 1
+    rows = [_creator_row(creator, rank=start_rank + i) for i, creator in enumerate(creators)]
+    next_btn = _page_based_load_more_button(
+        endpoint_url=f"/rankings/{category_slug}/{country_slug}/more",
+        section_type="ranking",
+        page=page,
+        total_pages=total_pages,
+    )
+    return (*rows, next_btn)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Language Detail Page View
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/views/lists.py
+++ b/views/lists.py
@@ -1512,7 +1512,7 @@ def render_country_creators_rows(
     total_pages: int = 1,
     total_count: int = 0,
     page_size: int = 20,
-) -> Div:
+) -> tuple:
     """
     Render just the creator rows for the HTMX load-more endpoint.
 
@@ -1652,7 +1652,7 @@ def render_category_creators_rows(
     total_count: int = 0,
     page_size: int = 20,
     category_name: str | None = None,
-) -> Div:
+) -> tuple:
     """
     Render just the creator rows for the HTMX load-more endpoint.
 
@@ -1790,7 +1790,7 @@ def render_ranking_creators_rows(
     page_size: int = 20,
     category_name: str | None = None,
     country_code: str | None = None,
-) -> Div:
+) -> tuple:
     """Render just creator rows for /rankings/{category}/{country}/more."""
     start_rank = (page - 1) * page_size + 1
     rows = [_creator_row(creator, rank=start_rank + i) for i, creator in enumerate(creators)]
@@ -1911,7 +1911,7 @@ def render_language_creators_rows(
     total_pages: int = 1,
     total_count: int = 0,
     page_size: int = 20,
-) -> Div:
+) -> tuple:
     """
     Render just the creator rows for the HTMX load-more endpoint.
 


### PR DESCRIPTION
…nality

## Summary by Sourcery

Add SEO-friendly category/country ranking landing pages and integrate them into routing, data access, and the sitemap.

New Features:
- Introduce public ranking detail and HTMX load-more views for category/country creator rankings.
- Expose new /rankings/{category_slug}/{country_slug} and /rankings/{category_slug}/{country_slug}/more endpoints for programmatic ranking pages.
- Add sitemap generation of a bounded set of high-intent category/country ranking URLs.

Enhancements:
- Implement Supabase-backed query for creators filtered by topic category and country with pagination and ranking metadata.
- Provide slug and alias resolution utilities for ranking categories and countries, including canonical path helpers for SEO.

Tests:
- Extend existing list and category tests to cover ranking routes and data fetch behavior.
- Add unit tests for ranking helpers and ensure sitemap includes programmatic ranking URLs.