### PR TITLE
feat: blueprint sign-in CTA for logged-out visitors

### DIFF
--- a/main.py
+++ b/main.py
@@ -1981,8 +1981,9 @@ def creator_blueprint(req, sess, creator_id: str):
                ├─ score_all_actions(signals)             ← utils/blueprint.py
                └─ render_blueprint_page(...)             ← views/blueprint.py
     """
+    auth = sess.get("auth") if sess else None
     channel_name = req.query_params.get("name", "Growth Blueprint")
-    page_content = blueprint_route(req, creator_id)
+    page_content = blueprint_route(req, creator_id, auth=auth)
     return Titled(
         f"{channel_name} — Growth Blueprint — ViralVibes",
         Container(

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -800,13 +800,17 @@ def blueprint_route(request, creator_id: str, auth=None):
     )
     actions = score_all_actions(signals)
 
+    bp_path = f"/creator/{creator_id}/blueprint"
+    bp_qs = request.url.query
+    return_url = f"{bp_path}?{bp_qs}" if bp_qs else bp_path
+
     return render_blueprint_page(
         creator,
         signals=signals,
         actions=actions,
         back_url=back_url,
         auth=bool(auth),
-        return_url=f"/creator/{creator_id}/blueprint",
+        return_url=return_url,
     )
 
 

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -771,7 +771,7 @@ def compare_creators_route(request, user_id: str | None = None):
     )
 
 
-def blueprint_route(request, creator_id: str):
+def blueprint_route(request, creator_id: str, auth=None):
     """
     GET /creator/{creator_id}/blueprint — Growth Blueprint page.
 
@@ -805,6 +805,8 @@ def blueprint_route(request, creator_id: str):
         signals=signals,
         actions=actions,
         back_url=back_url,
+        auth=bool(auth),
+        return_url=f"/creator/{creator_id}/blueprint",
     )
 
 

--- a/views/blueprint.py
+++ b/views/blueprint.py
@@ -209,6 +209,47 @@ def render_no_actions() -> Div:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Sign-in CTA (unauthenticated visitors only)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _render_signin_cta(return_url: str) -> Div:
+    """Soft sign-in invitation shown below blueprint content for logged-out visitors."""
+    from urllib.parse import urlencode
+    from components.auth_components import GoogleGLogo  # lazy — avoids circular import
+
+    login_href = f"/login?{urlencode({'return_url': return_url})}"
+    return Div(
+        Div(
+            UkIcon("bookmark", cls="w-5 h-5 text-primary shrink-0 mt-0.5"),
+            Div(
+                H4(
+                    "Track this creator — it's free",
+                    cls="text-base font-semibold text-foreground",
+                ),
+                P(
+                    "Sign in to add this channel to your watchlist and stay updated when their blueprint changes.",
+                    cls="text-sm text-muted-foreground mt-0.5",
+                ),
+                cls="flex-1 min-w-0",
+            ),
+            A(
+                GoogleGLogo(18),
+                Span("Continue with Google", cls="ml-2 text-sm font-semibold"),
+                href=login_href,
+                cls=(
+                    "inline-flex items-center shrink-0 px-4 py-2.5 "
+                    "bg-white border border-gray-200 hover:border-gray-300 "
+                    "hover:shadow-sm text-gray-800 rounded-lg transition-all no-underline"
+                ),
+            ),
+            cls="flex items-start gap-4 flex-wrap sm:flex-nowrap",
+        ),
+        cls="mt-10 p-5 rounded-xl border border-primary/20 bg-primary/5",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Full page
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -218,6 +259,8 @@ def render_blueprint_page(
     signals: CreatorSignals,
     actions: list[ActionResult],
     back_url: str = "/creators",
+    auth: bool = False,
+    return_url: str = "/creators",
 ) -> Div:
     """
     Full Growth Blueprint page for one creator.
@@ -339,9 +382,7 @@ def render_blueprint_page(
         else:
             actions_section = free_card
 
-    return Div(
-        header,
-        diag_section,
-        actions_section,
-        cls="max-w-3xl mx-auto px-4 py-10",
-    )
+    body_parts = [header, diag_section, actions_section]
+    if not auth:
+        body_parts.append(_render_signin_cta(return_url))
+    return Div(*body_parts, cls="max-w-3xl mx-auto px-4 py-10")


### PR DESCRIPTION
Add soft "Track this creator — it's free" invitation banner below the blueprint content for unauthenticated users. Page stays fully public; no content is gated. Auth is threaded from session → blueprint_route → render_blueprint_page and the CTA is suppressed for signed-in users.

## Summary by Sourcery

Add a soft sign-in call-to-action below blueprint content for logged-out visitors while keeping the page fully public.

New Features:
- Introduce a Google-based sign-in banner inviting unauthenticated users to track creators and add channels to their watchlist on the blueprint page.

Enhancements:
- Thread authentication state and a return URL from the session through the blueprint route into the blueprint page renderer to control CTA visibility for signed-in vs logged-out visitors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sign-in prompt for visitors who aren’t authenticated when viewing creator blueprints.
  * Added Google sign-in with a return link that brings visitors back to the requested blueprint.

* **Bug Fixes**
  * Preserved the existing blueprint layout and experience for authenticated visitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->