### PR TITLE
fix(creators): guard against JS sentinel handles and add retry to fal…

### DIFF
--- a/db.py
+++ b/db.py
@@ -87,11 +87,19 @@ def _is_transient_disconnect(exc: BaseException) -> bool:
         # httpcore HTTP/2 stream-bookkeeping bug: a non-200 response (e.g.
         # 206 Partial Content) can cause _response_closed() to try to delete
         # a stream_id that was already removed from self._events, raising
-        # KeyError(<stream_id>).  HTTP/2 stream IDs are always positive
-        # integers, so this combination is specific to httpcore's internal
-        # state machine.  The connection is corrupt after this; treat it as
-        # a transient disconnect so the retry opens a fresh connection.
-        if isinstance(e, KeyError) and e.args and isinstance(e.args[0], int) and e.args[0] > 0:
+        # KeyError(<stream_id>).  RFC 7540 §5.1.1: client-initiated HTTP/2
+        # stream IDs are always positive ODD integers (1, 3, 5, …).  No
+        # application dict key produced by our own code fits that shape, so
+        # the check is specific to httpcore's stream state machine.  The
+        # connection is corrupt after this; treat it as a transient disconnect
+        # so the retry opens a fresh connection.
+        if (
+            isinstance(e, KeyError)
+            and e.args
+            and isinstance(e.args[0], int)
+            and e.args[0] > 0
+            and e.args[0] % 2 == 1  # HTTP/2 client stream IDs are always odd
+        ):
             return True
         return False
 
@@ -4134,7 +4142,7 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
                     clear_category_creators_cache()
                 except Exception:
                     logger.debug(
-                        "[Hero Stats Cache] failed to clear top categories cache",
+                        "[Hero Stats Cache] failed to clear category caches (top_categories and/or category_creators)",
                         exc_info=True,
                     )
         except Exception as e:

--- a/db.py
+++ b/db.py
@@ -84,6 +84,15 @@ def _is_transient_disconnect(exc: BaseException) -> bool:
         # connection; a retry gets a fresh one.
         if isinstance(e, RuntimeError) and "iteration" in str(e) and "dictionary" in str(e):
             return True
+        # httpcore HTTP/2 stream-bookkeeping bug: a non-200 response (e.g.
+        # 206 Partial Content) can cause _response_closed() to try to delete
+        # a stream_id that was already removed from self._events, raising
+        # KeyError(<stream_id>).  HTTP/2 stream IDs are always positive
+        # integers, so this combination is specific to httpcore's internal
+        # state machine.  The connection is corrupt after this; treat it as
+        # a transient disconnect so the retry opens a fresh connection.
+        if isinstance(e, KeyError) and e.args and isinstance(e.args[0], int) and e.args[0] > 0:
+            return True
         return False
 
     return _matches(exc) or (exc.__cause__ is not None and _matches(exc.__cause__))
