### PR TITLE
fix: increase HTTP/2 disconnect retry attempts and backoff window

### DIFF
--- a/db.py
+++ b/db.py
@@ -90,8 +90,12 @@ def _is_transient_disconnect(exc: BaseException) -> bool:
 
 _with_disconnect_retry = retry(
     retry=retry_if_exception(_is_transient_disconnect),
-    stop=stop_after_attempt(2),  # 1 original + 1 retry
-    wait=wait_exponential(multiplier=0.1, min=0.1, max=1),
+    stop=stop_after_attempt(3),  # 1 original + 2 retries
+    # min=0.5 s gives the httpcore connection pool enough time to evict the
+    # broken HTTP/2 connection before we retry.  With 0.1 s the pool still
+    # hands out the same stale connection on the first retry, causing a second
+    # identical failure from the stored _read_exception.
+    wait=wait_exponential(multiplier=0.3, min=0.5, max=2),
     before_sleep=before_sleep_log(logger, logging.WARNING),
     reraise=True,
 )

--- a/db.py
+++ b/db.py
@@ -20,6 +20,7 @@ from tenacity import (
     retry,
     stop_after_attempt,
     wait_exponential,
+    wait_exponential_jitter,
     retry_if_exception_type,
     retry_if_exception,
     before_sleep_log,
@@ -88,14 +89,27 @@ def _is_transient_disconnect(exc: BaseException) -> bool:
     return _matches(exc) or (exc.__cause__ is not None and _matches(exc.__cause__))
 
 
+# ---------------------------------------------------------------------------
+# HTTP/2 disconnect retry configuration
+# Extracted as constants so the policy can be tuned without code changes if
+# Supabase connection-pool behaviour or service latency characteristics change.
+# ---------------------------------------------------------------------------
+_DISCONNECT_RETRY_ATTEMPTS = 3  # 1 original attempt + 2 retries
+_DISCONNECT_RETRY_INITIAL_S = 0.5  # min wait — gives httpcore time to evict the stale connection
+_DISCONNECT_RETRY_MAX_S = 2.0  # upper cap per retry interval
+_DISCONNECT_RETRY_JITTER_S = 0.5  # random addend to spread retries and avoid synchronized spikes
+
 _with_disconnect_retry = retry(
     retry=retry_if_exception(_is_transient_disconnect),
-    stop=stop_after_attempt(3),  # 1 original + 2 retries
-    # min=0.5 s gives the httpcore connection pool enough time to evict the
-    # broken HTTP/2 connection before we retry.  With 0.1 s the pool still
-    # hands out the same stale connection on the first retry, causing a second
-    # identical failure from the stored _read_exception.
-    wait=wait_exponential(multiplier=0.3, min=0.5, max=2),
+    stop=stop_after_attempt(_DISCONNECT_RETRY_ATTEMPTS),
+    # Jittered exponential backoff: initial * 2^attempt + random(0, jitter).
+    # The 0.5 s floor gives the httpcore connection pool enough time to evict
+    # a broken HTTP/2 connection before the next attempt reuses the same pool.
+    wait=wait_exponential_jitter(
+        initial=_DISCONNECT_RETRY_INITIAL_S,
+        max=_DISCONNECT_RETRY_MAX_S,
+        jitter=_DISCONNECT_RETRY_JITTER_S,
+    ),
     before_sleep=before_sleep_log(logger, logging.WARNING),
     reraise=True,
 )


### PR DESCRIPTION
The shared httpcore connection pool can hand out a stale HTTP/2 connection on the first retry (0.1 s is not enough for it to evict the broken connection and establish a fresh one), causing a second identical RemoteProtocolError from the stored _read_exception.

- stop_after_attempt: 2 → 3 (adds a second retry)
- wait min: 0.1 s → 0.5 s  (time for pool to evict stale connection)
- wait multiplier: 0.1 → 0.3 (second retry backs off to ~0.9 s)
- wait max: 1 s → 2 s

Fixes frequent "[EmbeddingPeers] get_embedding_peers failed: Server disconnected" log noise on creator profile pages.

## Summary by Sourcery

Enhancements:
- Adjust disconnect retry policy to use three total attempts with a longer exponential backoff window to allow stale HTTP/2 connections to be evicted.