### PR TITLE
fix: category detail pages return 0 results (sync_status filter)

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -10,6 +10,7 @@ import time
 from typing import Callable, NamedTuple
 from urllib.parse import unquote, urlparse
 
+from constants import BROWSEABLE_SYNC_STATUSES
 from utils import normalize_category_name, safe_get_value, slugify
 
 logger = logging.getLogger(__name__)
@@ -333,7 +334,7 @@ def _apply_topic_category_filters(query, category: str):
     if label:
         query = query.filter("topic_categories", "cs", json.dumps([label]))
     return (
-        query.eq("sync_status", "synced")
+        query.in_("sync_status", list(BROWSEABLE_SYNC_STATUSES))
         .not_.is_("channel_name", "null")
         .not_.is_("topic_categories", "null")
         .gt("current_subscribers", 0)
@@ -346,7 +347,7 @@ def _apply_topic_category_text_filters(query, category: str):
     if pattern:
         query = query.ilike("topic_categories", pattern)
     return (
-        query.eq("sync_status", "synced")
+        query.in_("sync_status", list(BROWSEABLE_SYNC_STATUSES))
         .not_.is_("channel_name", "null")
         .not_.is_("topic_categories", "null")
         .gt("current_subscribers", 0)

--- a/db_lists.py
+++ b/db_lists.py
@@ -328,17 +328,26 @@ def resolve_category_slug(slug: str) -> str | None:
     return fallback_label[0].upper() + fallback_label[1:]
 
 
-def _apply_topic_category_filters(query, category: str):
-    """Apply filters shared by category group cards and detail pages."""
-    label = _topic_category_label(category)
-    if label:
-        query = query.filter("topic_categories", "cs", json.dumps([label]))
+def _apply_browseable_constraints(query):
+    """Apply the four predicates shared by every topic-category query.
+
+    Centralised so that a change to BROWSEABLE_SYNC_STATUSES or the
+    standard row-quality filters only needs to happen in one place.
+    """
     return (
         query.in_("sync_status", list(BROWSEABLE_SYNC_STATUSES))
         .not_.is_("channel_name", "null")
         .not_.is_("topic_categories", "null")
         .gt("current_subscribers", 0)
     )
+
+
+def _apply_topic_category_filters(query, category: str):
+    """Apply filters shared by category group cards and detail pages."""
+    label = _topic_category_label(category)
+    if label:
+        query = query.filter("topic_categories", "cs", json.dumps([label]))
+    return _apply_browseable_constraints(query)
 
 
 def _apply_topic_category_text_filters(query, category: str):
@@ -346,12 +355,7 @@ def _apply_topic_category_text_filters(query, category: str):
     pattern = _topic_category_ilike_pattern(category)
     if pattern:
         query = query.ilike("topic_categories", pattern)
-    return (
-        query.in_("sync_status", list(BROWSEABLE_SYNC_STATUSES))
-        .not_.is_("channel_name", "null")
-        .not_.is_("topic_categories", "null")
-        .gt("current_subscribers", 0)
-    )
+    return _apply_browseable_constraints(query)
 
 
 def get_topic_category_creators(

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -79,6 +79,10 @@ class _FakeQuery:
         self._call.setdefault("eq", []).append(args)
         return self
 
+    def in_(self, *args):
+        self._call.setdefault("in_", []).append(args)
+        return self
+
     def is_(self, *args):
         self._call.setdefault("is", []).append(args)
         return self


### PR DESCRIPTION
_apply_topic_category_filters and _apply_topic_category_text_filters were filtering sync_status = 'synced' only. Migration 045 added 'synced_partial' to BROWSEABLE_SYNC_STATUSES but the Python-side filter helpers were never updated, silently excluding all synced_partial creators.

Result: every /lists/category/{slug} page returned 0 creators despite the /creators sidebar showing correct counts (327K+ for lifestyle-sociology, etc.) because /creators uses get_creators() from db.py which already uses BROWSEABLE_SYNC_STATUSES.

Fix: replace .eq("sync_status", "synced") with
.in_("sync_status", list(BROWSEABLE_SYNC_STATUSES)) in both filter helpers. Import BROWSEABLE_SYNC_STATUSES from constants. Add in_() method to _FakeQuery test mock.

Fixes all 61 /lists/category/* pages.

## Summary by Sourcery

Update category detail filters to include all browseable sync statuses so category pages return creators as expected.

Bug Fixes:
- Fix category detail pages returning zero creators by aligning sync_status filtering with BROWSEABLE_SYNC_STATUSES.

Tests:
- Extend the _FakeQuery test mock with an in_() method to support the updated filtering logic.