### PR TITLE
fix(db): recognize "deque mutated during iteration" as a retryable HT…

### DIFF
--- a/db.py
+++ b/db.py
@@ -82,7 +82,14 @@ def _is_transient_disconnect(exc: BaseException) -> bool:
         # RuntimeErrors are NOT wrapped into RemoteProtocolError so they bypass
         # the check above.  After such a failure httpcore drops the broken
         # connection; a retry gets a fresh one.
-        if isinstance(e, RuntimeError) and "iteration" in str(e) and "dictionary" in str(e):
+        # Also covers hpack/table.py: the HPACK dynamic table is a deque shared
+        # across multiplexed HTTP/2 streams; concurrent header encoding produces
+        # "deque mutated during iteration" — same class of bug, same fix.
+        if (
+            isinstance(e, RuntimeError)
+            and "iteration" in str(e)
+            and ("dictionary" in str(e) or "deque" in str(e))
+        ):
             return True
         # httpcore HTTP/2 stream-bookkeeping bug: a non-200 response (e.g.
         # 206 Partial Content) can cause _response_closed() to try to delete


### PR DESCRIPTION
…TP/2 error

The HPACK dynamic header table (hpack/table.py) uses a deque. Concurrent HTTP/2 streams sharing the same connection race to encode headers, mutating the deque while it's being iterated. This produces:

  RuntimeError: deque mutated during iteration

The existing _is_transient_disconnect guard already handled the analogous dict mutation ("dictionary changed size during iteration") from the h2 stream layer, but the string check required "dictionary" so the deque variant was not recognized as retryable — it propagated as an unhandled exception and spammed error logs.

Broaden the check to match both forms:

  "dictionary" in str(e) or "deque" in str(e)

Both errors are the same class of concurrent-write bug in the vendored HTTP/2 stack. httpcore drops the corrupt connection after either failure; a retry transparently opens a fresh one.

## Summary by Sourcery

Bug Fixes:
- Recognize "deque mutated during iteration" RuntimeErrors from the HTTP/2 HPACK header table as retryable transient disconnects alongside existing dictionary mutation errors.