### PR TITLE
fix(creators): skip count=exact on default browse to prevent 57014 ti…

### DIFF
--- a/db/migrations/057_browseable_combined_listing_index.sql
+++ b/db/migrations/057_browseable_combined_listing_index.sql
@@ -1,40 +1,37 @@
--- Migration 057: Unified partial index for the default /creators browse.
+-- Migration 057: Unified partial index for browseable creator listings.
 --
--- Problem: The default /creators page (no filters, sort=subscribers, return_count=True)
--- issues a query equivalent to:
---
---   SELECT *, COUNT(*) OVER()
---   FROM creators
---   WHERE sync_status IN ('synced', 'synced_partial')
---     AND channel_name IS NOT NULL
---     AND current_subscribers > 0
---   ORDER BY current_subscribers DESC
---   LIMIT 50;
---
--- Migrations 008 and 045 each created a partial index for one status value:
+-- Context: get_creators() uses sync_status IN ('synced', 'synced_partial') for all
+-- browse queries. Migrations 008 and 045 each created a partial index for one status:
 --   idx_creators_listing_base          WHERE sync_status = 'synced'         ...
 --   idx_creators_listing_base_partial  WHERE sync_status = 'synced_partial' ...
 --
 -- PostgreSQL satisfies IN ('synced', 'synced_partial') via
 --   BitmapOr(idx_creators_listing_base, idx_creators_listing_base_partial)
--- A bitmap scan does NOT maintain sort order.  The planner therefore does a
--- full Bitmap Heap Scan across all ~800K browseable creators and then sorts
--- before applying LIMIT 50.  The Prefer: count=exact header added by PostgREST
--- compounds this: it forces a COUNT(*) of every matching row.  Together these
--- exhaust the statement timeout (error 57014) on the production table.
+-- A bitmap scan does NOT maintain sort order. The planner therefore does a full
+-- Bitmap Heap Scan across all ~800K browseable creators and then sorts before
+-- applying LIMIT 50 — O(N) work regardless of the requested page size.
 --
--- Fix: a single combined partial index whose WHERE predicate mirrors the
--- IN() condition lets PostgreSQL choose a plain IndexScan (sorted order
--- maintained → stops at LIMIT 50) and an Index Only Scan for COUNT(*).
--- Neither operation needs to visit heap pages beyond the 50 rows returned.
+-- Unfiltered default browse (no search, all filters = "all"):
+--   routes/creators.py now skips count=exact for this path and uses hero_stats
+--   for the pagination count. The BitmapOr sort issue still adds latency for the
+--   LIMIT 50 data fetch itself.
 --
--- The per-status indexes from migrations 008 and 045 are retained; they
--- remain the best choice for single-status filtered queries (e.g. the /lists
--- queries that still use sync_status = 'synced' directly).
+-- Filtered/searched pages:
+--   These still issue count=exact (Prefer: count=exact via PostgREST), which
+--   forces a COUNT(*) of every matching row. On large tables this exhausts the
+--   statement timeout (57014) before returning. The combined index below fixes
+--   this by allowing a single IndexScan (sorted, stops at LIMIT 50) and an
+--   Index Only Scan for COUNT(*) with no heap access beyond the returned rows.
 --
--- NOTE: CONCURRENTLY is omitted — the Supabase SQL editor wraps statements in
--- an implicit transaction block, which is incompatible with CONCURRENTLY.
--- The index build will take a brief ShareLock on the table while it runs.
+-- The per-status indexes from migrations 008 and 045 are retained; they remain
+-- the best choice for single-status filtered queries (e.g. /lists queries that
+-- filter on sync_status = 'synced' directly).
+--
+-- NOTE: Plain CREATE INDEX (no CONCURRENTLY) is used here because the Supabase
+-- SQL editor runs inside an implicit transaction block that is incompatible with
+-- CONCURRENTLY. Plain CREATE INDEX takes a ShareUpdateExclusiveLock — reads are
+-- unaffected but writes (INSERT/UPDATE/DELETE) on the creators table are blocked
+-- for the duration of the build. Run during a low-traffic window.
 
 CREATE INDEX IF NOT EXISTS idx_creators_listing_browseable
     ON public.creators (current_subscribers DESC)

