### PR TITLE
fix(db): replace get_top_categories_with_counts lateral unnest with m…

### DIFF
--- a/db.py
+++ b/db.py
@@ -3965,6 +3965,7 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
     for rpc_name, view_label in [
         ("refresh_mv_hero_stats", "mv_hero_stats"),
         ("refresh_mv_lists_meta", "mv_lists_meta"),
+        ("refresh_mv_category_counts", "mv_category_counts"),
     ]:
         try:
             resp = supabase_client.rpc(rpc_name).execute()
@@ -3998,6 +3999,16 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
                 except Exception:
                     logger.debug(
                         "[Hero Stats Cache] failed to clear lists meta cache",
+                        exc_info=True,
+                    )
+            if view_label == "mv_category_counts":
+                try:
+                    from db_lists import clear_top_categories_cache
+
+                    clear_top_categories_cache()
+                except Exception:
+                    logger.debug(
+                        "[Hero Stats Cache] failed to clear top categories cache",
                         exc_info=True,
                     )
         except Exception as e:

--- a/db/migrations/054_mv_category_counts.sql
+++ b/db/migrations/054_mv_category_counts.sql
@@ -42,8 +42,8 @@ $$;
 -- 1. Materialized view
 -- ─────────────────────────────────────────────────────────────────────────────
 -- The aggregation logic is identical to the LATERAL unnest in migration 053;
--- running it once at refresh time means serving requests costs only an index
--- seek.  Refresh is triggered by the worker's bootstrap pass (via
+-- running it once at refresh time means serving requests costs only a seq scan
+-- over ~60 rows.  Refresh is triggered by the worker's bootstrap pass (via
 -- refresh_mv_category_counts() RPC added to db.py's refresh_hero_stats_cache
 -- loop) so data is always at most one worker cycle out of date.
 CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_category_counts AS
@@ -86,7 +86,10 @@ GROUP BY cat
 ORDER BY creator_count DESC
 WITH DATA;
 
--- Unique index lets the function ORDER BY + LIMIT use an index-only scan.
+-- Unique index: enforces one row per category and enables
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY (requires a unique index).
+-- ORDER BY creator_count DESC LIMIT uses a seq scan — the MV has at most
+-- ~60 rows (fixed YouTube topic taxonomy) so a seq scan is always faster.
 CREATE UNIQUE INDEX IF NOT EXISTS mv_category_counts_category_idx
     ON public.mv_category_counts (category);
 
@@ -146,6 +149,6 @@ $$;
 
 COMMENT ON FUNCTION public.get_top_categories_with_counts(integer) IS
     'Returns (category, creator_count) from mv_category_counts. '
-    'O(p_limit) index scan — was O(n_creators × avg_categories) LATERAL unnest. '
+    'O(p_limit) seq scan on ~60 rows — was O(n_creators × avg_categories) LATERAL unnest. '
     'Fixes 57014 statement timeout (migration 054). '
     'MV is refreshed by refresh_mv_category_counts() in the worker bootstrap.';

