### PR TITLE
fix(db): remove WAF-triggering not.is.null from get_creator_rank and …

### DIFF
--- a/db.py
+++ b/db.py
@@ -1896,13 +1896,14 @@ def get_creator_rank(
                 .execute()
             )
         except Exception as exc:
-            # 400 = Cloudflare WAF rejection — triggered by (a) the now-removed
-            # `channel_name=not.is.null` PostgREST pattern, and (b) values like
+            # Narrow to PostgREST APIError only (matched by class name, consistent
+            # with the _is_transient_disconnect pattern used elsewhere in this file)
+            # so unexpected programming errors still surface via re-raise.
+            # 400 = Cloudflare WAF rejection — triggered by the now-removed
+            # `channel_name=not.is.null` PostgREST pattern and by values like
             # "Film & Animation" whose URL-encoded %26 trips parameter-pollution
-            # WAF rules. Not retryable; skip rank silently rather than spamming
-            # the error log with a full traceback for a non-critical field.
-            code = getattr(exc, "code", None)
-            if code == 400 or str(code) == "400":
+            # WAF rules. Not retryable; return None for this non-critical field.
+            if type(exc).__name__ == "APIError" and getattr(exc, "code", None) == 400:
                 logger.debug(
                     "[DB] get_creator_rank: 400 for %s=%r — skipping rank (%s)",
                     filter_key,

--- a/db.py
+++ b/db.py
@@ -1885,16 +1885,32 @@ def get_creator_rank(
         before_sleep=before_sleep_log(logger, logging.WARNING),
     )
     def _fetch_rank():
-        resp = (
-            supabase_client.table(CREATOR_TABLE)
-            .select("id", count="estimated")
-            .eq("sync_status", "synced")
-            .not_.is_("channel_name", "null")
-            .gt("current_subscribers", current_subscribers)
-            .eq(filter_key, filter_val)
-            .limit(1)
-            .execute()
-        )
+        try:
+            resp = (
+                supabase_client.table(CREATOR_TABLE)
+                .select("id", count="estimated")
+                .eq("sync_status", "synced")
+                .gt("current_subscribers", current_subscribers)
+                .eq(filter_key, filter_val)
+                .limit(1)
+                .execute()
+            )
+        except Exception as exc:
+            # 400 = Cloudflare WAF rejection — triggered by (a) the now-removed
+            # `channel_name=not.is.null` PostgREST pattern, and (b) values like
+            # "Film & Animation" whose URL-encoded %26 trips parameter-pollution
+            # WAF rules. Not retryable; skip rank silently rather than spamming
+            # the error log with a full traceback for a non-critical field.
+            code = getattr(exc, "code", None)
+            if code == 400 or str(code) == "400":
+                logger.debug(
+                    "[DB] get_creator_rank: 400 for %s=%r — skipping rank (%s)",
+                    filter_key,
+                    filter_val,
+                    exc,
+                )
+                return None
+            raise
         above = getattr(resp, "count", None)
         return int(above) + 1 if above is not None else None
 

--- a/db/migrations/047_creators_keyword_pipeline_idx.sql
+++ b/db/migrations/047_creators_keyword_pipeline_idx.sql
@@ -25,13 +25,15 @@
 -- The Python-side approach is also fine to keep — it is slightly less
 -- selective at the DB level but has no correctness impact.
 
-CREATE INDEX IF NOT EXISTS idx_creators_keyword_pipeline
+-- Drop first so a pre-existing index with a mismatched definition is not
+-- silently left in place by IF NOT EXISTS (which would cause hard-to-debug
+-- query-planner behaviour without any error).
+DROP INDEX IF EXISTS idx_creators_keyword_pipeline;
+
+CREATE INDEX idx_creators_keyword_pipeline
     ON public.creators (id)
     WHERE sync_status = 'synced'
       AND transcript_keywords_updated_at IS NULL;
 
 COMMENT ON INDEX public.idx_creators_keyword_pipeline IS
-    'Partial index for the Kaggle keyword extraction pipeline. '
-    'Supports: SELECT id … WHERE sync_status=''synced'' AND transcript_keywords_updated_at IS NULL ORDER BY id. '
-    'Eliminates statement timeout (57014) in notebooks/creator_keyword_poc.ipynb Cell 5. '
-    'Applied via migration 047.';
+    'Partial index for the Kaggle keyword extraction pipeline. Supports: SELECT id WHERE sync_status=''synced'' AND transcript_keywords_updated_at IS NULL ORDER BY id. Eliminates statement timeout (57014) in notebooks/creator_keyword_poc.ipynb Cell 5. Applied via migration 047.';

--- a/db/migrations/047_creators_keyword_pipeline_idx.sql
+++ b/db/migrations/047_creators_keyword_pipeline_idx.sql
@@ -1,0 +1,37 @@
+-- 047_creators_keyword_pipeline_idx.sql
+-- Partial index to support the _fetch_eligible_ids() query in
+-- notebooks/creator_keyword_poc.ipynb without statement timeout (57014).
+--
+-- The pipeline query pattern (Cell 5):
+--   SELECT id, default_language, engagement_score, current_subscribers
+--   FROM   creators
+--   WHERE  sync_status = 'synced'
+--     AND  transcript_keywords_updated_at IS NULL
+--   ORDER BY id ASC
+--   LIMIT 1000
+--
+-- Without this index Postgres performs a sequential table scan, which
+-- exceeds Supabase's statement timeout on tables with > ~50K rows.
+-- With this index Postgres uses a partial index range scan — O(log n)
+-- per page regardless of table size, typically < 50ms.
+--
+-- Note: CONCURRENTLY is omitted so this can run inside the Supabase SQL
+-- editor (transaction block). The table is briefly locked for writes
+-- during index build — run during low-traffic hours if needed.
+--
+-- After applying this migration, the notebook's Python-side filters
+-- (engagement_score, default_language, current_subscribers) can optionally
+-- be moved back into the Supabase query since the seq-scan risk is gone.
+-- The Python-side approach is also fine to keep — it is slightly less
+-- selective at the DB level but has no correctness impact.
+
+CREATE INDEX IF NOT EXISTS idx_creators_keyword_pipeline
+    ON public.creators (id)
+    WHERE sync_status = 'synced'
+      AND transcript_keywords_updated_at IS NULL;
+
+COMMENT ON INDEX public.idx_creators_keyword_pipeline IS
+    'Partial index for the Kaggle keyword extraction pipeline. '
+    'Supports: SELECT id … WHERE sync_status=''synced'' AND transcript_keywords_updated_at IS NULL ORDER BY id. '
+    'Eliminates statement timeout (57014) in notebooks/creator_keyword_poc.ipynb Cell 5. '
+    'Applied via migration 047.';


### PR DESCRIPTION
…handle 400 gracefully

The `channel_name=not.is.null` PostgREST filter in _fetch_rank generated a URL pattern that Cloudflare's WAF blocked as a SQL injection probe, causing all rank queries to 400. Categories like "Film & Animation" compounded the issue — their %26-encoded ampersand also trips the parameter-pollution rule.

- Remove .not_.is_("channel_name", "null") — not needed for rank computation
- Catch 400 errors inside _fetch_rank; return None at debug level instead of propagating a full exception traceback for a non-critical display field
- Other errors (5xx, timeouts) still re-raise for tenacity retry logic

## Summary by Sourcery

Handle WAF-induced 400 errors in creator rank queries and add a partial index to support the creator keyword pipeline without statement timeouts.

Bug Fixes:
- Stop using the WAF-triggering channel_name not.is.null filter in get_creator_rank so rank queries no longer fail with 400 responses.
- Treat WAF-driven 400 responses as non-fatal in _fetch_rank, returning no rank and logging at debug level instead of propagating exceptions.

Enhancements:
- Improve robustness of creator rank fetching by distinguishing non-retryable 400 errors from other exceptions that should still propagate for retry logic.

Build:
- Add a partial index on creators(id) for synced rows with null transcript_keywords_updated_at to support the keyword pipeline query pattern and avoid statement timeouts.