### PR TITLE
feat: soft auth modal on creator profile + fix /blog 404

### DIFF
--- a/components/modals.py
+++ b/components/modals.py
@@ -273,6 +273,7 @@ def AuthModal(
                         ),
                         H2(
                             "One click away.",
+                            id=f"{modal_id}-heading",
                             cls="text-2xl font-bold text-white leading-tight",
                         ),
                         P(
@@ -343,6 +344,9 @@ def AuthModal(
                     "w-full max-w-sm mx-4 "
                     "animate-in fade-in zoom-in-95 duration-200"
                 ),
+                role="dialog",
+                aria_modal="true",
+                aria_labelledby=f"{modal_id}-heading",
             ),
             onclick=f"if(event.target===this){{{close_js}}}",
             cls=(
@@ -350,7 +354,23 @@ def AuthModal(
                 "bg-gray-900/60 backdrop-blur-sm animate-in fade-in duration-200"
             ),
         ),
-        Script(f"document.getElementById('{modal_id}').classList.remove('hidden')"),
+        Script(
+            f"""
+(function() {{
+    var el = document.getElementById('{modal_id}');
+    el.classList.remove('hidden');
+    var closeBtn = el.querySelector('button[aria-label="Close"]');
+    if (closeBtn) {{ closeBtn.focus(); }}
+    function _onKey(e) {{
+        if (e.key === 'Escape') {{
+            {close_js};
+            document.removeEventListener('keydown', _onKey);
+        }}
+    }}
+    document.addEventListener('keydown', _onKey);
+}})();
+"""
+        ),
         id=modal_id,
         cls="modal-container hidden",
     )