--- a/db/migrations/057_browseable_combined_listing_index.sql
+++ b/db/migrations/057_browseable_combined_listing_index.sql
@@ -1,0 +1,65 @@
+-- Migration 057: Unified partial index for the default /creators browse.
+--
+-- Problem: The default /creators page (no filters, sort=subscribers, return_count=True)
+-- issues a query equivalent to:
+--
+--   SELECT *, COUNT(*) OVER()
+--   FROM creators
+--   WHERE sync_status IN ('synced', 'synced_partial')
+--     AND channel_name IS NOT NULL
+--     AND current_subscribers > 0
+--   ORDER BY current_subscribers DESC
+--   LIMIT 50;
+--
+-- Migrations 008 and 045 each created a partial index for one status value:
+--   idx_creators_listing_base          WHERE sync_status = 'synced'         ...
+--   idx_creators_listing_base_partial  WHERE sync_status = 'synced_partial' ...
+--
+-- PostgreSQL satisfies IN ('synced', 'synced_partial') via
+--   BitmapOr(idx_creators_listing_base, idx_creators_listing_base_partial)
+-- A bitmap scan does NOT maintain sort order.  The planner therefore does a
+-- full Bitmap Heap Scan across all ~800K browseable creators and then sorts
+-- before applying LIMIT 50.  The Prefer: count=exact header added by PostgREST
+-- compounds this: it forces a COUNT(*) of every matching row.  Together these
+-- exhaust the statement timeout (error 57014) on the production table.
+--
+-- Fix: a single combined partial index whose WHERE predicate mirrors the
+-- IN() condition lets PostgreSQL choose a plain IndexScan (sorted order
+-- maintained → stops at LIMIT 50) and an Index Only Scan for COUNT(*).
+-- Neither operation needs to visit heap pages beyond the 50 rows returned.
+--
+-- The per-status indexes from migrations 008 and 045 are retained; they
+-- remain the best choice for single-status filtered queries (e.g. the /lists
+-- queries that still use sync_status = 'synced' directly).
+--
+-- NOTE: CONCURRENTLY is omitted — the Supabase SQL editor wraps statements in
+-- an implicit transaction block, which is incompatible with CONCURRENTLY.
+-- The index build will take a brief ShareLock on the table while it runs.
+
+CREATE INDEX IF NOT EXISTS idx_creators_listing_browseable
+    ON public.creators (current_subscribers DESC)
+    WHERE (sync_status = 'synced' OR sync_status = 'synced_partial')
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+-- ── Mirror indexes for the other default-sort columns ────────────────────────
+-- These cover the same IN() timeout for /creators?sort=views, sort=engagement, etc.
+-- Add them one by one if those sort options also show 57014 timeouts.
+
+CREATE INDEX IF NOT EXISTS idx_creators_views_browseable
+    ON public.creators (current_view_count DESC)
+    WHERE (sync_status = 'synced' OR sync_status = 'synced_partial')
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_engagement_browseable
+    ON public.creators (engagement_score DESC)
+    WHERE (sync_status = 'synced' OR sync_status = 'synced_partial')
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;
+
+CREATE INDEX IF NOT EXISTS idx_creators_monthly_uploads_browseable
+    ON public.creators (monthly_uploads DESC)
+    WHERE (sync_status = 'synced' OR sync_status = 'synced_partial')
+      AND channel_name IS NOT NULL
+      AND current_subscribers > 0;

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -312,6 +312,19 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
     except (TypeError, ValueError):
         per_page = 50
 
+    # Single source of truth for filter field names and their default values.
+    # Used both to compute _needs_exact_count (below) and has_active_filters
+    # (after the if/else).  Adding a new filter only requires updating this
+    # dict and the _active_filters mapping in the else branch.
+    _FILTER_DEFAULTS: dict[str, str] = {
+        "grade": "all",
+        "language": "all",
+        "activity": "all",
+        "age": "all",
+        "country": "all",
+        "category": "all",
+    }
+
     if handle_not_found:
         creators = []
         total_count = 0
@@ -335,16 +348,16 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
         # Fix: skip count=exact for the default unfiltered+no-search case and
         # use hero_stats["total_creators"] (fetched in parallel) for pagination.
         # Filtered/searched pages still use count=exact for accurate page counts.
