### PR TITLE
fix: sync_status filter on get_veteran_creators + update creator coun…

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -1413,6 +1413,7 @@ def get_veteran_creators(limit: int = 20) -> list[dict]:
             .not_.is_("channel_name", "null")
             .gt("current_subscribers", 0)
             .gte("channel_age_days", 3650)  # 10 years
+            .eq("sync_status", "synced")
             .order("current_subscribers", desc=True)
             .limit(limit)
             .execute()

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -22,4 +22,5 @@ pytest-asyncio
 beautifulsoup4
 python-dotenv
 stripe>=11.0.0
+python-frontmatter
 Pillow>10.0.0


### PR DESCRIPTION
…t copy

- get_veteran_creators was missing .eq("sync_status", "synced"), causing un-synced/stale creators to appear in the veterans list

## Summary by Sourcery

Bug Fixes:
- Filter veteran creator results by sync_status = 'synced' to exclude unsynced or stale creators from the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated veteran creator listings to include only records with a completed sync status, improving result accuracy.

* **Chores**
  * Added backend support for processing front matter in content files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->