### PR TITLE
Added get_country_creators() in db_lists.py , using the country-speci…

### DIFF
--- a/db/migrations/055_country_detail_index.sql
+++ b/db/migrations/055_country_detail_index.sql
@@ -1,0 +1,12 @@
+-- Speed up /lists/country/{country_code} detail pages.
+--
+-- The page filters by country_code, restricts to synced browseable rows, and
+-- orders by current_subscribers DESC.  A country-only partial index can still
+-- leave large countries such as US/IN sorting many rows before LIMIT applies;
+-- this composite index lets Postgres read the ranking order directly.
+
+CREATE INDEX IF NOT EXISTS idx_creators_country_subscribers_synced
+ON public.creators (country_code, current_subscribers DESC)
+WHERE sync_status = 'synced'
+  AND channel_name IS NOT NULL
+  AND current_subscribers > 0;

--- a/db_lists.py
+++ b/db_lists.py
@@ -231,6 +231,11 @@ class TopicCategoryPageResult(NamedTuple):
     total_count: int
 
 
+class CountryPageResult(NamedTuple):
+    creators: list[dict]
+    total_count: int
+
+
 # ---------------------------------------------------------------------------
 # Per-key TTL cache for category creator listings.
 # Key: (category_label, limit, offset, return_count)
@@ -250,11 +255,21 @@ _category_creators_cache: dict[tuple, tuple[float, _CategoryCreatorsValue]] = {}
 # Key: (category_label, country_code, limit, offset, return_count)
 _category_country_creators_cache: dict[tuple, tuple[float, _CategoryCreatorsValue]] = {}
 
+_CountryCreatorsValue = list[dict] | CountryPageResult
+
+# Key: (country_code, limit, offset, return_count)
+_country_creators_cache: dict[tuple, tuple[float, _CountryCreatorsValue]] = {}
+
 
 def clear_category_creators_cache() -> None:
     """Invalidate both category-creators caches (called after mv_category_counts refresh)."""
     _category_creators_cache.clear()
     _category_country_creators_cache.clear()
+
+
+def clear_country_creators_cache() -> None:
+    """Invalidate cached country detail pages."""
+    _country_creators_cache.clear()
 
 
 _CATEGORY_SLUG_CACHE_TTL_S = 60 * 60
@@ -664,6 +679,7 @@ def clear_top_countries_cache() -> None:
     """Clear this process's short-lived top-countries cache."""
     global _top_countries_cache
     _top_countries_cache = None
+    clear_country_creators_cache()
 
 
 def clear_top_languages_cache() -> None:
@@ -917,6 +933,88 @@ def get_creators_by_country(country_code: str, limit: int = 10) -> list[dict]:
     except Exception as e:
         logger.exception(f"Error fetching creators for country {country_code}: {e}")
         return []
+
+
+def get_country_creators(
+    country_code: str,
+    *,
+    limit: int = 20,
+    offset: int = 0,
+    return_count: bool = False,
+) -> list[dict] | CountryPageResult:
+    """
+    Paginated creator listing for a country detail page.
+
+    This intentionally mirrors the By Country preview cards: a creator is
+    listable when it has sync_status='synced', a country_code, channel_name,
+    and positive subscribers. The generic get_creators() path uses an IN() sync
+    filter and gracefully returns empty on filtered statement timeouts; for
+    large countries that made public country pages look empty even though the
+    country cards had creators.
+    """
+    import time as _time
+
+    normalized_country = str(country_code or "").strip().upper()
+    if len(normalized_country) != 2:
+        return CountryPageResult([], 0) if return_count else []
+
+    cache_key = (normalized_country, limit, offset, return_count)
+    now = _time.monotonic()
+    cached_entry = _country_creators_cache.get(cache_key)
+    if cached_entry is not None:
+        ts, cached = cached_entry
+        if now - ts < _CATEGORY_CREATORS_TTL_SECONDS:
+            return cached  # type: ignore[return-value]
+
+    supabase_client = _get_supabase_client()
+    if not supabase_client:
+        if cached_entry:
+            logger.warning(
+                "Supabase client unavailable in get_country_creators(%s) - serving stale cache",
+                normalized_country,
+            )
+            return cached_entry[1]  # type: ignore[return-value]
+        return CountryPageResult([], 0) if return_count else []
+
+    try:
+        query = (
+            supabase_client.table("creators")
+            .select("*", count="exact" if return_count else None)
+            .eq("country_code", normalized_country)
+            .eq("sync_status", "synced")
+            .not_.is_("channel_name", "null")
+            .gt("current_subscribers", 0)
+            .order("current_subscribers", desc=True)
+            .limit(limit)
+        )
+        if offset:
+            query = query.offset(offset)
+        response = query.execute()
+    except Exception:
+        if cached_entry:
+            logger.warning(
+                "Error fetching creators for country %s - serving stale cache (age %.0fs)",
+                normalized_country,
+                now - cached_entry[0],
+            )
+            return cached_entry[1]  # type: ignore[return-value]
+        logger.exception("Error fetching creators for country %s", normalized_country)
+        return CountryPageResult([], 0) if return_count else []
+
+    creators = response.data if response and response.data else []
+    total_count = (getattr(response, "count", 0) or 0) if return_count and response else 0
+
+    for idx, creator in enumerate(creators, 1):
+        creator["_rank"] = offset + idx
+
+    result: list[dict] | CountryPageResult
+    if return_count:
+        result = CountryPageResult(creators, total_count)
+    else:
+        result = creators
+
+    _country_creators_cache[cache_key] = (now, result)
+    return result
 
 
 def get_creators_by_category(category: str, limit: int = 10) -> list[dict]:

