### PR TITLE
feat: replace auth warning alerts with sign-in nudge cards (PR2)

### DIFF
--- a/components/modals.py
+++ b/components/modals.py
@@ -374,3 +374,64 @@ def AuthModal(
         id=modal_id,
         cls="modal-container hidden",
     )
+
+
+# ---------------------------------------------------------------------------
+# SignInNudge — inline sign-in invitation card
+# ---------------------------------------------------------------------------
+# Used wherever an unauthenticated user tries to take a protected action
+# (playlist analysis, suggest a creator, etc.).  Unlike AuthModal it is not
+# a floating overlay — it renders inline inside the HTMX swap target so the
+# rest of the page stays visible and the prompt feels like a natural next step
+# rather than a hard gate.
+# ---------------------------------------------------------------------------
+
+
+def SignInNudge(
+    *,
+    context_label: str = "Sign in to continue",
+    return_url: str = "/login",
+) -> Div:
+    """Compact inline sign-in card returned by HTMX action endpoints.
+
+    Args:
+        context_label: Short phrase describing why sign-in is needed, e.g.
+                       ``"Sign in to analyse playlists"``.
+        return_url:    URL the login flow redirects back to after auth.
+    """
+    from components.auth_components import GoogleGLogo  # lazy — avoids circular import
+
+    login_href = f"/login?{urlencode({'return_url': return_url})}"
+
+    return Div(
+        # Thin gradient header strip
+        Div(
+            P(
+                context_label,
+                cls="text-xs font-mono uppercase tracking-[0.14em] text-white/90",
+            ),
+            cls=("px-4 py-2.5 " "bg-gradient-to-r from-blue-600 to-indigo-600 " "rounded-t-xl"),
+        ),
+        # Body
+        Div(
+            P(
+                "Free forever — no credit card required.",
+                cls="text-sm text-muted-foreground mb-4",
+            ),
+            A(
+                GoogleGLogo(18),
+                Span("Continue with Google", cls="ml-2 text-sm font-semibold"),
+                href=login_href,
+                cls=(
+                    "flex items-center justify-center w-full px-4 py-2.5 "
+                    "bg-white border border-gray-200 hover:border-gray-300 "
+                    "hover:shadow-sm text-gray-800 rounded-lg transition-all no-underline"
+                ),
+            ),
+            cls="px-4 py-4",
+        ),
+        cls=(
+            "rounded-xl border border-border bg-background shadow-sm "
+            "max-w-xs mx-auto my-4 overflow-hidden"
+        ),
+    )

--- a/controllers/auth_routes.py
+++ b/controllers/auth_routes.py
@@ -102,25 +102,31 @@ def build_logout_response():
     return response
 
 
-def require_auth(auth, error_message="Please log in.", skip_in_tests=True):
+def require_auth(
+    auth, context_label="Sign in to continue", return_url="/login", skip_in_tests=True
+):
     """
     Check if user is authenticated.
-    Returns alert if not authenticated.
+    Returns a SignInNudge card if not authenticated, None if authenticated.
 
     Args:
-        auth: Authentication data from session
-        error_message: Custom error message
-        skip_in_tests: If True, skip auth check when TESTING=1 (default: True)
+        auth:           Authentication data from session.
+        context_label:  Short phrase shown at the top of the nudge card,
+                        e.g. "Sign in to analyse playlists".
+        return_url:     After login the user is redirected here.
+        skip_in_tests:  If True, bypass auth check when TESTING=1 (default True).
 
     Returns:
-        Alert if not authenticated, None if authenticated
+        SignInNudge Div if not authenticated, None if authenticated.
     """
     # ✅ In test mode, bypass auth check
     if skip_in_tests and os.getenv("TESTING") == "1":
         return None  # Auth passed
 
     if not auth:
-        return Alert(P(error_message), cls=AlertT.warning)
+        from components.modals import SignInNudge  # lazy — avoids circular import
+
+        return SignInNudge(context_label=context_label, return_url=return_url)
     return None
 
 