--- a/db/migrations/054_mv_category_counts.sql
+++ b/db/migrations/054_mv_category_counts.sql
@@ -1,0 +1,151 @@
+-- Migration 054: mv_category_counts — pre-compute category counts to fix statement timeout
+--
+-- Root cause
+-- ----------
+-- get_top_categories_with_counts (migrations 002 → 034 → 053) runs a
+-- LATERAL jsonb_array_elements_text unnest over every creator row on every
+-- page request. As the creators table grows this scan consistently exceeds
+-- the PostgREST statement timeout (Postgres error 57014, HTTP 500). The
+-- emergency client-side fallback is capped at 1 000 rows — inaccurate.
+--
+-- Fix
+-- ---
+-- 1. Create mv_category_counts: a materialized view that pre-computes the
+--    GROUP BY result once.  The per-request query becomes a sub-millisecond
+--    O(p_limit) index scan instead of O(n_creators × avg_categories).
+-- 2. Add refresh_mv_category_counts() RPC (same signature as the existing
+--    mv_hero_stats / mv_lists_meta refresh RPCs) so the worker can refresh
+--    it alongside the other materialised views.
+-- 3. Rewrite get_top_categories_with_counts() to read from the MV.
+--
+-- Dependency: safe_jsonb() helper from migration 053 (idempotently re-created
+-- here so this migration can be applied standalone if 053 was skipped).
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 0. Ensure safe_jsonb() exists (idempotent — also in migration 053)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.safe_jsonb(p_text text)
+RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+SECURITY INVOKER
+AS $$
+BEGIN
+    RETURN p_text::jsonb;
+EXCEPTION WHEN OTHERS THEN
+    RETURN NULL;
+END;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Materialized view
+-- ─────────────────────────────────────────────────────────────────────────────
+-- The aggregation logic is identical to the LATERAL unnest in migration 053;
+-- running it once at refresh time means serving requests costs only an index
+-- seek.  Refresh is triggered by the worker's bootstrap pass (via
+-- refresh_mv_category_counts() RPC added to db.py's refresh_hero_stats_cache
+-- loop) so data is always at most one worker cycle out of date.
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_category_counts AS
+WITH unnested AS (
+    SELECT
+        TRIM(
+            REGEXP_REPLACE(
+                REPLACE(
+                    CASE
+                        WHEN cat_raw.value LIKE '%/wiki/%'
+                        THEN SPLIT_PART(cat_raw.value, '/wiki/', 2)
+                        ELSE cat_raw.value
+                    END,
+                    '_', ' '
+                ),
+                '\s+', ' ', 'g'
+            )
+        ) AS cat
+    FROM public.creators c
+    -- Parse topic_categories once per row; NULL result (malformed JSON) drops
+    -- the row via the empty-set behaviour of jsonb_array_elements_text(NULL).
+    CROSS JOIN LATERAL (SELECT public.safe_jsonb(c.topic_categories) AS j) AS parsed
+    CROSS JOIN LATERAL jsonb_array_elements_text(
+        CASE
+            WHEN jsonb_typeof(parsed.j) = 'array' THEN parsed.j
+            ELSE '[]'::jsonb
+        END
+    ) AS cat_raw(value)
+    WHERE c.sync_status         IN ('synced', 'synced_partial')
+      AND c.channel_name        IS NOT NULL
+      AND c.topic_categories    IS NOT NULL
+      AND c.current_subscribers  > 0
+)
+SELECT
+    cat               AS category,
+    COUNT(*)::bigint  AS creator_count
+FROM unnested
+WHERE cat <> ''
+GROUP BY cat
+ORDER BY creator_count DESC
+WITH DATA;
+
+-- Unique index lets the function ORDER BY + LIMIT use an index-only scan.
+CREATE UNIQUE INDEX IF NOT EXISTS mv_category_counts_category_idx
+    ON public.mv_category_counts (category);
+
+COMMENT ON MATERIALIZED VIEW public.mv_category_counts IS
+    'Pre-computed topic-category creator counts (synced + synced_partial). '
+    'Refreshed via refresh_mv_category_counts() RPC in the worker bootstrap. '
+    'Replaces the per-request LATERAL unnest that was causing 57014 timeouts '
+    'as the creators table grew (migration 054).';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. Refresh RPC  (mirrors refresh_mv_hero_stats / refresh_mv_lists_meta)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.refresh_mv_category_counts()
+RETURNS TABLE (
+    materialized_view  text,
+    rows_refreshed     bigint,
+    refresh_duration_ms bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    _start TIMESTAMPTZ;
+    _end   TIMESTAMPTZ;
+    _rows  BIGINT;
+BEGIN
+    _start := clock_timestamp();
+    REFRESH MATERIALIZED VIEW public.mv_category_counts;
+    _end := clock_timestamp();
+    SELECT COUNT(*) INTO _rows FROM public.mv_category_counts;
+    RETURN QUERY SELECT
+        'mv_category_counts'::TEXT,
+        _rows,
+        EXTRACT(MILLISECONDS FROM (_end - _start))::BIGINT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.refresh_mv_category_counts() IS
+    'Refresh mv_category_counts. Called by db.py refresh_hero_stats_cache() '
+    'alongside mv_hero_stats and mv_lists_meta refreshes (migration 054).';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. Rewrite get_top_categories_with_counts to read from the MV
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.get_top_categories_with_counts(p_limit integer DEFAULT 50)
+RETURNS TABLE (category text, creator_count bigint)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT category, creator_count
+    FROM public.mv_category_counts
+    ORDER BY creator_count DESC
+    LIMIT p_limit;
+$$;
+
+COMMENT ON FUNCTION public.get_top_categories_with_counts(integer) IS
+    'Returns (category, creator_count) from mv_category_counts. '
+    'O(p_limit) index scan — was O(n_creators × avg_categories) LATERAL unnest. '
+    'Fixes 57014 statement timeout (migration 054). '
+    'MV is refreshed by refresh_mv_category_counts() in the worker bootstrap.';

--- a/db_lists.py
+++ b/db_lists.py
@@ -541,11 +541,20 @@ NEW_CHANNEL_MAX_AGE_DAYS = 365
 _LISTS_META_TTL_SECONDS = 600  # 10 min — data changes at most a few times/day
 _lists_meta_cache: tuple[float, dict[str, int]] | None = None
 
+_TOP_CATEGORIES_TTL_SECONDS = 600  # 10 min — category counts change only on worker runs
+_top_categories_cache: tuple[float, list[tuple[str, int]]] | None = None
+
 
 def clear_lists_meta_cache() -> None:
     """Clear this process's short-lived lists metadata cache."""
     global _lists_meta_cache
     _lists_meta_cache = None
+
+
+def clear_top_categories_cache() -> None:
+    """Clear this process's short-lived top-categories cache."""
+    global _top_categories_cache
+    _top_categories_cache = None
 
 
 def _get_supabase_client():
@@ -1526,8 +1535,18 @@ def get_top_categories_with_counts(limit: int = 10) -> list[tuple[str, int]]:
     Returns list of (category_name, creator_count) tuples.
     Used for the "By Category" tab and the /creators filter dropdown.
     """
+    global _top_categories_cache
+
     if limit <= 0:
         return []
+
+    # Return from process-level cache when fresh (avoids repeated DB round-trips
+    # on a warm Vercel function instance between worker refresh cycles).
+    now = time.monotonic()
+    if _top_categories_cache is not None:
+        cached_at, cached_result = _top_categories_cache
+        if now - cached_at < _TOP_CATEGORIES_TTL_SECONDS:
+            return cached_result[: min(limit, TOTAL_TOPIC_CATEGORIES)]
 
     # Fetch enough rows to cover the full fixed taxonomy before projection.
     fetch_limit = max(limit, TOTAL_TOPIC_CATEGORIES)
@@ -1538,7 +1557,12 @@ def get_top_categories_with_counts(limit: int = 10) -> list[tuple[str, int]]:
         fetch_limit,
     )
     merged = _merge_with_fixed_topic_categories(raw_counts)
-    return merged[: min(limit, TOTAL_TOPIC_CATEGORIES)]
+    full = merged[:TOTAL_TOPIC_CATEGORIES]
+
+    # Cache the full taxonomy-sized result; individual callers slice from it.
+    _top_categories_cache = (now, full)
+
+    return full[: min(limit, TOTAL_TOPIC_CATEGORIES)]
 
 
 def suggest_primary_categories(q: str, limit: int = 8) -> list[tuple[str, int]]:

--- a/tests/test_lists_category_endpoints.py
+++ b/tests/test_lists_category_endpoints.py
@@ -76,6 +76,7 @@ def _ranking_req(*, query_params=None, session=None, category_slug=None, country
 
 
 def test_get_top_categories_with_counts_projects_onto_fixed_taxonomy(monkeypatch):
+    monkeypatch.setattr(db_lists, "_top_categories_cache", None)  # bypass process-level cache
     monkeypatch.setattr(
         db_lists,
         "_fetch_top_counts",
@@ -95,6 +96,7 @@ def test_get_top_categories_with_counts_projects_onto_fixed_taxonomy(monkeypatch
 
 
 def test_get_top_categories_with_counts_respects_smaller_limit_and_tie_order(monkeypatch):
+    monkeypatch.setattr(db_lists, "_top_categories_cache", None)  # bypass process-level cache
     monkeypatch.setattr(
         db_lists,
         "_fetch_top_counts",
@@ -111,6 +113,7 @@ def test_get_top_categories_with_counts_respects_smaller_limit_and_tie_order(mon
 
 
 def test_get_top_categories_with_counts_zero_limit_returns_empty(monkeypatch):
+    monkeypatch.setattr(db_lists, "_top_categories_cache", None)  # bypass process-level cache
     monkeypatch.setattr(
         db_lists,
         "_fetch_top_counts",


### PR DESCRIPTION
…aterialized view

Root cause: the function did a LATERAL jsonb_array_elements_text unnest across every creator row on every page request. As the DB grew this consistently hit the PostgREST statement timeout (Postgres 57014, HTTP 500), falling back to an inaccurate 1 000-row client-side scan.

- Add mv_category_counts materialized view — runs the expensive aggregation once at refresh time; per-request query becomes an O(p_limit) index scan
- Add refresh_mv_category_counts() RPC (same signature as the existing mv_hero_stats / mv_lists_meta RPCs) and wire it into refresh_hero_stats_cache() in db.py so the worker refreshes it alongside the other materialized views
- Rewrite get_top_categories_with_counts() to SELECT from the MV
- Add _top_categories_cache (10-min TTL) in db_lists.py so warm function instances serve from memory between worker refresh cycles; invalidated by clear_top_categories_cache() after each MV refresh
- safe_jsonb() helper included idempotently so migration 054 is self-contained if migration 053 was not applied

## Summary by Sourcery

Precompute and cache topic-category creator counts to eliminate per-request lateral JSONB aggregation timeouts and serve fast top-category queries.

New Features:
- Introduce mv_category_counts materialized view to store precomputed topic-category creator counts.
- Expose refresh_mv_category_counts() RPC to refresh the mv_category_counts view in line with other stats materialized views.
- Add a process-level _top_categories_cache with TTL to serve top-category queries from memory between worker refresh cycles.

Enhancements:
- Update refresh_hero_stats_cache workflow to refresh mv_category_counts and clear the associated top-categories cache when the view is refreshed.

Documentation:
- Add migration documentation comments explaining the mv_category_counts materialized view, its refresh RPC, and the performance motivation behind replacing the lateral unnest approach.