### PR TITLE
fix(db): add sync_status=synced filter to get_top_rated_creators

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -838,6 +838,7 @@ def get_top_rated_creators(limit: int = 20) -> list[dict]:
         response = (
             supabase_client.table("creators")
             .select("*")
+            .eq("sync_status", "synced")
             .not_.is_("channel_name", "null")
             .gt("current_subscribers", 0)
             .order("current_subscribers", desc=True)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Filter top-rated creators to only include entries with sync_status set to 'synced' to avoid unsynced or invalid records.