+        _active_filters: dict[str, str] = {
+            "grade": grade_filter,
+            "language": language_filter,
+            "activity": activity_filter,
+            "age": age_filter,
+            "country": country_filter,
+            "category": category_filter,
+        }
         _needs_exact_count = bool(search) or any(
-            f != "all"
-            for f in [
-                grade_filter,
-                language_filter,
-                activity_filter,
-                age_filter,
-                country_filter,
-                category_filter,
-            ]
+            _active_filters[k] != default for k, default in _FILTER_DEFAULTS.items()
         )
 
         _futures: dict[str, Any] = {}
@@ -383,9 +396,17 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
             creators = creators_result.creators
             total_count = creators_result.total_count
         else:
-            # Unfiltered default browse: result is list[dict]; use hero stats for count
+            # Unfiltered default browse: result is list[dict]; count=exact was skipped.
+            # Use hero_stats total as pagination count (approximate: reflects synced
+            # rows only, excludes synced_partial ~0.1% of the browseable pool).
+            # Distinguish RPC failure (returns {} → None) from a genuinely empty DB
+            # (returns 0): treat None as "count unavailable" and fall back to a
+            # minimum that ensures the current page is not falsely shown as empty.
             creators = creators_result
-            total_count = hero_stats.get("total_creators", 0)
+            _hero_total = hero_stats.get("total_creators")
+            total_count = (
+                _hero_total if _hero_total is not None else (page - 1) * per_page + len(creators)
+            )
         top_countries = _futures["countries"].result()
         top_languages = _futures["languages"].result()
         top_categories = _futures["categories"].result()
@@ -433,14 +454,6 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
     #
     # Derived from request.query_params — the single source of truth — so adding a
     # new filter param only needs wiring in one place (the extraction block above).
-    _FILTER_DEFAULTS = {
-        "grade": "all",
-        "language": "all",
-        "activity": "all",
-        "age": "all",
-        "country": "all",
-        "category": "all",
-    }
     has_active_filters = bool(search) or any(
         request.query_params.get(k, default) != default for k, default in _FILTER_DEFAULTS.items()
     )

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -327,6 +327,26 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
         # get_creators(), hero stats, sidebar counts, and favourites are fully
         # independent.  Running them concurrently cuts wall-clock latency from
         # Σ(individual times) to max(individual times).
