### PR TITLE
fix(db): retry on httpcore HTTP/2 stream KeyError (206 response corru…

### DIFF
--- a/db.py
+++ b/db.py
@@ -84,6 +84,15 @@ def _is_transient_disconnect(exc: BaseException) -> bool:
         # connection; a retry gets a fresh one.
         if isinstance(e, RuntimeError) and "iteration" in str(e) and "dictionary" in str(e):
             return True
+        # httpcore HTTP/2 stream-bookkeeping bug: a non-200 response (e.g.
+        # 206 Partial Content) can cause _response_closed() to try to delete
+        # a stream_id that was already removed from self._events, raising
+        # KeyError(<stream_id>).  HTTP/2 stream IDs are always positive
+        # integers, so this combination is specific to httpcore's internal
+        # state machine.  The connection is corrupt after this; treat it as
+        # a transient disconnect so the retry opens a fresh connection.
+        if isinstance(e, KeyError) and e.args and isinstance(e.args[0], int) and e.args[0] > 0:
+            return True
         return False
 
     return _matches(exc) or (exc.__cause__ is not None and _matches(exc.__cause__))
@@ -4116,9 +4125,13 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
                     )
             if view_label == "mv_category_counts":
                 try:
-                    from db_lists import clear_top_categories_cache
+                    from db_lists import (
+                        clear_top_categories_cache,
+                        clear_category_creators_cache,
+                    )
 
                     clear_top_categories_cache()
+                    clear_category_creators_cache()
                 except Exception:
                     logger.debug(
                         "[Hero Stats Cache] failed to clear top categories cache",


### PR DESCRIPTION
…ption)

A rank-computation query returning HTTP 206 Partial Content triggers a bug in the vendored httpcore where _response_closed() calls `del self._events[stream_id]` on an already-removed stream ID. The resulting KeyError corrupts the HTTP/2 connection; subsequent requests
reusing that connection from the pool fail with KeyError: <stream_id>
rather than a RemoteProtocolError, so _is_transient_disconnect() did not catch it and _with_disconnect_retry() propagated the crash instead of retrying.

Fix: add a KeyError guard to _matches() in _is_transient_disconnect(). HTTP/2 stream IDs are always positive integers, so `isinstance(e, KeyError) and isinstance(e.args[0], int) and e.args[0] > 0` is specific to httpcore's internal stream state machine. The retry decorator now opens a fresh connection on this failure class, matching the behaviour already in place for RemoteProtocolError and h2 dict-iteration RuntimeErrors.

## Summary by Sourcery

Handle httpcore HTTP/2 stream bookkeeping KeyError as a transient disconnect and update cache refresh to clear additional category-related caches.

Bug Fixes:
- Treat specific KeyError from httpcore HTTP/2 stream handling as a transient disconnect so rank-computation queries are retried with a fresh connection instead of failing.
- Ensure hero stats cache refresh invalidates both top categories and category creators caches to avoid stale category data.