--- a/components/modals.py
+++ b/components/modals.py
@@ -2,6 +2,8 @@
 Reusable modal components with modern glass effects and animations.
 """
 
+from urllib.parse import urlencode
+
 from fasthtml.common import *
 from monsterui.all import *
 
@@ -203,4 +205,152 @@ def ExportModal(dashboard_id: str, playlist_name: str, modal_id: str = "export-m
             cls="grid grid-cols-1 md:grid-cols-3 gap-4",
         ),
         modal_id=modal_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AuthModal — soft sign-in gate
+# ---------------------------------------------------------------------------
+# Shown in-place (HTMX OOB) when an anonymous user tries a protected action
+# such as saving a creator.  Replaces the hard 401 redirect with a contextual
+# "here is what you unlock" overlay that lets them stay on the page.
+# ---------------------------------------------------------------------------
+
+_AUTH_BENEFITS = [
+    ("heart", "Save creators to your personal watchlist"),
+    ("mail", "Access extracted contact emails"),
+    ("download", "Export CSV for outreach campaigns"),
+    ("git-compare", "Compare any two creators side by side"),
+]
+
+
+def AuthModal(
+    *,
+    modal_id: str = "auth-modal",
+    return_url: str = "/creators",
+    context_label: str = "Sign in to save creators",
+):
+    """Soft auth gate modal — shown instead of a hard /login redirect.
+
+    Displays the four key benefits of a free ViralVibes account, a Google
+    sign-in CTA, and a "Maybe later" dismiss link.  Designed to be injected
+    via HTMX ``hx-swap-oob`` into a ``<div id="auth-modal-mount">`` already
+    present on the page so no full reload is needed.
+
+    Args:
+        modal_id:      DOM id for the modal wrapper (default ``auth-modal``).
+        return_url:    After successful login, redirect back to this URL.
+        context_label: Short phrase shown above the headline, e.g.
+                       "Sign in to save this creator".
+    """
+    from components.auth_components import GoogleGLogo  # lazy — avoids circular import
+
+    login_href = f"/login?{urlencode({'return_url': return_url})}"
+    close_js = f"document.getElementById('{modal_id}').classList.add('hidden')"
+
+    def _benefit(icon: str, text: str):
+        return Div(
+            Div(
+                UkIcon(icon, cls="w-4 h-4 text-blue-600"),
+                cls="flex-shrink-0 w-8 h-8 rounded-full bg-blue-50 flex items-center justify-center",
+            ),
+            P(text, cls="text-sm text-foreground leading-snug"),
+            cls="flex items-center gap-3",
+        )
+
+    return Div(
+        # ── Backdrop ──────────────────────────────────────────────────────────
+        Div(
+            # ── Panel ─────────────────────────────────────────────────────────
+            Div(
+                # Header band — gradient accent
+                Div(
+                    Div(
+                        # Eyebrow
+                        P(
+                            context_label,
+                            cls="text-xs font-mono uppercase tracking-[0.16em] text-blue-200 mb-2",
+                        ),
+                        H2(
+                            "One click away.",
+                            cls="text-2xl font-bold text-white leading-tight",
+                        ),
+                        P(
+                            "Free forever — no credit card required.",
+                            cls="text-sm text-blue-100 mt-1",
+                        ),
+                        cls="",
+                    ),
+                    # Close button (top-right)
+                    Button(
+                        UkIcon("x", cls="w-4 h-4"),
+                        onclick=close_js,
+                        type="button",
+                        aria_label="Close",
+                        cls=(
+                            "absolute top-4 right-4 p-1.5 rounded-lg "
+                            "text-blue-200 hover:text-white hover:bg-white/10 transition-colors"
+                        ),
+                    ),
+                    cls=(
+                        "relative px-6 py-6 "
+                        "bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-700 "
+                        "rounded-t-xl"
+                    ),
+                ),
+                # Body
+                Div(
+                    # What you unlock
+                    P(
+                        "After signing in you can:",
+                        cls="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-4",
+                    ),
+                    Div(
+                        *[_benefit(icon, text) for icon, text in _AUTH_BENEFITS],
+                        cls="flex flex-col gap-3 mb-6",
+                    ),
+                    # Google CTA
+                    A(
+                        GoogleGLogo(18),
+                        Span("Continue with Google", cls="ml-2 text-sm font-semibold"),
+                        href=login_href,
+                        cls=(
+                            "flex items-center justify-center w-full px-4 py-3 "
+                            "bg-white border border-gray-200 hover:border-gray-300 "
+                            "hover:shadow-md text-gray-800 rounded-lg transition-all "
+                            "no-underline"
+                        ),
+                    ),
+                    # Footer row
+                    Div(
+                        Span(
+                            UkIcon("lock", cls="w-3 h-3 mr-1 inline"),
+                            "Secure Google sign-in",
+                            cls="text-xs text-muted-foreground",
+                        ),
+                        Button(
+                            "Maybe later",
+                            onclick=close_js,
+                            type="button",
+                            cls="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 bg-transparent border-0 cursor-pointer",
+                        ),
+                        cls="flex items-center justify-between mt-4",
+                    ),
+                    cls="px-6 py-5",
+                ),
+                cls=(
+                    "relative bg-background rounded-xl shadow-2xl "
+                    "w-full max-w-sm mx-4 "
+                    "animate-in fade-in zoom-in-95 duration-200"
+                ),
+            ),
+            onclick=f"if(event.target===this){{{close_js}}}",
+            cls=(
+                "fixed inset-0 z-50 flex items-center justify-center "
+                "bg-gray-900/60 backdrop-blur-sm animate-in fade-in duration-200"
+            ),
+        ),
+        Script(f"document.getElementById('{modal_id}').classList.remove('hidden')"),
+        id=modal_id,
+        cls="modal-container hidden",
     )

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -45,7 +45,7 @@ from db_lists import (
 )
 
 # from services.youtube_backend_api import YouTubeBackendAPI
-from controllers.auth_routes import require_auth
+from controllers.auth_routes import require_auth, safe_local_return_url
 from views.compare import render_compare_page
 from views.creators import (
     creator_profile_url,
@@ -652,8 +652,11 @@ def toggle_favourite_route(request, sess, creator_id: str):
     favourited it is removed.  Returns the updated FavouriteButton fragment
     so HTMX can swap it in-place.
 
-    AUTH: Requires a valid session (``sess['auth']``).  Returns 401 when the
-    user is not logged in.
+    AUTH: When the session carries no ``auth`` token the endpoint returns an
+    HTMX OOB tuple: the unchanged heart button (primary swap) and an
+    ``AuthModal`` injected into ``#auth-modal-mount`` so no hard redirect
+    is needed.  Authenticated users with a missing ``user_id`` still receive
+    a 401 to guard the DB helpers.
     """
     from views.creators import render_favourite_button
 
