### PR TITLE
perf(homepage): add CDN cache headers for anonymous visitors

### DIFF
--- a/main.py
+++ b/main.py
@@ -492,7 +492,7 @@ def index(req, sess):
         "Discover and vet YouTube creators at scale. Filter by engagement rate, niche, "
         "country and audience quality. Built for brands and agencies."
     )
-    return Titled(
+    response = Titled(
         _homepage_title,
         Container(
             TopAlertBar(),
@@ -527,6 +527,22 @@ def index(req, sess):
             }
         ),
     )
+
+    # Cache at the CDN edge for anonymous visitors only.
+    # The homepage makes zero DB calls and renders identically for every
+    # logged-out user, so a longer TTL is safe.
+    # Authenticated users get a fresh response (different nav state).
+    # Vary: Cookie keeps logged-in and logged-out entries separate.
+    if not sess.get("auth"):
+        return HTMLResponse(
+            _render_page(response),
+            headers={
+                "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
+                "Vary": "Cookie",
+            },
+        )
+
+    return response
 
 
 @rt("/login")

--- a/main.py
+++ b/main.py
@@ -542,7 +542,10 @@ def index(req, sess):
             },
         )
 
-    return response
+    return HTMLResponse(
+        _render_page(response),
+        headers={"Cache-Control": "private, no-store"},
+    )
 
 
 @rt("/login")


### PR DESCRIPTION
Cache-Control: public, s-maxage=300, stale-while-revalidate=3600
Vary: Cookie

The homepage makes zero DB calls and renders identically for every logged-out user. With no cache header it hit the origin on every request; now the CDN serves it for 5 minutes with a 1-hour stale window.

Authenticated users get a fresh response (different nav state). Pattern mirrors /creators and /lists — already in production.

## Summary by Sourcery

Enhancements:
- Serve the homepage with public CDN caching and a short TTL for logged-out users, varying by Cookie to separate authenticated traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Enabled CDN edge caching for homepage content shown to signed-out visitors (improves load times).
  * Cached responses are reused for up to 5 minutes and refreshed in the background.
  * Signed-in visitors now receive non-cached, personalized homepage content to ensure privacy and freshness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->