@@ -3151,10 +3160,10 @@ def _find_creator_by_normalized_handle(
 
     for candidate in (normalized_handle, f"@{normalized_handle}"):
         try:
-            resp = (
-                supabase_client.table(CREATOR_TABLE)
+            resp = _db_execute(
+                lambda c=candidate: supabase_client.table(CREATOR_TABLE)
                 .select(select)
-                .ilike("custom_url", candidate)
+                .ilike("custom_url", c)
                 .limit(1)
                 .execute()
             )
@@ -4116,9 +4125,13 @@ def refresh_hero_stats_cache() -> dict[str, Any]:
                     )
             if view_label == "mv_category_counts":
                 try:
-                    from db_lists import clear_top_categories_cache
+                    from db_lists import (
+                        clear_top_categories_cache,
+                        clear_category_creators_cache,
+                    )
 
                     clear_top_categories_cache()
+                    clear_category_creators_cache()
                 except Exception:
                     logger.debug(
                         "[Hero Stats Cache] failed to clear top categories cache",

--- a/main.py
+++ b/main.py
@@ -1716,6 +1716,21 @@ _CREATOR_UUID_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Strings that are never valid YouTube handles but frequently appear in URLs
+# when JavaScript/template rendering emits an un-set variable (e.g. a JS `null`
+# serialised into a URL template before the value has loaded).
+_INVALID_HANDLE_SENTINELS: frozenset[str] = frozenset(
+    {
+        "null",
+        "undefined",
+        "none",
+        "nan",
+        "false",
+        "true",
+        "0",
+    }
+)
+
 
 @rt("/creator/{creator_id}")
 def creator_profile(req, sess, creator_id: str):
@@ -1744,6 +1759,38 @@ def creator_profile(req, sess, creator_id: str):
     # _normalize_creator_handle (inside find_creator_by_handle) strips "@" and
     # lower-cases before the DB lookup.
     if not _CREATOR_UUID_RE.match(creator_id):
+        # Reject JS/template sentinel strings immediately — no DB queries.
+        if creator_id.lower().lstrip("@") in _INVALID_HANDLE_SENTINELS:
+            return HTMLResponse(
+                _render_page(
+                    Titled(
+                        "Creator Not Found - ViralVibes",
+                        Container(
+                            NavComponent(oauth, req, sess),
+                            Div(
+                                UkIcon(
+                                    "user-x", cls="w-12 h-12 text-muted-foreground mx-auto mb-4"
+                                ),
+                                H2(
+                                    "Creator not found",
+                                    cls="text-2xl font-bold text-foreground mb-2",
+                                ),
+                                P(
+                                    "That handle is not valid.",
+                                    cls="text-muted-foreground",
+                                ),
+                                A(
+                                    "← Browse Creators",
+                                    href="/creators",
+                                    cls="mt-4 inline-flex items-center text-sm font-medium text-primary hover:underline",
+                                ),
+                                cls="max-w-2xl mx-auto px-4 py-24 text-center",
+                            ),
+                        ),
+                    )
+                ),
+                status_code=404,
+            )
         creator = find_creator_by_handle(creator_id)
         if not creator:
             # Normalise handle for display: strip any leading '@' then re-add

--- a/main.py
+++ b/main.py
@@ -267,6 +267,32 @@ def _render_page(ft_response) -> str:
     )
 
 
+def _creator_not_found_response(req, sess, message: str) -> HTMLResponse:
+    """Return a 404 HTMLResponse for the creator profile route.
+
+    Shared by the JS-sentinel guard and the handle-lookup-failed path so
+    both render identically without duplicating the page structure.
+    """
+    page = Titled(
+        "Creator Not Found - ViralVibes",
+        Container(
+            NavComponent(oauth, req, sess),
+            Div(
+                UkIcon("user-x", cls="w-12 h-12 text-muted-foreground mx-auto mb-4"),
+                H2("Creator not found", cls="text-2xl font-bold text-foreground mb-2"),
+                P(message, cls="text-muted-foreground"),
+                A(
+                    "← Browse Creators",
+                    href="/creators",
+                    cls="mt-4 inline-flex items-center text-sm font-medium text-primary hover:underline",
+                ),
+                cls="max-w-2xl mx-auto px-4 py-24 text-center",
+            ),
+        ),
+    )
+    return HTMLResponse(_render_page(page), status_code=404)
+
+
 # ============================================================================
 # Safety Constants
 # ============================================================================
@@ -1760,66 +1786,17 @@ def creator_profile(req, sess, creator_id: str):
     # lower-cases before the DB lookup.
     if not _CREATOR_UUID_RE.match(creator_id):
         # Reject JS/template sentinel strings immediately — no DB queries.
-        if creator_id.lower().lstrip("@") in _INVALID_HANDLE_SENTINELS:
-            return HTMLResponse(
-                _render_page(
-                    Titled(
-                        "Creator Not Found - ViralVibes",
-                        Container(
-                            NavComponent(oauth, req, sess),
-                            Div(
-                                UkIcon(
-                                    "user-x", cls="w-12 h-12 text-muted-foreground mx-auto mb-4"
-                                ),
-                                H2(
-                                    "Creator not found",
-                                    cls="text-2xl font-bold text-foreground mb-2",
-                                ),
-                                P(
-                                    "That handle is not valid.",
-                                    cls="text-muted-foreground",
-                                ),
-                                A(
-                                    "← Browse Creators",
-                                    href="/creators",
-                                    cls="mt-4 inline-flex items-center text-sm font-medium text-primary hover:underline",
-                                ),
-                                cls="max-w-2xl mx-auto px-4 py-24 text-center",
-                            ),
-                        ),
-                    )
-                ),
-                status_code=404,
-            )
+        normalized_creator_id = creator_id.strip().lower().lstrip("@")
+        if normalized_creator_id in _INVALID_HANDLE_SENTINELS:
+            return _creator_not_found_response(req, sess, "That handle is not valid.")
         creator = find_creator_by_handle(creator_id)
         if not creator:
             # Normalise handle for display: strip any leading '@' then re-add
             # it so the message always shows the canonical "@handle" shape.
             display_handle = f"@{creator_id.lstrip('@')}"
-            page = Titled(
-                "Creator Not Found - ViralVibes",
-                Container(
-                    NavComponent(oauth, req, sess),
-                    Div(
-                        UkIcon("user-x", cls="w-12 h-12 text-muted-foreground mx-auto mb-4"),
-                        H2(
-                            "Creator not found",
-                            cls="text-2xl font-bold text-foreground mb-2",
-                        ),
-                        P(
-                            f"No creator with handle {display_handle!r} could be found.",
-                            cls="text-muted-foreground",
-                        ),
-                        A(
-                            "← Browse Creators",
-                            href="/creators",
-                            cls="mt-4 inline-flex items-center text-sm font-medium text-primary hover:underline",
-                        ),
-                        cls="max-w-2xl mx-auto px-4 py-24 text-center",
-                    ),
-                ),
+            return _creator_not_found_response(
+                req, sess, f"No creator with handle {display_handle!r} could be found."
             )
-            return HTMLResponse(_render_page(page), status_code=404)
         canonical_id = creator["id"]
         return RedirectResponse(f"/creator/{canonical_id}", status_code=301)
     result = creator_profile_route(req, creator_id, user_id=sess.get("user_id") if sess else None)


### PR DESCRIPTION
…lback lookup

/creator/null (and /creator/undefined etc.) was firing two expensive DB calls — a find_creator_by_normalized_handle RPC that timed out (57014), then an ilike fallback that hit a RemoteProtocolError — because "null" is a syntactically valid YouTube handle and bypassed all existing guards.

Changes:

main.py:
- Add _INVALID_HANDLE_SENTINELS frozenset (null, undefined, none, nan, false, true, 0) checked before any DB call in the handle path of /creator/{creator_id}; leading '@' is stripped before comparison so both /creator/null and /creator/@null are caught
- Returns 404 immediately with no round-trips to Supabase

db.py (_find_creator_by_normalized_handle):
- Wrap fallback ilike queries in _db_execute so they get the same _with_disconnect_retry protection as the RPC path; previously a RemoteProtocolError on the second candidate was silently swallowed and the function returned None instead of retrying on a fresh connection

## Summary by Sourcery

Guard creator handle lookup against invalid JavaScript sentinel values and make creator handle fallbacks resilient to transient DB connection errors.

Bug Fixes:
- Return a 404 error without querying the database when /creator/{creator_id} receives common JavaScript sentinel strings as handles.
- Wrap fallback handle ilike lookups in the same retryable DB execution wrapper used elsewhere to avoid silently swallowing transient connection errors.
- Treat specific httpcore HTTP/2 KeyError stream failures as transient disconnects so they trigger connection retries.
- Clear the category creators cache alongside the top categories cache when refreshing hero stats to keep cached category data in sync.

Enhancements:
- Show a dedicated "Creator not found" error page when an invalid handle sentinel is requested instead of falling through to normal lookup.