--- a/main.py
+++ b/main.py
@@ -873,11 +873,12 @@ def validate_full(
 
     # Check auth
     if not (sess and sess.get("auth")):
-        sess["intended_url"] = str(req.url.path)
-        return Alert(
-            P("Please log in to analyze playlists."),
-            A("Log in", href="/login", cls=f"{ButtonT.primary}"),
-            cls=AlertT.warning,
+        sess["intended_url"] = "/analysis"
+        from components.modals import SignInNudge
+
+        return SignInNudge(
+            context_label="Sign in to analyse playlists",
+            return_url="/analysis",
         )
 
     # --- Check if this is an HTMX sort request BEFORE streaming ---
@@ -1146,7 +1147,7 @@ def check_job_status(playlist_url: str, req, sess):
     auth = sess.get("auth") if sess else None
 
     # Use existing require_auth
-    auth_error = require_auth(auth)
+    auth_error = require_auth(auth, return_url="/analysis")
     if auth_error:
         return auth_error
 
@@ -2025,7 +2026,8 @@ async def add_creator(req, sess):
 
     if not auth:
         logger.warning("[AddCreator] Unauthorized submission attempt")
-        return Response("Authentication required", status_code=401)
+        sess["intended_url"] = "/creators"
+        return RedirectResponse("/login", status_code=303)
 
     if not user_id:
         logger.warning("[AddCreator] User auth present but no user_id")

--- a/main.py
+++ b/main.py
@@ -873,12 +873,13 @@ def validate_full(
 
     # Check auth
     if not (sess and sess.get("auth")):
-        sess["intended_url"] = "/analysis"
+        if sess:
+            sess["intended_url"] = str(req.url.path)
         from components.modals import SignInNudge
 
         return SignInNudge(
             context_label="Sign in to analyse playlists",
-            return_url="/analysis",
+            return_url=str(req.url.path),
         )
 
     # --- Check if this is an HTMX sort request BEFORE streaming ---
@@ -2026,7 +2027,8 @@ async def add_creator(req, sess):
 
     if not auth:
         logger.warning("[AddCreator] Unauthorized submission attempt")
-        sess["intended_url"] = "/creators"
+        if sess:
+            sess["intended_url"] = "/creators"
         return RedirectResponse("/login", status_code=303)
 
     if not user_id:

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -816,12 +816,9 @@ async def creator_request_route(request, sess):
     Returns an inline HTMX partial (no full page reload).
     """
     auth = sess.get("auth") if sess else None
-    auth_error = require_auth(auth)
+    auth_error = require_auth(auth, "Sign in to suggest creators", return_url="/creators")
     if auth_error:
-        return render_add_creator_result(
-            success=False,
-            message="You must be logged in to submit a creator.",
-        )
+        return auth_error
 
     user_id = sess.get("user_id") if sess else None
 

--- a/routes/dashboard.py
+++ b/routes/dashboard.py
@@ -257,7 +257,7 @@ def my_dashboards(request: Request, sess) -> Div:
     """
     # Check authentication
     auth = sess.get("auth")
-    auth_error = require_auth(auth, "Please log in to view your dashboards.")
+    auth_error = require_auth(auth, "Sign in to view your dashboards", return_url="/me/dashboards")
     if auth_error:
         return auth_error
 
@@ -356,7 +356,7 @@ def user_profile(request: Request, sess) -> Div:
     """
     # Check authentication
     auth = sess.get("auth")
-    auth_error = require_auth(auth, "Please log in to view your profile.")
+    auth_error = require_auth(auth, "Sign in to view your profile", return_url="/me/favourites")
     if auth_error:
         return auth_error
 


### PR DESCRIPTION
- Add SignInNudge component: compact inline invitation card (not a modal) with gradient header, "Free forever" copy, and Google sign-in button
- require_auth() now returns SignInNudge instead of AlertT.warning; add context_label + return_url params for contextual copy per surface
- Fix /creators/add silent 401 → 303 redirect to /login with intent preserved
- Replace /validate/full inline alert with SignInNudge
- Update analysis polling routes, dashboard routes, and suggest-a-creator route with surface-specific context labels and return URLs

## Summary by Sourcery

Replace generic auth warning alerts with inline sign-in nudge cards and align protected routes with intent-preserving login redirects.

New Features:
- Introduce a reusable SignInNudge inline card component for prompting unauthenticated users to sign in across protected actions.

Bug Fixes:
- Correct unauthenticated /creators/add submissions to redirect to the login flow with the creator dashboard intent preserved instead of returning a silent 401.

Enhancements:
- Update require_auth to return context-aware SignInNudge cards with configurable labels and post-login return URLs.
- Apply SignInNudge to playlist analysis, creator suggestion, and dashboard/profile routes with surface-specific messaging and redirect targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual sign-in prompts for protected actions.
  * Google sign-in links now return visitors to their intended destination.
* **Bug Fixes**
  * Standardized authentication handling across playlist analysis, creator requests, dashboards, and profiles.
  * Replaced inconsistent login alerts and error responses with a unified sign-in experience.
  * Preserved return destinations for analysis, creator, dashboard, and favourites pages after sign-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->