### PR TITLE
fix: batch embedding-peer hydration to avoid Cloudflare WAF URL limit

### DIFF
--- a/db.py
+++ b/db.py
@@ -13,7 +13,7 @@ import random
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Protocol, NamedTuple
+from typing import Any, Dict, List, Optional, Protocol, NamedTuple, Tuple
 
 from supabase import Client, create_client
 from tenacity import (
@@ -2581,7 +2581,7 @@ def get_embedding_peers(
     *,
     hydrate_limit: Optional[int] = None,
     include_contacts: bool = False,
-) -> Optional[List[Dict[str, Any]]]:
+) -> Optional[Tuple[List[Dict[str, Any]], int]]:
     """Return hydrated creator dicts for the embedding-based peer list.
 
     Two-query pattern:
@@ -2631,11 +2631,17 @@ def get_embedding_peers(
 
         total = len(all_peer_ids)  # count before the hydrate_limit slice
 
+        # Clamp hydrate_limit to a valid range so unexpected inputs don't
+        # cause confusing behaviour or unnecessary extra batching work.
+        effective_hydrate = (
+            max(0, min(hydrate_limit, total)) if hydrate_limit is not None else total
+        )
+        fetch_ids = all_peer_ids[:effective_hydrate]
+
         # Step 2: hydrate creator rows for the IDs we actually need to display.
         # Batched in chunks of _HYDRATION_BATCH_SIZE to keep the PostgREST
         # IN() query URL well under Cloudflare's WAF length limit (50 UUIDs
         # × 36 chars ≈ 2 kB → HTTP 400; 20 UUIDs ≈ 900 B → always safe).
-        fetch_ids = all_peer_ids[: hydrate_limit if hydrate_limit is not None else limit]
         fields = _PEER_CREATOR_FIELDS_WITH_CONTACT if include_contacts else _PEER_CREATOR_FIELDS
         creators_by_id: dict[str, dict] = {}
         for i in range(0, len(fetch_ids), _HYDRATION_BATCH_SIZE):

--- a/db.py
+++ b/db.py
@@ -2544,6 +2544,12 @@ def get_favourite_creators_with_stats(user_id: str, limit: int = 50) -> List[Dic
 
 _CREATOR_PEERS_TABLE = "creator_peers"
 
+# Maximum number of IDs to include in a single PostgREST IN() query.
+# Cloudflare's WAF rejects URLs that are too long; 50 UUIDs × 36 chars ≈ 2 kB
+# which reliably triggers an HTTP 400.  Batching at 20 keeps each URL well
+# under 1 kB regardless of field-set size.
+_HYDRATION_BATCH_SIZE = 20
+
 # Fields fetched for each peer creator — same subset used by the similar-rail tiles
 _PEER_CREATOR_FIELDS = (
     "id, channel_name, channel_thumbnail_url, "
@@ -2573,32 +2579,40 @@ def get_embedding_peers(
     peer_type: str = "embedding_v1",
     limit: int = 20,
     *,
+    hydrate_limit: Optional[int] = None,
     include_contacts: bool = False,
 ) -> Optional[List[Dict[str, Any]]]:
     """Return hydrated creator dicts for the embedding-based peer list.
 
     Two-query pattern:
       1. Fetch the peer_list (ordered UUID array) from creator_peers.
-      2. Fetch the matching creator rows, then re-order to match the ranked list.
+      2. Fetch the matching creator rows in batches, then re-order to match
+         the ranked list.
 
     Args:
-        creator_id: Seed creator UUID.
-        peer_type: Which embedding bucket to look up (default ``embedding_v1``).
-        limit: Maximum peers to return.
+        creator_id:    Seed creator UUID.
+        peer_type:     Which embedding bucket to look up (default ``embedding_v1``).
+        limit:         Maximum peers counted / returned.
+        hydrate_limit: When set, only this many peers are fetched from the DB
+                       in step 2 (useful when the caller only needs a small rail
+                       but still wants ``total`` for CTA copy).  Defaults to
+                       ``limit`` (hydrate everything counted).
         include_contacts: When True, fetches the wider field set that
-            ``ContactExtractorService.build_creator_contact_row`` needs
-            (extracted_* contact columns + growth deltas). Used by
-            ``/creators/like/{handle}``. Default keeps the cheap rail query.
+                       ``ContactExtractorService.build_creator_contact_row``
+                       needs (extracted_* contact columns + growth deltas).
+                       Used by ``/creators/like/{handle}``.
 
     Returns:
-        list[dict]  — peer creator rows in similarity order (best first)
-        None        — creator_id not present in creator_peers for this peer_type,
-                      so callers should suppress the "Similar creators" section.
+        ``(creators, total)`` tuple where ``creators`` is the hydrated list in
+        similarity order and ``total`` is the count of available peers (up to
+        ``limit``) before the ``hydrate_limit`` slice is applied.
+        Returns ``None`` when creator_id has no peer row for this peer_type so
+        callers can suppress the section entirely.
     """
     if not supabase_client or not creator_id:
         return None
     try:
-        # Step 1: look up peer list
+        # Step 1: fetch the full ranked peer_list (one lightweight JSONB read).
         resp = _db_execute(
             lambda: supabase_client.table(_CREATOR_PEERS_TABLE)
             .select("peer_list")
@@ -2609,24 +2623,35 @@ def get_embedding_peers(
         )
         rows = resp.data or []
         if not rows:
-            return None  # ← caller must hide the section
+            return None  # caller must hide the section
 
-        peer_ids: list[str] = (rows[0].get("peer_list") or [])[:limit]
-        if not peer_ids:
+        all_peer_ids: list[str] = (rows[0].get("peer_list") or [])[:limit]
+        if not all_peer_ids:
             return None
 
-        # Step 2: hydrate creator rows for those IDs
-        fields = _PEER_CREATOR_FIELDS_WITH_CONTACT if include_contacts else _PEER_CREATOR_FIELDS
-        creators_resp = _db_execute(
-            lambda: supabase_client.table(CREATOR_TABLE)
-            .select(fields)
-            .in_("id", peer_ids)
-            .execute()
-        )
-        creators_by_id = {c["id"]: c for c in (creators_resp.data or [])}
+        total = len(all_peer_ids)  # count before the hydrate_limit slice
 
-        # Re-order to preserve similarity ranking from peer_list
-        return [creators_by_id[pid] for pid in peer_ids if pid in creators_by_id]
+        # Step 2: hydrate creator rows for the IDs we actually need to display.
+        # Batched in chunks of _HYDRATION_BATCH_SIZE to keep the PostgREST
+        # IN() query URL well under Cloudflare's WAF length limit (50 UUIDs
+        # × 36 chars ≈ 2 kB → HTTP 400; 20 UUIDs ≈ 900 B → always safe).
+        fetch_ids = all_peer_ids[: hydrate_limit if hydrate_limit is not None else limit]
+        fields = _PEER_CREATOR_FIELDS_WITH_CONTACT if include_contacts else _PEER_CREATOR_FIELDS
+        creators_by_id: dict[str, dict] = {}
+        for i in range(0, len(fetch_ids), _HYDRATION_BATCH_SIZE):
+            batch = fetch_ids[i : i + _HYDRATION_BATCH_SIZE]
+            batch_resp = _db_execute(
+                lambda b=batch: supabase_client.table(CREATOR_TABLE)
+                .select(fields)
+                .in_("id", b)
+                .execute()
+            )
+            for c in batch_resp.data or []:
+                creators_by_id[c["id"]] = c
+
+        # Re-order to preserve similarity ranking from peer_list.
+        creators = [creators_by_id[pid] for pid in fetch_ids if pid in creators_by_id]
+        return creators, total
 
     except Exception as exc:
         logger.exception("[EmbeddingPeers] get_embedding_peers failed for %s: %s", creator_id, exc)

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -579,13 +579,14 @@ def creator_profile_route(request, creator_id: str, user_id: str | None = None):
     niche_leaderboard = get_category_leaderboard(creator.get("primary_category", ""), limit=5)
     is_fav = is_creator_favourited(user_id, creator_id) if user_id else False
     similar_creators = _get_similar_creators(creator)
-    # Fetch the full peer list once (cheap: one JSONB read + one IN-list hydrate)
-    # then slice for the profile rail. The total length drives the CTA copy on
-    # the rail ("See N more lookalikes for X") so users know there's more on
-    # the dedicated landing page.
-    embedding_peers_full = get_embedding_peers(creator_id, limit=LOOKALIKE_LIMIT) or []
-    embedding_peers = embedding_peers_full[:_PROFILE_PEER_RAIL_LIMIT] or None
-    embedding_peer_total = len(embedding_peers_full)
+    # Fetch peer list once (cheap: one JSONB read + batched IN-list hydration).
+    # hydrate_limit caps step-2 to the rail size so each IN() URL stays well
+    # under Cloudflare's WAF length limit; total comes from step-1's raw count.
+    peers_result = get_embedding_peers(
+        creator_id, limit=LOOKALIKE_LIMIT, hydrate_limit=_PROFILE_PEER_RAIL_LIMIT
+    )
+    embedding_peers = peers_result[0] if peers_result else None
+    embedding_peer_total = peers_result[1] if peers_result else 0
 
     body = render_creator_profile_page(
         creator,
@@ -1061,15 +1062,16 @@ def creators_like_route(request, *, handle: str):
     if not seed_id:
         return Response("Creator not found", status_code=404)
 
-    peers = get_embedding_peers(
+    peers_result = get_embedding_peers(
         seed_id,
         limit=LOOKALIKE_LIMIT,
         include_contacts=True,
     )
-    if not peers:
+    if not peers_result:
         # No peer row → don't render an empty SEO page Google can crawl.
         return Response("No lookalikes available for this creator", status_code=404)
 
+    peers, _total = peers_result
     contact_count = sum(1 for p in peers if p.get("has_contact_info") or p.get("extracted_email"))
 
     body = render_creators_like_page(
@@ -1105,13 +1107,15 @@ def creators_like_export_route(request, *, handle: str):
     if not seed or not seed.get("id"):
         return Response("Creator not found", status_code=404)
 
-    peers = get_embedding_peers(
+    peers_result = get_embedding_peers(
         seed["id"],
         limit=LOOKALIKE_LIMIT,
         include_contacts=True,
     )
-    if not peers:
+    if not peers_result:
         return Response("No lookalikes available for this creator", status_code=404)
+
+    peers, _total = peers_result
 
     # Build email-tool-friendly rows and filter to those with an email.
     # Pulling base_url from the live request keeps profile URLs portable

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -1067,8 +1067,8 @@ def creators_like_route(request, *, handle: str):
         limit=LOOKALIKE_LIMIT,
         include_contacts=True,
     )
-    if not peers_result:
-        # No peer row → don't render an empty SEO page Google can crawl.
+    if not peers_result or not peers_result[0]:
+        # No peer row or all peer IDs were deleted → don't serve an empty SEO page.
         return Response("No lookalikes available for this creator", status_code=404)
 
     peers, _total = peers_result
@@ -1112,7 +1112,7 @@ def creators_like_export_route(request, *, handle: str):
         limit=LOOKALIKE_LIMIT,
         include_contacts=True,
     )
-    if not peers_result:
+    if not peers_result or not peers_result[0]:
         return Response("No lookalikes available for this creator", status_code=404)
 
     peers, _total = peers_result


### PR DESCRIPTION
50 UUIDs × 36 chars in a single PostgREST IN() GET request produces a ~2 kB URL. Cloudflare's WAF rejects it with HTTP 400 and returns an HTML error page; postgrest-py fails to parse the HTML and surfaces a misleading "JSON could not be generated" error.

Changes:
- Add _HYDRATION_BATCH_SIZE = 20 in db.py; step-2 now loops in chunks of 20 IDs, keeping each IN() URL under ~900 bytes
- Add hydrate_limit param to get_embedding_peers so the profile rail fetches only 8 IDs for display while still counting up to LOOKALIKE_LIMIT from the step-1 JSONB read
- Return (creators, total) tuple instead of bare list so callers get the pre-hydration count without an extra query
- Update all three call sites in routes/creators.py accordingly

Profile page: 2 DB calls (was 1 broken 50-ID call)
/like/ routes: 3 batched calls of 20 (was 1 broken 50-ID call)

## Summary by Sourcery

Batch embedding peer hydration to avoid Cloudflare WAF URL length limits and expose total peer count alongside hydrated peers.

Bug Fixes:
- Prevent embedding peer lookups from failing with Cloudflare WAF HTTP 400 errors caused by overly long PostgREST IN() URLs.

Enhancements:
- Introduce a configurable hydration batch size and optional hydrate_limit to control how many peer creator rows are fetched for display versus counted.
- Change get_embedding_peers to return a (creators, total) tuple so callers can access the full peer count without extra queries.
- Update creator profile and like routes to consume the new get_embedding_peers API and keep their peer rail queries within safe URL length limits.