### PR TITLE
feat(seo): add creator_profile_url() helper and use canonical @handle…

### DIFF
--- a/routes/creators.py
+++ b/routes/creators.py
@@ -48,6 +48,7 @@ from db_lists import (
 from controllers.auth_routes import require_auth
 from views.compare import render_compare_page
 from views.creators import (
+    creator_profile_url,
     render_add_creator_result,
     render_add_creator_status_result,
     render_creator_preview,
@@ -730,7 +731,7 @@ def blueprint_route(request, creator_id: str):
         )
 
     category = creator.get("primary_category", "")
-    back_url = request.query_params.get("from", f"/creator/{creator_id}")
+    back_url = request.query_params.get("from", creator_profile_url(creator))
 
     benchmarks = get_category_peer_benchmarks(category)
     signals = signals_from_row(

--- a/tests/test_creator_profile.py
+++ b/tests/test_creator_profile.py
@@ -202,7 +202,7 @@ class TestCreatorProfile:
         assert r.status_code == 200
         assert "<title>Test Channel YouTube Stats - ViralVibes</title>" in r.text
         assert 'rel="canonical"' in r.text
-        assert f'href="https://www.viralvibes.fyi/creator/{FAKE_CREATOR_UUID}"' in r.text
+        assert 'href="https://www.viralvibes.fyi/creators/@testchannel"' in r.text
         assert "Explore Test Channel" in r.text
         assert "YouTube stats:" in r.text
         assert 'property="og:image"' in r.text

--- a/views/blueprint.py
+++ b/views/blueprint.py
@@ -22,6 +22,7 @@ from monsterui.all import *
 
 from utils import format_number, safe_get_value
 from utils.blueprint import ActionResult, CreatorSignals
+from views.creators import creator_profile_url
 
 import logging
 
@@ -230,7 +231,7 @@ def render_blueprint_page(
     channel_name = safe_get_value(creator, "channel_name", "Creator")
     thumbnail = safe_get_value(creator, "channel_thumbnail_url") or "/static/favicon.jpeg"
     creator_id = safe_get_value(creator, "id", "")
-    profile_url = f"/creator/{creator_id}"
+    profile_url = creator_profile_url(creator)
 
     # Split actions: first scored action = free card; rest will be pro-gated.
     scored = [a for a in actions if a.score > 0]

--- a/views/creators.py
+++ b/views/creators.py
@@ -94,6 +94,19 @@ def _login_href(return_url: str = "/creators") -> str:
     return f"/login?{urlencode({'return_url': return_url})}"
 
 
+def creator_profile_url(creator: dict) -> str:
+    """Return the canonical profile URL for a creator.
+
+    Prefers /creators/@{handle} when custom_url is set; falls back to
+    /creator/{id} for creators without a YouTube handle.
+    """
+    handle = (creator.get("custom_url") or "").lstrip("@")
+    if handle:
+        return f"/creators/@{handle}"
+    creator_id = creator.get("id") or ""
+    return f"/creator/{creator_id}" if creator_id else "/creators"
+
+
 # Brand-accurate colours keyed by Lucide icon name
 _SOCIAL_COLOURS = {
     "instagram": "text-pink-500 hover:text-pink-600",
@@ -2552,7 +2565,7 @@ def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
         return card
     return A(
         card,
-        href=f"/creator/{creator_uuid}?name={quote(channel_name)}",
+        href=f"{creator_profile_url(creator)}?name={quote(channel_name)}",
         cls="block no-underline group min-w-0 w-full",
     )
 
@@ -3041,7 +3054,7 @@ def _render_similar_creators(
                     ),
                     cls="flex flex-col",
                 ),
-                href=f"/creator/{cid}",
+                href=creator_profile_url(c),
                 cls="no-underline",
             ),
             # ⇄ Compare link below the tile
@@ -3413,7 +3426,7 @@ def render_creator_profile_page(
                 A(
                     UkIcon("map", cls="w-4 h-4 mr-1"),
                     "Blueprint",
-                    href=f"/creator/{creator_id}/blueprint?from=/creator/{creator_id}&name={quote_plus(channel_name)}",
+                    href=f"/creator/{creator_id}/blueprint?from={creator_profile_url(creator)}&name={quote_plus(channel_name)}",
                     title="Growth Blueprint — Studio-grounded actions ranked by confidence",
                     cls="inline-flex items-center px-3 py-1.5 sm:px-4 sm:py-2 bg-primary/10 hover:bg-primary/20 text-primary text-xs sm:text-sm font-semibold rounded-lg no-underline transition-colors",
                 ),
@@ -4666,7 +4679,7 @@ def _creator_country_display_name(country_code: str) -> str:
 def creator_profile_head(creator: dict) -> tuple:
     """Return canonical, description, and social tags for a creator profile."""
     creator_id = safe_get_value(creator, "id", "")
-    path = f"/creator/{creator_id}" if creator_id else "/creators"
+    path = creator_profile_url(creator) if creator_id else "/creators"
     title = creator_profile_page_title(creator)
     name = safe_get_value(creator, "channel_name", "this creator")
     category = safe_get_value(creator, "primary_category", "")

--- a/views/creators.py
+++ b/views/creators.py
@@ -4679,7 +4679,7 @@ def _creator_country_display_name(country_code: str) -> str:
 def creator_profile_head(creator: dict) -> tuple:
     """Return canonical, description, and social tags for a creator profile."""
     creator_id = safe_get_value(creator, "id", "")
-    path = creator_profile_url(creator) if creator_id else "/creators"
+    path = creator_profile_url(creator)
     title = creator_profile_page_title(creator)
     name = safe_get_value(creator, "channel_name", "this creator")
     category = safe_get_value(creator, "primary_category", "")


### PR DESCRIPTION
… URLs in internal links

- Add creator_profile_url(creator) to views/creators.py — returns /creators/@{handle} when custom_url is set, falls back to /creator/{id}
- Use helper in creator card wrapper href, peer rail tiles, blueprint button from= param, and creator_profile_head() canonical path
- Update views/blueprint.py: profile_url now uses canonical handle URL
- Update routes/creators.py: blueprint back_url default uses handle URL

HTMX action endpoints (/creator/{id}/favourite) and status-callback links where only creator_id is available remain UUID-based; main.py's 301 redirect handles those transparently.

## Summary by Sourcery

Standardize creator profile links around a canonical helper so UI and SEO-facing URLs consistently use /creators/@handle when available, falling back to ID-based URLs.

New Features:
- Introduce a creator_profile_url() helper to generate the canonical profile URL for a creator.

Enhancements:
- Update creator cards, peer rail tiles, and blueprint CTA links to use the canonical creator_profile_url() helper instead of raw /creator/{id} URLs.
- Ensure creator_profile_head() and blueprint profile_url use the canonical handle-based profile URL for SEO consistency.
- Adjust the blueprint back_url default to use the canonical creator profile URL when no explicit from parameter is provided.