--- a/db_lists.py
+++ b/db_lists.py
@@ -255,10 +255,10 @@ _category_creators_cache: dict[tuple, tuple[float, _CategoryCreatorsValue]] = {}
 # Key: (category_label, country_code, limit, offset, return_count)
 _category_country_creators_cache: dict[tuple, tuple[float, _CategoryCreatorsValue]] = {}
 
-_CountryCreatorsValue = list[dict] | CountryPageResult
-
 # Key: (country_code, limit, offset, return_count)
-_country_creators_cache: dict[tuple, tuple[float, _CountryCreatorsValue]] = {}
+# Values are always stored as CountryPageResult (the canonical form).
+# When return_count=False, the list is extracted on return to match the function signature.
+_country_creators_cache: dict[tuple, tuple[float, CountryPageResult]] = {}
 
 
 def clear_category_creators_cache() -> None:
@@ -392,8 +392,6 @@ def get_topic_category_creators(
     pages never go blank.  ``clear_category_creators_cache()`` is called by
     ``refresh_hero_stats_cache()`` after ``mv_category_counts`` is refreshed.
     """
-    import time as _time
-
     if not category or not str(category).strip():
         return TopicCategoryPageResult([], 0) if return_count else []
 
@@ -404,7 +402,7 @@ def get_topic_category_creators(
         return TopicCategoryPageResult([], 0) if return_count else []
 
     cache_key = (category_label, limit, offset, return_count)
-    now = _time.monotonic()
+    now = time.monotonic()
     cached_entry = _category_creators_cache.get(cache_key)
     if cached_entry is not None:
         ts, cached = cached_entry
@@ -482,8 +480,6 @@ def get_topic_category_country_creators(
     return_count: bool = False,
 ) -> list[dict] | TopicCategoryPageResult:
     """Paginated creator listing for a topic category within one country."""
-    import time as _time
-
     if not category or not str(category).strip() or not country_code:
         return TopicCategoryPageResult([], 0) if return_count else []
 
@@ -495,7 +491,7 @@ def get_topic_category_country_creators(
         return TopicCategoryPageResult([], 0) if return_count else []
 
     cache_key = (category_label, normalized_country, limit, offset, return_count)
-    now = _time.monotonic()
+    now = time.monotonic()
     cached_entry = _category_country_creators_cache.get(cache_key)
     if cached_entry is not None:
         ts, cached = cached_entry
@@ -952,19 +948,18 @@ def get_country_creators(
     large countries that made public country pages look empty even though the
     country cards had creators.
     """
-    import time as _time
-
     normalized_country = str(country_code or "").strip().upper()
     if len(normalized_country) != 2:
         return CountryPageResult([], 0) if return_count else []
 
     cache_key = (normalized_country, limit, offset, return_count)
-    now = _time.monotonic()
+    now = time.monotonic()
     cached_entry = _country_creators_cache.get(cache_key)
     if cached_entry is not None:
-        ts, cached = cached_entry
+        ts, cached_result = cached_entry
         if now - ts < _CATEGORY_CREATORS_TTL_SECONDS:
-            return cached  # type: ignore[return-value]
+            # Cache always stores CountryPageResult; extract list if needed
+            return cached_result if return_count else cached_result.creators
 
     supabase_client = _get_supabase_client()
     if not supabase_client:
@@ -973,7 +968,8 @@ def get_country_creators(
                 "Supabase client unavailable in get_country_creators(%s) - serving stale cache",
                 normalized_country,
             )
-            return cached_entry[1]  # type: ignore[return-value]
+            cached_result = cached_entry[1]
+            return cached_result if return_count else cached_result.creators
         return CountryPageResult([], 0) if return_count else []
 
     try:
@@ -997,7 +993,8 @@ def get_country_creators(
                 normalized_country,
                 now - cached_entry[0],
             )
-            return cached_entry[1]  # type: ignore[return-value]
+            cached_result = cached_entry[1]
+            return cached_result if return_count else cached_result.creators
         logger.exception("Error fetching creators for country %s", normalized_country)
         return CountryPageResult([], 0) if return_count else []
 
@@ -1007,14 +1004,10 @@ def get_country_creators(
     for idx, creator in enumerate(creators, 1):
         creator["_rank"] = offset + idx
 
-    result: list[dict] | CountryPageResult
-    if return_count:
-        result = CountryPageResult(creators, total_count)
-    else:
-        result = creators
-
-    _country_creators_cache[cache_key] = (now, result)
-    return result
+    # Always store as CountryPageResult; extract on return to match function signature
+    cached_result = CountryPageResult(creators, total_count)
+    _country_creators_cache[cache_key] = (now, cached_result)
+    return cached_result if return_count else cached_result.creators
 
 
 def get_creators_by_category(category: str, limit: int = 10) -> list[dict]:

--- a/routes/lists.py
+++ b/routes/lists.py
@@ -11,6 +11,7 @@ from db import get_creators, get_user_favourite_list_keys
 from db_lists import (
     _count_distinct_languages,
     get_category_groups,
+    get_country_creators,
     get_country_groups,
     get_language_groups,
     get_lists_meta,
@@ -285,9 +286,8 @@ def _fetch_country_page(country_code: str, page: int) -> tuple[list, int, int]:
     Returns:
         ``(creators, total_count, total_pages)`` tuple.
     """
-    result = get_creators(
-        country_filter=country_code,
-        sort="subscribers",
+    result = get_country_creators(
+        country_code,
         limit=DETAIL_PAGE_LIMIT,
         offset=(page - 1) * DETAIL_PAGE_LIMIT,
         return_count=True,

--- a/tests/test_category_detail.py
+++ b/tests/test_category_detail.py
@@ -304,6 +304,27 @@ def test_get_topic_category_country_creators_filters_country_and_category(monkey
     assert call["order"]["args"] == ("current_subscribers",)
 
 
+def test_get_country_creators_filters_country_with_synced_status(monkeypatch):
+    fake_client = _FakeSupabaseClient(
+        {
+            "data": [{"channel_name": "US Channel", "current_subscribers": 100}],
+            "count": 1,
+        }
+    )
+    monkeypatch.setattr(db_lists, "_get_supabase_client", lambda: fake_client)
+    monkeypatch.setattr(db_lists, "_country_creators_cache", {})
+
+    result = db_lists.get_country_creators("us", limit=10, return_count=True)
+
+    assert result.total_count == 1
+    assert result.creators[0]["_rank"] == 1
+    call = fake_client.calls[0]
+    assert ("country_code", "US") in call["eq"]
+    assert ("sync_status", "synced") in call["eq"]
+    assert "in_" not in call
+    assert call["order"]["args"] == ("current_subscribers",)
+
+
 # ---------------------------------------------------------------------------
 # Cache behaviour tests
 # ---------------------------------------------------------------------------
@@ -377,6 +398,16 @@ def test_clear_category_creators_cache_clears_both_dicts(monkeypatch):
     assert db_lists._category_country_creators_cache == {}
 
 
+def test_clear_top_countries_cache_clears_country_detail_cache(monkeypatch):
+    monkeypatch.setattr(db_lists, "_top_countries_cache", (0.0, [("US", 1)]))
+    monkeypatch.setattr(db_lists, "_country_creators_cache", {"US": (0.0, [])})
+
+    db_lists.clear_top_countries_cache()
+
+    assert db_lists._top_countries_cache is None
+    assert db_lists._country_creators_cache == {}
+
+
 def test_fetch_category_page_uses_topic_categories_not_primary_category(monkeypatch):
     page_result = db_lists.TopicCategoryPageResult(
         creators=[{"channel_name": "Test Channel", "current_subscribers": 1000}],
@@ -399,6 +430,28 @@ def test_fetch_category_page_uses_topic_categories_not_primary_category(monkeypa
         "Lifestyle (sociology)",
         limit=20,
         offset=0,
+        return_count=True,
+    )
+
+
+def test_fetch_country_page_uses_country_specific_query(monkeypatch):
+    page_result = db_lists.CountryPageResult(
+        creators=[{"channel_name": "US Channel", "current_subscribers": 1000}],
+        total_count=42,
+    )
+
+    mock_get = MagicMock(return_value=page_result)
+    monkeypatch.setattr(lists_routes, "get_country_creators", mock_get)
+
+    creators, total_count, total_pages = lists_routes._fetch_country_page("us", page=2)
+
+    assert total_count == 42
+    assert total_pages == 3
+    assert len(creators) == 1
+    mock_get.assert_called_once_with(
+        "us",
+        limit=20,
+        offset=20,
         return_count=True,
     )
 


### PR DESCRIPTION
…fic query shape instead of generic get_creators().

Updated lists.py and its load-more path use that helper. Added a composite index for country_code + current_subscribers.This is the durable fix for large countries like US/India. Added focused tests .

## Summary by Sourcery

Introduce a dedicated country-specific creators listing for country detail pages backed by a targeted query and cache, and optimize it with a composite index.

New Features:
- Add get_country_creators() and CountryPageResult to support paginated country detail pages with counts.
- Wire lists country detail route to use the new country-specific creators helper instead of the generic listing.

Enhancements:
- Add a per-country creators cache and ensure it is invalidated when top countries cache is cleared to keep country pages fresh.

Build:
- Add a Postgres composite partial index on creators by country_code and current_subscribers for synced, browseable rows to speed up large-country detail pages.

Tests:
- Add tests covering the country-specific creators query, cache invalidation via clear_top_countries_cache, and the lists country page fetch path using the new helper.