### PR TITLE
fix(mentions): downgrade YouTube RSS 404 logs from ERROR to DEBUG

### DIFF
--- a/services/mentions.py
+++ b/services/mentions.py
@@ -140,10 +140,35 @@ def fetch_recent_videos(channel_id: str, limit: int = 6) -> list[VideoItem]:
         with httpx.Client(timeout=8.0) as client:
             resp = client.get(url, headers={"User-Agent": "ViralVibesBot/1.0"})
             resp.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status == 404:
+            # Channel deleted, private, or terminated — expected for churned channels.
+            # Not an error: log at DEBUG so error monitors stay clean.
+            logger.debug(
+                "YouTube RSS 404 for channel %s — channel may be deleted or private",
+                channel_id,
+            )
+        elif status == 429:
+            logger.warning(
+                "YouTube RSS rate-limited (429) for channel %s — backing off",
+                channel_id,
+            )
+        else:
+            logger.warning(
+                "YouTube RSS HTTP %d for channel %s",
+                status,
+                channel_id,
+            )
+        return []
+    except httpx.TimeoutException:
+        logger.warning("YouTube RSS request timed out for channel %s", channel_id)
+        return []
     except Exception as exc:
         logger.error(
-            "Failed to fetch YouTube RSS feed",
-            extra={"channel_id": channel_id, "exception": repr(exc)},
+            "Failed to fetch YouTube RSS feed for channel %s: %r",
+            channel_id,
+            exc,
         )
         return []
 

--- a/services/mentions.py
+++ b/services/mentions.py
@@ -164,7 +164,7 @@ def fetch_recent_videos(channel_id: str, limit: int = 6) -> list[VideoItem]:
     except httpx.TimeoutException:
         logger.warning("YouTube RSS request timed out for channel %s", channel_id)
         return []
-    except Exception as exc:
+    except httpx.RequestError as exc:
         logger.error(
             "Failed to fetch YouTube RSS feed for channel %s: %r",
             channel_id,

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -7,6 +7,7 @@ All HTTP calls are stubbed — no network required.
 
 from __future__ import annotations
 
+import httpx
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
@@ -110,8 +111,6 @@ def test_fetch_recent_videos_respects_limit():
 
 
 def test_fetch_recent_videos_returns_empty_on_http_error():
-    import httpx
-
     mock_client = MagicMock()
     mock_client.__enter__ = MagicMock(return_value=mock_client)
     mock_client.__exit__ = MagicMock(return_value=False)
@@ -125,8 +124,6 @@ def test_fetch_recent_videos_returns_empty_on_http_error():
 
 def test_fetch_recent_videos_404_returns_empty_and_logs_debug():
     """404 is expected for deleted/private channels — must not log at ERROR."""
-    import httpx
-
     mock_client = MagicMock()
     mock_client.__enter__ = MagicMock(return_value=mock_client)
     mock_client.__exit__ = MagicMock(return_value=False)
@@ -143,8 +140,6 @@ def test_fetch_recent_videos_404_returns_empty_and_logs_debug():
 
 
 def test_fetch_recent_videos_timeout_returns_empty_and_logs_warning():
-    import httpx
-
     mock_client = MagicMock()
     mock_client.__enter__ = MagicMock(return_value=mock_client)
     mock_client.__exit__ = MagicMock(return_value=False)
@@ -214,8 +209,6 @@ def test_fetch_news_mentions_handles_title_without_source():
 
 
 def test_fetch_news_mentions_returns_empty_on_http_error():
-    import httpx
-
     mock_client = MagicMock()
     mock_client.__enter__ = MagicMock(return_value=mock_client)
     mock_client.__exit__ = MagicMock(return_value=False)

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -116,11 +116,45 @@ def test_fetch_recent_videos_returns_empty_on_http_error():
     mock_client.__enter__ = MagicMock(return_value=mock_client)
     mock_client.__exit__ = MagicMock(return_value=False)
     mock_client.get.side_effect = httpx.HTTPStatusError(
-        "404", request=MagicMock(), response=MagicMock(status_code=404)
+        "500", request=MagicMock(), response=MagicMock(status_code=500)
     )
     with patch("services.mentions.httpx.Client", return_value=mock_client):
         videos = fetch_recent_videos("UCbad", limit=6)
     assert videos == []
+
+
+def test_fetch_recent_videos_404_returns_empty_and_logs_debug():
+    """404 is expected for deleted/private channels — must not log at ERROR."""
+    import httpx
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.side_effect = httpx.HTTPStatusError(
+        "404", request=MagicMock(), response=MagicMock(status_code=404)
+    )
+    with patch("services.mentions.httpx.Client", return_value=mock_client):
+        with patch("services.mentions.logger") as mock_logger:
+            videos = fetch_recent_videos("UCM0QeKc-ozt38Fw-0hhhAFw", limit=6)
+    assert videos == []
+    mock_logger.error.assert_not_called()
+    mock_logger.debug.assert_called_once()
+    assert "404" in mock_logger.debug.call_args[0][0]
+
+
+def test_fetch_recent_videos_timeout_returns_empty_and_logs_warning():
+    import httpx
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.side_effect = httpx.TimeoutException("timed out")
+    with patch("services.mentions.httpx.Client", return_value=mock_client):
+        with patch("services.mentions.logger") as mock_logger:
+            videos = fetch_recent_videos("UCtest", limit=6)
+    assert videos == []
+    mock_logger.error.assert_not_called()
+    mock_logger.warning.assert_called_once()
 
 
 def test_fetch_recent_videos_returns_empty_on_malformed_xml():


### PR DESCRIPTION
YouTube returns 404 for deleted, private, or terminated channels. This is an expected condition for churned creators, not a real error. Treating it as ERROR flooded Vercel error monitors with false alarms.

- Split bare `except Exception` into typed handlers:
  - 404 → logger.debug (channel gone/private, not actionable)
  - 429 → logger.warning (rate-limited)
  - Other 4xx/5xx → logger.warning
  - Timeout → logger.warning
  - Unexpected exceptions → logger.error (unchanged)
- Add tests asserting 404 and timeout never reach logger.error

## Summary by Sourcery

Handle expected YouTube RSS failures more gracefully in mention fetching by downgrading certain conditions from errors and tightening exception handling.

Enhancements:
- Classify HTTP errors from YouTube RSS requests into specific handlers, logging 404 responses at debug level, 429 and other non-success statuses at warning, and reserving error logs for unexpected exceptions.
- Log timeouts for YouTube RSS requests as warnings instead of generic errors while still returning an empty video list on failure.

Tests:
- Add tests to verify that 404 HTTP errors log at debug level and never reach error logging when fetching recent videos.
- Add tests to verify that timeout errors log at warning level and never reach error logging when fetching recent videos.
- Adjust existing HTTP error test to cover non-404 server errors while ensuring an empty list is returned.