### PR TITLE
fix(seo): fix sitemap and auth to complete canonical @handle URL migr…

### DIFF
--- a/auth/auth_service.py
+++ b/auth/auth_service.py
@@ -48,6 +48,12 @@ AUTH_SKIP_ROUTE_PATTERNS: list[str] = [
     # Persistence (save/export) is soft-gated per-action, not at route level.
     "/creators",
     r"/creator/.*",
+    # Canonical handle-based creator profiles — must be crawlable by Google.
+    # re.search() means r"/creators/@" covers /creators/@handle and
+    # /creators/@handle/blueprint.  Without this, the OAuth middleware blocks
+    # unauthenticated access and Googlebot gets the login page instead of the
+    # canonical profile content, defeating the entire SEO URL migration.
+    r"/creators/@",
     "/lists",
     r"/lists/.*",
     "/analysis",

--- a/services/sitemap.py
+++ b/services/sitemap.py
@@ -46,11 +46,11 @@ STATIC_ROUTES: list[tuple[str, str, str]] = [
 
 
 def fetch_synced_creators(client) -> list:
-    """Return ``{id, last_updated_at}`` rows for all synced creators."""
+    """Return ``{id, custom_url, last_updated_at}`` rows for all synced creators."""
     try:
         resp = (
             client.table("creators")
-            .select("id, last_updated_at")
+            .select("id, custom_url, last_updated_at")
             .eq("sync_status", "synced")
             .execute()
         )
@@ -98,9 +98,11 @@ def build_sitemap_xml(
     """Build and return the complete sitemap XML string.
 
     Args:
-        creators: List of ``{id, last_updated_at}`` dicts for synced creators.
-                  Each becomes a ``/creator/{id}`` entry. Pass an empty list
-                  to emit static routes only (e.g. in CI when DB is offline).
+        creators: List of ``{id, custom_url, last_updated_at}`` dicts for synced
+                  creators. Each becomes a ``/creators/@{handle}`` entry when
+                  ``custom_url`` is set, or ``/creator/{id}`` as a fallback.
+                  Pass an empty list to emit static routes only (e.g. in CI
+                  when DB is offline).
         aplus_creators: Optional list of ``{custom_url, last_updated_at}``
                   dicts for A+ creators with a usable handle. Each becomes a
                   ``/creators/like/{handle}`` lookalike-page entry. Scoped to
@@ -129,8 +131,10 @@ def build_sitemap_xml(
         creator_id = creator.get("id")
         if not creator_id:
             continue
+        handle = (creator.get("custom_url") or "").lstrip("@").lower()
+        path = f"/creators/@{handle}" if handle else f"/creator/{creator_id}"
         url_el = ET.SubElement(urlset, "url")
-        ET.SubElement(url_el, "loc").text = urljoin(BASE_URL, f"/creator/{creator_id}")
+        ET.SubElement(url_el, "loc").text = urljoin(BASE_URL, path)
         ET.SubElement(url_el, "lastmod").text = _lastmod_or_today(creator, today)
         ET.SubElement(url_el, "changefreq").text = "weekly"
         ET.SubElement(url_el, "priority").text = "0.7"

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -8,7 +8,7 @@ because generate_sitemap.py falls back to empty lists when DB creds are absent.
 import xml.etree.ElementTree as ET
 
 from services.rankings import iter_ranking_sitemap_paths
-from services.sitemap import STATIC_ROUTES, build_sitemap_xml
+from services.sitemap import STATIC_ROUTES, build_sitemap_xml, fetch_synced_creators
 
 _NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
 
@@ -107,3 +107,61 @@ class TestBuildSitemapXml:
         aplus = [{"custom_url": "@handle", "last_updated_at": "2026-06-01"}]
         xml = build_sitemap_xml(creators, aplus_creators=aplus)
         ET.fromstring(xml)  # raises if not well-formed
+
+
+class TestFetchSyncedCreators:
+    """Contract tests for fetch_synced_creators — no real Supabase connection needed."""
+
+    def _make_client(self, rows):
+        """Return a fake Supabase client that records the SELECT projection."""
+        recorded = {}
+
+        class _Exe:
+            data = rows
+
+        class _Query:
+            def select(self_, cols):
+                recorded["cols"] = cols
+                return self_
+
+            def eq(self_, *_):
+                return self_
+
+            def execute(self_):
+                return _Exe()
+
+        class _Client:
+            def table(self_, *_):
+                return _Query()
+
+        return _Client(), recorded
+
+    def test_select_projection_includes_custom_url(self):
+        """The SELECT must include custom_url — without it all creators silently
+        fall back to UUID URLs in the sitemap, defeating the handle migration."""
+        client, recorded = self._make_client([])
+        fetch_synced_creators(client)
+        assert "custom_url" in recorded["cols"], (
+            f"fetch_synced_creators projected {recorded['cols']!r}; "
+            "expected 'custom_url' to be present"
+        )
+
+    def test_returned_rows_retain_custom_url(self):
+        """Rows returned by the client must pass through with custom_url intact."""
+        rows = [
+            {"id": "u1", "custom_url": "mrbeast", "last_updated_at": "2026-01-01"},
+            {"id": "u2", "custom_url": None, "last_updated_at": "2026-01-01"},
+        ]
+        client, _ = self._make_client(rows)
+        result = fetch_synced_creators(client)
+        assert result[0]["custom_url"] == "mrbeast"
+        assert result[1]["custom_url"] is None
+
+    def test_exception_returns_empty_list(self):
+        """Any DB error must be swallowed and return []."""
+
+        class _BadClient:
+            def table(self_, *_):
+                raise RuntimeError("connection refused")
+
+        assert fetch_synced_creators(_BadClient()) == []

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -28,7 +28,8 @@ class TestBuildSitemapXml:
         locs = _parse_locs(build_sitemap_xml([]))
         assert "https://www.viralvibes.fyi/rankings/gaming/united-states" in locs
 
-    def test_creator_urls_included(self):
+    def test_creator_urls_included_fallback_to_uuid(self):
+        """Creators without custom_url fall back to /creator/{id} entries."""
         creators = [
             {"id": "abc123", "last_updated_at": "2026-01-01T00:00:00+00:00"},
             {"id": "def456", "last_updated_at": "2026-06-15T12:00:00+00:00"},
@@ -36,6 +37,30 @@ class TestBuildSitemapXml:
         locs = _parse_locs(build_sitemap_xml(creators))
         assert any("/creator/abc123" in loc for loc in locs)
         assert any("/creator/def456" in loc for loc in locs)
+
+    def test_creator_with_handle_uses_handle_url(self):
+        """Creators with custom_url must emit /creators/@handle, not /creator/{id}."""
+        creators = [
+            {"id": "abc123", "custom_url": "mychannel", "last_updated_at": "2026-01-01"},
+            {"id": "def456", "custom_url": "@another", "last_updated_at": "2026-01-01"},
+        ]
+        locs = _parse_locs(build_sitemap_xml(creators))
+        assert any("/creators/@mychannel" in loc for loc in locs)
+        assert any("/creators/@another" in loc for loc in locs)
+        # UUID form must NOT appear — would confuse Google's canonical election
+        assert not any("/creator/abc123" in loc for loc in locs)
+        assert not any("/creator/def456" in loc for loc in locs)
+
+    def test_creator_mixed_handle_and_no_handle(self):
+        """Mixed batch: handle → @handle URL, no-handle → UUID fallback."""
+        creators = [
+            {"id": "uuid-1", "custom_url": "withhandle", "last_updated_at": "2026-01-01"},
+            {"id": "uuid-2", "custom_url": None, "last_updated_at": "2026-01-01"},
+        ]
+        locs = _parse_locs(build_sitemap_xml(creators))
+        assert any("/creators/@withhandle" in loc for loc in locs)
+        assert any("/creator/uuid-2" in loc for loc in locs)
+        assert not any("/creator/uuid-1" in loc for loc in locs)
 
     def test_aplus_lookalike_urls_included(self):
         """A+ creator handles produce /creators/like/{handle} entries."""


### PR DESCRIPTION
…ation

Sitemap
- fetch_synced_creators now selects custom_url in addition to id/lastmod
- build_sitemap_xml emits /creators/@{handle} for creators with a handle, falling back to /creator/{id} — makes the sitemap consistent with the canonical tags set by creator_profile_head() (PR2)
- Without this Google sides with the sitemap's UUID URL over the page's canonical tag, causing "Duplicate, Google chose different canonical" (105 pages) and "Alternate page with proper canonical tag" (710 pages)

Auth skip list
- Add explicit r"/creators/@" to AUTH_SKIP_ROUTE_PATTERNS so that the OAuth middleware does not block Googlebot on the new handle-based canonical URLs (/creators/@{handle} and /creators/@{handle}/blueprint)
- Existing plain-string "/creators" already matches via re.search but the explicit entry documents the intent and guards against anchored patterns

Tests
- Rename test_creator_urls_included → test_creator_urls_included_fallback_to_uuid
- Add test_creator_with_handle_uses_handle_url
- Add test_creator_mixed_handle_and_no_handle

All three SEO URL PRs must be deployed together:
  PR1 – routing (main.py canonical handle route + UUID redirects) PR2 – internal links (creator_profile_url helper + view/route updates) PR3 – this: sitemap + auth skip (makes migration visible to Google)

## Summary by Sourcery

Update sitemap and auth skip routes to use canonical handle-based creator URLs while retaining UUID fallbacks for creators without handles.

New Features:
- Emit /creators/@{handle} entries in the sitemap for creators with custom URLs, falling back to /creator/{id} when no handle is present.

Bug Fixes:
- Ensure Googlebot can crawl canonical handle-based creator profile and blueprint pages by exempting /creators/@ URLs from OAuth authentication.

Enhancements:
- Extend creator sitemap data to include custom_url and adjust URL generation to normalize handles and avoid duplicate UUID entries for handled creators.

Tests:
- Add and rename sitemap tests to cover handle-based creator URLs, UUID fallbacks, and mixed creator batches in the sitemap output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Creator sitemaps now use canonical handle-based URLs when available.
  * Creators without a custom URL continue to use their ID-based sitemap URL.
  * Handle-based creator profile pages are accessible without authentication.

* **Bug Fixes**
  * Improved sitemap URL generation for creators with and without custom handles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->