@@ -665,7 +668,9 @@ def toggle_favourite_route(request, sess, creator_id: str):
 
         # Return the unchanged button as the primary HTMX swap target, and
         # inject the auth modal out-of-band so no hard redirect is needed.
-        return_url = request.headers.get("referer", "/creators")
+        # safe_local_return_url strips scheme/host and rejects external URLs,
+        # preventing an open-redirect via a spoofed Referer header.
+        return_url = safe_local_return_url(request.headers.get("referer"), default="/creators")
         return (
             render_favourite_button(creator_id, is_favourited=False),
             Div(

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -661,7 +661,22 @@ def toggle_favourite_route(request, sess, creator_id: str):
     user_id = sess.get("user_id") if sess else None
     auth_error = require_auth(auth)
     if auth_error:
-        return Response("Authentication required", status_code=401)
+        from components.modals import AuthModal
+
+        # Return the unchanged button as the primary HTMX swap target, and
+        # inject the auth modal out-of-band so no hard redirect is needed.
+        return_url = request.headers.get("referer", "/creators")
+        return (
+            render_favourite_button(creator_id, is_favourited=False),
+            Div(
+                AuthModal(
+                    return_url=return_url,
+                    context_label="Sign in to save this creator",
+                ),
+                id="auth-modal-mount",
+                hx_swap_oob="innerHTML",
+            ),
+        )
     # In test mode require_auth is skipped; use a sentinel user_id so tests
     # that supply a session work, and tests that don't still get a predictable id.
     if not user_id and _IS_TESTING:

--- a/views/creators.py
+++ b/views/creators.py
@@ -4624,6 +4624,10 @@ def render_creator_profile_page(
         embedding_peers_section,
         box_plot_section,
         footer_section,
+        # HTMX OOB injection point for the soft auth modal (e.g. unauthenticated
+        # heart-button click).  Starts empty; populated server-side via
+        # hx-swap-oob="innerHTML" when toggle_favourite_route detects no session.
+        Div(id="auth-modal-mount"),
         cls="max-w-5xl mx-auto px-4 pb-16 pt-6",
     )
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -834,6 +834,10 @@ def render_creators_page(
             if creators
             else _render_empty_state(search, grade_filter, has_active_filters, is_authenticated)
         ),
+        # HTMX OOB injection point for the soft auth modal — creator cards on
+        # this page also POST to /creator/{id}/favourite, so the mount must
+        # exist here too (same OOB target as the profile page).
+        Div(id="auth-modal-mount"),
         cls=ContainerT.xl,
     )
 


### PR DESCRIPTION
Unauthenticated users who click Save/Heart on a creator profile no longer receive a bare 401. Instead, the favourite endpoint returns an HTMX OOB tuple: the unchanged heart button (primary swap) + an AuthModal injected into #auth-modal-mount, showing four unlock benefits and a Google sign-in CTA. Post-login return_url comes from the Referer header so users land back on the same creator profile.

Also registers @rt("/blog") to fix the footer 404 — every public page footer linked /blog but no route existed.

- components/modals.py: AuthModal with gradient header + benefit list
- routes/creators.py: toggle_favourite_route OOB response for anon users
- views/creators.py: add #auth-modal-mount injection point to profile
- routes/blog.py + main.py: /blog coming-soon page

## Summary by Sourcery

Introduce a soft authentication modal for protected actions on creator profiles and add a basic /blog route to avoid broken footer links.

New Features:
- Show a contextual AuthModal with sign-in benefits and Google login when unauthenticated users try to favourite a creator instead of returning a hard 401.
- Provide an HTMX out-of-band injection point on creator profile pages for rendering the auth modal without a full page reload.
- Add a simple /blog route to serve a coming-soon page for the blog.

Bug Fixes:
- Resolve 404 errors from the /blog footer link by registering a matching route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-page “soft auth gate” sign-in modal when unauthenticated visitors attempt to favorite/save creators.
  * The modal highlights sign-in benefits, includes a “Continue with Google” option, and a “Maybe later” dismissal.
  * After sign-in, users are returned to the page they came from when available.

* **Bug Fixes**
  * Replaced the plain authentication error response with an HTMX-friendly modal flow instead of blocking the action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->