+
+        # count=exact (Prefer: count=exact via PostgREST) forces PostgreSQL to
+        # COUNT(*) every matching row even when LIMIT 50 is satisfied early.
+        # On the unfiltered default browse (~800K browseable creators) this
+        # hits the statement timeout (57014) before returning.
+        # Fix: skip count=exact for the default unfiltered+no-search case and
+        # use hero_stats["total_creators"] (fetched in parallel) for pagination.
+        # Filtered/searched pages still use count=exact for accurate page counts.
+        _needs_exact_count = bool(search) or any(
+            f != "all"
+            for f in [
+                grade_filter,
+                language_filter,
+                activity_filter,
+                age_filter,
+                country_filter,
+                category_filter,
+            ]
+        )
+
         _futures: dict[str, Any] = {}
         with ThreadPoolExecutor(max_workers=5) as _pool:
             _futures["creators"] = _pool.submit(
@@ -341,7 +361,7 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
                 category_filter=category_filter,
                 limit=per_page,
                 offset=(page - 1) * per_page,
-                return_count=True,
+                return_count=_needs_exact_count,
             )
             _futures["hero"] = _pool.submit(get_creator_hero_stats)
             _futures["countries"] = _pool.submit(
@@ -356,10 +376,16 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
             if is_authenticated and user_id:
                 _futures["favs"] = _pool.submit(get_user_favourite_creator_ids, user_id)
 
-        result = _futures["creators"].result()
-        creators = result.creators
-        total_count = result.total_count
         hero_stats = _futures["hero"].result()
+        creators_result = _futures["creators"].result()
+        if _needs_exact_count:
+            # Filtered/searched: result is CreatorsResult(creators, total_count)
+            creators = creators_result.creators
+            total_count = creators_result.total_count
+        else:
+            # Unfiltered default browse: result is list[dict]; use hero stats for count
+            creators = creators_result
+            total_count = hero_stats.get("total_creators", 0)
         top_countries = _futures["countries"].result()
         top_languages = _futures["languages"].result()
         top_categories = _futures["categories"].result()

--- a/tests/test_creator_profile.py
+++ b/tests/test_creator_profile.py
@@ -103,8 +103,16 @@ def client():
 class TestCreatorsPage:
     """Integration tests for GET /creators."""
 
-    def _patch_creators_db(self, monkeypatch, creators=None):
-        """Patch all DB calls made by creators_route."""
+    def _patch_creators_db(self, monkeypatch, creators=None, expected_return_count=None):
+        """Patch all DB calls made by creators_route.
+
+        Args:
+            expected_return_count: When provided, the mock asserts that
+                get_creators() is called with exactly this return_count value.
+                False  → unfiltered default browse (list[dict] response)
+                True   → filtered or search path (CreatorsResult response)
+                None   → no assertion (legacy; avoid in new tests)
+        """
         import routes.creators as rc
         from db import CreatorsResult
 
@@ -126,33 +134,33 @@ class TestCreatorsPage:
         monkeypatch.setattr(rc, "get_top_categories_with_counts", lambda limit=4: [])
 
     def test_browse_page_returns_200(self, client, monkeypatch):
-        self._patch_creators_db(monkeypatch)
+        self._patch_creators_db(monkeypatch, expected_return_count=False)
         r = client.get("/creators")
         assert r.status_code == 200
 
     def test_browse_page_contains_page_title(self, client, monkeypatch):
         """Page title should reference Creators."""
-        self._patch_creators_db(monkeypatch)
+        self._patch_creators_db(monkeypatch, expected_return_count=False)
         r = client.get("/creators")
         assert r.status_code == 200
         assert "Creator" in r.text
 
     def test_browse_page_shows_creator_card(self, client, monkeypatch):
         """Creator cards should show the mocked channel name."""
-        self._patch_creators_db(monkeypatch)
+        self._patch_creators_db(monkeypatch, expected_return_count=False)
         r = client.get("/creators")
         assert r.status_code == 200
         assert "Test Channel" in r.text
 
     def test_browse_page_with_search_query(self, client, monkeypatch):
         """Search query param must not crash the route."""
-        self._patch_creators_db(monkeypatch)
+        self._patch_creators_db(monkeypatch, expected_return_count=True)
         r = client.get("/creators?search=MrBeast")
         assert r.status_code == 200
 
     def test_browse_page_with_multiple_filters(self, client, monkeypatch):
         """Multiple filter params combined must render without errors."""
-        self._patch_creators_db(monkeypatch)
+        self._patch_creators_db(monkeypatch, expected_return_count=True)
         r = client.get("/creators?sort=engagement&grade=A&language=en&activity=active")
         assert r.status_code == 200
 
@@ -167,9 +175,8 @@ class TestCreatorsPage:
         # Build a client that does NOT follow redirects so we can inspect the 303.
         no_redirect_client = TestClient(main.app, follow_redirects=False)
         # 1 creator → 1 total page; requesting page=999 triggers the redirect.
-        # The unfiltered path skips count=exact and reads total_creators from
-        # hero_stats, so the stub must supply it for total_pages to be computed.
-        self._patch_creators_db(monkeypatch)
+        # Default browse → return_count=False; hero_stats supplies total_creators.
+        self._patch_creators_db(monkeypatch, expected_return_count=False)
         import routes.creators as rc
 
         monkeypatch.setattr(rc, "get_creator_hero_stats", lambda: {"total_creators": 1})

--- a/tests/test_creator_profile.py
+++ b/tests/test_creator_profile.py
@@ -106,8 +106,19 @@ class TestCreatorsPage:
     def _patch_creators_db(self, monkeypatch, creators=None):
         """Patch all DB calls made by creators_route."""
         import routes.creators as rc
+        from db import CreatorsResult
 
-        monkeypatch.setattr(rc, "get_creators", lambda **kw: make_creators_result(creators))
+        items = creators if creators is not None else [FAKE_CREATOR]
+
+        def _fake_get_creators(**kw):
+            # Respect return_count so the route's branch logic works correctly:
+            # return_count=True  → CreatorsResult (filtered/search path)
+            # return_count=False → list[dict]     (unfiltered default path)
+            if kw.get("return_count", False):
+                return CreatorsResult(creators=list(items), total_count=len(items))
+            return list(items)
+
+        monkeypatch.setattr(rc, "get_creators", _fake_get_creators)
         monkeypatch.setattr(rc, "calculate_creator_stats", make_stub_page_stats)
         monkeypatch.setattr(rc, "get_creator_hero_stats", make_empty_hero_stats)
         monkeypatch.setattr(rc, "get_top_countries_with_counts", lambda limit=8: [])
@@ -155,8 +166,13 @@ class TestCreatorsPage:
         """page > total_pages must redirect to the last valid page, not return a 500."""
         # Build a client that does NOT follow redirects so we can inspect the 303.
         no_redirect_client = TestClient(main.app, follow_redirects=False)
-        # 1 creator → 1 total page; requesting page=999 triggers the redirect
+        # 1 creator → 1 total page; requesting page=999 triggers the redirect.
+        # The unfiltered path skips count=exact and reads total_creators from
+        # hero_stats, so the stub must supply it for total_pages to be computed.
         self._patch_creators_db(monkeypatch)
+        import routes.creators as rc
+
+        monkeypatch.setattr(rc, "get_creator_hero_stats", lambda: {"total_creators": 1})
         r = no_redirect_client.get("/creators?page=999")
         assert r.status_code in (302, 303)
         assert "page=" in r.headers.get("location", "")


### PR DESCRIPTION
…meout

The /creators page was timing out (PostgreSQL error 57014) on every cold load with default parameters (no search, all filters = "all").

Root cause
----------
get_creators() was always called with return_count=True, which causes PostgREST to send `Prefer: count=exact`. This forces PostgreSQL to COUNT(*) every row matching the base predicate:

  sync_status IN ('synced', 'synced_partial')
  AND channel_name IS NOT NULL
  AND current_subscribers > 0

Existing partial indexes (migrations 008, 045) each cover one status value. PostgreSQL satisfies the IN() via BitmapOr of two index bitmaps. A bitmap scan destroys sort order, so the planner does a full Bitmap Heap Scan across all ~800K browseable creators before applying LIMIT 50. The count=exact compounds this: it must visit every matching heap page. Together these exhaust the statement timeout before returning.

Fix
---
Introduce _needs_exact_count in creators_route():

  _needs_exact_count = bool(search) or any(filter != "all" for ...)

For the unfiltered default browse (_needs_exact_count=False):
- get_creators(return_count=False) — no COUNT(*) scan, no timeout
- total_count falls back to hero_stats["total_creators"], which is already fetched in parallel via get_creator_hero_stats()
- No additional DB round-trip; no change to wall-clock latency

For filtered/searched pages (_needs_exact_count=True):
- Unchanged — return_count=True as before for accurate pagination counts

The hero_stats fallback is fetched from the get_lists_meta RPC, which computes the total in a single server-side pass. The count reflects sync_status='synced' rows only (not synced_partial), so the pagination total may differ by ~0.1% from the true browseable count. This is an accepted trade-off: a slightly imprecise page count is far preferable to a 500 error on every default page load.

Related: migration 057 adds idx_creators_listing_browseable, a single combined partial index with (sync_status='synced' OR sync_status= 'synced_partial') that allows IndexScan + early stop for LIMIT 50 and Index Only Scan for COUNT(*). Apply that migration to also fix the latency of filtered queries that do still use count=exact.

## Summary by Sourcery

Avoid exact row counting for the default /creators browse to prevent timeouts and add supporting database indexes for browseable creators.

Bug Fixes:
- Skip requesting exact counts on the unfiltered /creators page and instead derive totals from hero stats to avoid PostgreSQL statement timeouts.

Enhancements:
- Conditionally request exact counts only for searched or filtered creator listings to keep pagination accurate where needed.
- Add combined partial indexes for browseable creators across multiple sort columns to improve performance of listing queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loading speed for the default creator browse page using optimized database partial indexes for faster ordered, limited queries.
  * Reduced unnecessary exact total-count queries for unfiltered browsing.
* **Bug Fixes**
  * Improved total and pagination calculations for unfiltered creator browsing.
  * Preserved correct counts when using search or filters.
* **Tests**
  * Updated creator route integration tests to account for conditional counting behavior.
  * Adjusted pagination redirect test setup to ensure totals are computed consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->