### PR TITLE
perf(db): add stale-on-error TTL caches for hero stats and category c…

### DIFF
--- a/db.py
+++ b/db.py
@@ -4116,9 +4116,13 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
                     )
             if view_label == "mv_category_counts":
                 try:
-                    from db_lists import clear_top_categories_cache
+                    from db_lists import (
+                        clear_top_categories_cache,
+                        clear_category_creators_cache,
+                    )
 
                     clear_top_categories_cache()
+                    clear_category_creators_cache()
                 except Exception:
                     logger.debug(
                         "[Hero Stats Cache] failed to clear top categories cache",

--- a/db_lists.py
+++ b/db_lists.py
@@ -230,7 +230,25 @@ class TopicCategoryPageResult(NamedTuple):
     total_count: int
 
 
-# Slug → canonical category name (fixed labels plus live DB categories).
+# ---------------------------------------------------------------------------
+# Per-key TTL cache for category creator listings.
+# Key: (category_label, limit, offset, return_count)
+# Value: (monotonic_timestamp, TopicCategoryPageResult | list)
+# On a statement-timeout the stale entry is served so pages don't go blank.
+# ---------------------------------------------------------------------------
+_CATEGORY_CREATORS_TTL_SECONDS = 600  # 10 min
+_category_creators_cache: dict[tuple, tuple[float, object]] = {}
+
+# Key: (category_label, country_code, limit, offset, return_count)
+_category_country_creators_cache: dict[tuple, tuple[float, object]] = {}
+
+
+def clear_category_creators_cache() -> None:
+    """Invalidate both category-creators caches (called after mv_category_counts refresh)."""
+    _category_creators_cache.clear()
+    _category_country_creators_cache.clear()
+
+
 _CATEGORY_SLUG_CACHE_TTL_S = 60 * 60
 _category_slug_cache: dict[str, object] = {"expires_at": 0.0, "map": {}}
 
@@ -341,16 +359,38 @@ def get_topic_category_creators(
     Filters on ``topic_categories`` (same column as category counts / list
     cards), not ``primary_category`` — the latter holds YouTube video-level
     categories and does not match Wikipedia topic taxonomy.
+
+    Results are cached in-process for ``_CATEGORY_CREATORS_TTL_SECONDS``
+    seconds.  On a statement-timeout the last known value is returned so
+    pages never go blank.  ``clear_category_creators_cache()`` is called by
+    ``refresh_hero_stats_cache()`` after ``mv_category_counts`` is refreshed.
     """
+    import time as _time
+
     if not category or not str(category).strip():
         return TopicCategoryPageResult([], 0) if return_count else []
 
     supabase_client = _get_supabase_client()
-    if not supabase_client:
-        return TopicCategoryPageResult([], 0) if return_count else []
 
     category_label = _topic_category_label(category)
     if not category_label:
+        return TopicCategoryPageResult([], 0) if return_count else []
+
+    cache_key = (category_label, limit, offset, return_count)
+    now = _time.monotonic()
+    cached_entry = _category_creators_cache.get(cache_key)
+    if cached_entry is not None:
+        ts, cached = cached_entry
+        if now - ts < _CATEGORY_CREATORS_TTL_SECONDS:
+            return cached  # type: ignore[return-value]
+
+    if not supabase_client:
+        if cached_entry:
+            logger.warning(
+                "Supabase client unavailable in get_topic_category_creators(%r) — serving stale cache",
+                category_label,
+            )
+            return cached_entry[1]  # type: ignore[return-value]
         return TopicCategoryPageResult([], 0) if return_count else []
 
     def _run(use_text_fallback: bool = False):
@@ -375,6 +415,13 @@ def get_topic_category_creators(
     try:
         response = _run(use_text_fallback=True)
     except Exception:
+        if cached_entry:
+            logger.warning(
+                "Error fetching topic category creators for %r — serving stale cache (age %.0fs)",
+                category_label,
+                now - cached_entry[0],
+            )
+            return cached_entry[1]  # type: ignore[return-value]
         logger.exception(
             "Error fetching topic category creators for %r via text fallback",
             category_label,
@@ -387,9 +434,16 @@ def get_topic_category_creators(
     for idx, creator in enumerate(creators, 1):
         creator["_rank"] = offset + idx
 
+    result: list[dict] | TopicCategoryPageResult
     if return_count:
-        return TopicCategoryPageResult(creators, total_count)
-    return creators
+        result = TopicCategoryPageResult(creators, total_count)
+    else:
+        result = creators
+
+    if response is not None:
+        _category_creators_cache[cache_key] = (now, result)
+
+    return result
 
 
 def get_topic_category_country_creators(
@@ -401,16 +455,34 @@ def get_topic_category_country_creators(
     return_count: bool = False,
 ) -> list[dict] | TopicCategoryPageResult:
     """Paginated creator listing for a topic category within one country."""
+    import time as _time
+
     if not category or not str(category).strip() or not country_code:
         return TopicCategoryPageResult([], 0) if return_count else []
 
     supabase_client = _get_supabase_client()
-    if not supabase_client:
-        return TopicCategoryPageResult([], 0) if return_count else []
 
     category_label = _topic_category_label(category)
     normalized_country = str(country_code or "").strip().upper()
     if not category_label or len(normalized_country) != 2:
+        return TopicCategoryPageResult([], 0) if return_count else []
+
+    cache_key = (category_label, normalized_country, limit, offset, return_count)
+    now = _time.monotonic()
+    cached_entry = _category_country_creators_cache.get(cache_key)
+    if cached_entry is not None:
+        ts, cached = cached_entry
+        if now - ts < _CATEGORY_CREATORS_TTL_SECONDS:
+            return cached  # type: ignore[return-value]
+
+    if not supabase_client:
+        if cached_entry:
+            logger.warning(
+                "Supabase client unavailable in get_topic_category_country_creators(%r, %s) — serving stale cache",
+                category_label,
+                normalized_country,
+            )
+            return cached_entry[1]  # type: ignore[return-value]
         return TopicCategoryPageResult([], 0) if return_count else []
 
     try:
@@ -427,6 +499,14 @@ def get_topic_category_country_creators(
             query = query.offset(offset)
         response = query.execute()
     except Exception:
+        if cached_entry:
+            logger.warning(
+                "Error fetching topic category creators for %r in %s — serving stale cache (age %.0fs)",
+                category_label,
+                normalized_country,
+                now - cached_entry[0],
+            )
+            return cached_entry[1]  # type: ignore[return-value]
         logger.exception(
             "Error fetching topic category creators for %r in %s",
             category_label,
@@ -440,9 +520,14 @@ def get_topic_category_country_creators(
     for idx, creator in enumerate(creators, 1):
         creator["_rank"] = offset + idx
 
+    result: list[dict] | TopicCategoryPageResult
     if return_count:
-        return TopicCategoryPageResult(creators, total_count)
-    return creators
+        result = TopicCategoryPageResult(creators, total_count)
+    else:
+        result = creators
+
+    _category_country_creators_cache[cache_key] = (now, result)
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/db_lists.py
+++ b/db_lists.py
@@ -233,14 +233,21 @@ class TopicCategoryPageResult(NamedTuple):
 # ---------------------------------------------------------------------------
 # Per-key TTL cache for category creator listings.
 # Key: (category_label, limit, offset, return_count)
-# Value: (monotonic_timestamp, TopicCategoryPageResult | list)
-# On a statement-timeout the stale entry is served so pages don't go blank.
+# Value: (monotonic_timestamp, TopicCategoryPageResult | list[dict])
+#
+# TTL governs when a *fresh* DB fetch is attempted, not when stale entries
+# are discarded.  An expired entry stays in the dict and is returned as-is
+# when the subsequent DB call fails (e.g. statement timeout), so pages
+# never go blank due to a transient DB hiccup.  Entries are only truly
+# evicted by clear_category_creators_cache() (called after a worker refresh).
 # ---------------------------------------------------------------------------
 _CATEGORY_CREATORS_TTL_SECONDS = 600  # 10 min
-_category_creators_cache: dict[tuple, tuple[float, object]] = {}
+_CategoryCreatorsValue = list[dict] | TopicCategoryPageResult
+
+_category_creators_cache: dict[tuple, tuple[float, _CategoryCreatorsValue]] = {}
 
 # Key: (category_label, country_code, limit, offset, return_count)
-_category_country_creators_cache: dict[tuple, tuple[float, object]] = {}
+_category_country_creators_cache: dict[tuple, tuple[float, _CategoryCreatorsValue]] = {}
 
 
 def clear_category_creators_cache() -> None:

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -216,6 +216,7 @@ def test_get_topic_category_creators_always_uses_ilike_directly(monkeypatch):
         },
     )
     monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+    monkeypatch.setattr(db_lists, "_category_creators_cache", {})
 
     result = db_lists.get_topic_category_creators(
         "Lifestyle (sociology)",
@@ -238,6 +239,7 @@ def test_get_topic_category_creators_ilike_returns_count_and_creators(monkeypatc
         },
     )
     monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+    monkeypatch.setattr(db_lists, "_category_creators_cache", {})
 
     result = db_lists.get_topic_category_creators("Lifestyle (sociology)", return_count=True)
 
@@ -258,6 +260,7 @@ def test_get_topic_category_creators_applies_offset_to_rank(monkeypatch):
         }
     )
     monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+    monkeypatch.setattr(db_lists, "_category_creators_cache", {})
 
     offset = 10
     result = db_lists.get_topic_category_creators(
@@ -280,6 +283,7 @@ def test_get_topic_category_country_creators_filters_country_and_category(monkey
         }
     )
     monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+    monkeypatch.setattr(db_lists, "_category_country_creators_cache", {})
 
     result = db_lists.get_topic_category_country_creators(
         "Video game culture",
@@ -294,6 +298,79 @@ def test_get_topic_category_country_creators_filters_country_and_category(monkey
     assert call["ilike"][0] == "topic_categories"
     assert ("country_code", "US") in call["eq"]
     assert call["order"]["args"] == ("current_subscribers",)
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_topic_category_creators_caches_result_on_second_call(monkeypatch):
+    """A second call with identical params is served from cache (no extra DB hit)."""
+    fake_client = _FakeSupabaseClient(
+        {"data": [{"channel_name": "Cached Channel", "current_subscribers": 999}], "count": 1}
+    )
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+    monkeypatch.setattr(db_lists, "_category_creators_cache", {})
+
+    result1 = db_lists.get_topic_category_creators("Music", limit=5, return_count=True)
+    assert result1.total_count == 1
+    assert len(fake_client.calls) == 1
+
+    # Second call — same params → cache hit; no new .table() call.
+    result2 = db_lists.get_topic_category_creators("Music", limit=5, return_count=True)
+    assert result2.total_count == 1
+    assert len(fake_client.calls) == 1  # still 1
+
+
+def test_get_topic_category_creators_serves_stale_cache_on_exception(monkeypatch):
+    """When the DB raises (e.g. statement timeout), the last cached result is returned."""
+    stale_result = db_lists.TopicCategoryPageResult(
+        [{"channel_name": "Stale Channel", "current_subscribers": 100}], 1
+    )
+    label = db_lists._topic_category_label("Music")
+    # Insert an expired cache entry (timestamp 0.0 is in the distant past).
+    cache = {(label, 20, 0, True): (0.0, stale_result)}
+    monkeypatch.setattr(db_lists, "_category_creators_cache", cache)
+
+    error_client = _FakeSupabaseClient(Exception("canceling statement due to statement timeout"))
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: error_client)
+
+    result = db_lists.get_topic_category_creators("Music", return_count=True)
+
+    assert result.creators[0]["channel_name"] == "Stale Channel"
+    assert result.total_count == 1
+
+
+def test_get_topic_category_country_creators_serves_stale_cache_on_exception(monkeypatch):
+    """Country-scoped variant also returns stale cache on DB exception."""
+    stale_result = db_lists.TopicCategoryPageResult(
+        [{"channel_name": "Stale US Channel", "current_subscribers": 50}], 1
+    )
+    label = db_lists._topic_category_label("Video game culture")
+    cache = {(label, "US", 20, 0, True): (0.0, stale_result)}
+    monkeypatch.setattr(db_lists, "_category_country_creators_cache", cache)
+
+    error_client = _FakeSupabaseClient(Exception("canceling statement due to statement timeout"))
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: error_client)
+
+    result = db_lists.get_topic_category_country_creators(
+        "Video game culture", "US", return_count=True
+    )
+
+    assert result.creators[0]["channel_name"] == "Stale US Channel"
+    assert result.total_count == 1
+
+
+def test_clear_category_creators_cache_clears_both_dicts(monkeypatch):
+    """clear_category_creators_cache() empties both category cache dicts."""
+    monkeypatch.setattr(db_lists, "_category_creators_cache", {"key1": (0.0, [])})
+    monkeypatch.setattr(db_lists, "_category_country_creators_cache", {"key2": (0.0, [])})
+
+    db_lists.clear_category_creators_cache()
+
+    assert db_lists._category_creators_cache == {}
+    assert db_lists._category_country_creators_cache == {}
 
 
 def test_fetch_category_page_uses_topic_categories_not_primary_category(monkeypatch):


### PR DESCRIPTION
…reator listings

Supabase statement timeouts (57014) on mv_hero_stats RPC and ilike sequential scans on `topic_categories` were causing hero sections and category pages to render all-zeroes / go blank on DB hiccups.

db.py — get_creator_hero_stats:
- 5-min process-level TTL cache (_hero_stats_cache)
- On exception (including 57014 timeout), serve last cached value with logger.warning instead of returning {} and rendering zeroes
- Log stale-fallback on supabase_client=None and no-data paths too
- refresh_hero_stats_cache() calls clear_hero_stats_cache() after mv_hero_stats refresh; cache-clear failure logged at warning level

db_lists.py — get_topic_category_creators / get_topic_category_country_creators:
- Per-key 10-min TTL caches (_category_creators_cache, _category_country_creators_cache) keyed by (category, limit, offset, return_count)
- Same stale-on-error pattern: timeout returns last known page instead of []
- clear_category_creators_cache() clears both dicts; called by refresh_hero_stats_cache() after mv_category_counts refresh

tests/test_category_detail.py:
- 4 new tests: cache-hit short-circuits DB, stale-on-error for both category and country variants, clear function empties both dicts
- Existing 4 client-monkeypatching tests get cache-dict clearing to prevent cross-test pollution

## Summary by Sourcery

Introduce in-process TTL caches with stale-on-error behavior for hero-related category creator listings to keep pages populated during database hiccups.

New Features:
- Add per-key 10-minute TTL caches for topic category creator and country-scoped creator listings, keyed by request parameters.
- Provide a clear_category_creators_cache helper to invalidate both category creator caches after category count materialized view refreshes.

Enhancements:
- Serve last cached creator listing results when Supabase client is unavailable or RPCs fail, avoiding empty pages on DB timeouts.
- Wire hero stats cache refresh to also clear category creator caches alongside top categories cache to keep data consistent.

Tests:
- Add tests verifying cache hits avoid extra DB calls, stale cache is served on exceptions for both global and country-scoped listings, and the cache clear helper empties both dicts.
- Update existing category detail tests to reset cache dictionaries between runs to prevent cross-test interference.