### PR TITLE
chore(infra): add sin1 (Singapore) as Vercel deployment region

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "python scripts/generate_sitemap.py",
+  "regions": ["sin1", "iad1"],
   "github": {
     "deploymentEnabled": {
       "gh-pages": false


### PR DESCRIPTION
Reduces latency and compute cost for Asia-Pacific traffic. Pro plan routes each request to the geographically closest configured region; iad1 (US East) is retained for American traffic.

## Summary by Sourcery

Deployment:
- Configure Vercel to deploy to the sin1 (Singapore) region in addition to existing regions for better routing of Asia-Pacific traffic.