### PR TITLE
fix: restore CSS/JS on lookalike pages + fix logout session clear

### DIFF
--- a/auth/token_revocation.py
+++ b/auth/token_revocation.py
@@ -62,6 +62,7 @@ def clear_auth_session(sess: dict) -> None:
         "user_given_name",
         "user_has_avatar",
         "last_login_at",
+        "is_admin",
     ]
 
     for key in session_keys_to_clear:

--- a/main.py
+++ b/main.py
@@ -1544,7 +1544,12 @@ def creators_like(req, sess, handle: str):
     # response pipeline, so str(page) would produce a bare fragment with no
     # CSS or JS.  _render_page() replicates the <html><head><body> assembly.
     response = StarletteResponse(_render_page(page), media_type="text/html")
-    if result.headers:
+    if _is_authenticated(sess):
+        # Authenticated nav is personalised (profile pic, sign-out link).
+        # result.headers carries Cache-Control: public with no Vary: Cookie,
+        # so the CDN could serve the logged-in nav to anonymous users.
+        response.headers["Cache-Control"] = "private, no-store"
+    elif result.headers:
         for header_name, header_value in result.headers.items():
             response.headers[header_name] = header_value
     return response

--- a/main.py
+++ b/main.py
@@ -259,6 +259,42 @@ def _render_page(ft_response) -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# CDN edge-cache helpers
+# ---------------------------------------------------------------------------
+# TTL strings for public (logged-out) responses served via Vercel's edge CDN.
+# s-maxage: how long the CDN serves without revalidating.
+# stale-while-revalidate: how long the CDN may serve stale content while
+# refreshing in the background (users never wait for a cache miss).
+_CC_STD = "public, s-maxage=300, stale-while-revalidate=3600"  # creator profiles, lists, blueprints
+_CC_BLOG = "public, s-maxage=3600, stale-while-revalidate=86400"  # blog pages — rarely change
+_CC_RSS = "public, s-maxage=900, stale-while-revalidate=3600"  # RSS feed
+
+
+def _is_authenticated(sess) -> bool:
+    """True when the session carries a valid auth token.
+
+    Guards against ``sess`` being ``None`` (no session middleware) and against
+    the auth key being absent or falsy.
+    """
+    return bool(sess and sess.get("auth"))
+
+
+def _public_cached_response(sess, page, cache_control: str):
+    """Return *page* wrapped in a CDN-cacheable HTMLResponse for logged-out visitors.
+
+    Logged-in users receive the raw FastHTML ``Titled`` response so FastHTML's
+    pipeline can inject session-specific nav state.  ``Vary: Cookie`` tells the
+    CDN to keep both cache entries (logged-in / logged-out) separate.
+    """
+    if not _is_authenticated(sess):
+        return HTMLResponse(
+            _render_page(page),
+            headers={"Cache-Control": cache_control, "Vary": "Cookie"},
+        )
+    return page
+
+
 def _creator_not_found_response(req, sess, message: str) -> HTMLResponse:
     """Return a 404 HTMLResponse for the creator profile route.
 
@@ -622,8 +658,9 @@ def login_new_ui(req, sess):
 
 
 @rt("/logout")
-def logout():
+def logout(sess):
     """Standard logout - clears session and redirects"""
+    clear_auth_session(sess)
     return build_logout_response()
 
 
@@ -1398,16 +1435,9 @@ def creators(req, sess):
         or req.query_params.get("country")
         or req.query_params.get("language")
     )
-    if not sess.get("auth") and not is_filtered:
-        return HTMLResponse(
-            _render_page(response),
-            headers={
-                "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120",
-                "Vary": "Cookie",
-            },
-        )
-
-    return response
+    if is_filtered:
+        return response
+    return _public_cached_response(sess, response, _CC_STD)
 
 
 @rt("/creators/request")
@@ -1451,7 +1481,7 @@ def _render_creators_top(req, sess, category_slug: str | None):
         creators=result.creators,
     )
 
-    return Titled(
+    page = Titled(
         creators_top_page_title(result.category_label),
         Container(
             NavComponent(oauth, req, sess),
@@ -1460,6 +1490,7 @@ def _render_creators_top(req, sess, category_slug: str | None):
         ),
         *head_tags,
     )
+    return _public_cached_response(sess, page, _CC_STD)
 
 
 @rt("/creators/top")
@@ -1509,7 +1540,10 @@ def creators_like(req, sess, handle: str):
 
     # Apply HTTP cache headers from the route result to the response.
     # This enables CDN/browser caching (1 hour) and ETag-based revalidation.
-    response = StarletteResponse(str(page), media_type="text/html")
+    # _render_page() is required here — StarletteResponse bypasses FastHTML's
+    # response pipeline, so str(page) would produce a bare fragment with no
+    # CSS or JS.  _render_page() replicates the <html><head><body> assembly.
+    response = StarletteResponse(_render_page(page), media_type="text/html")
     if result.headers:
         for header_name, header_value in result.headers.items():
             response.headers[header_name] = header_value
@@ -1548,16 +1582,7 @@ def lists(req, sess):
     # Cache at the CDN edge for logged-out visitors only.
     # Vary: Cookie tells the CDN to keep separate cache entries per
     # cookie presence, so logged-in users always get a fresh response.
-    if not sess.get("auth"):
-        return HTMLResponse(
-            _render_page(response),
-            headers={
-                "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
-                "Vary": "Cookie",
-            },
-        )
-
-    return response
+    return _public_cached_response(sess, response, _CC_STD)
 
 
 @rt("/lists/more-countries")
@@ -1830,7 +1855,7 @@ def creator_profile_by_handle(req, sess, handle: str):
 
     if isinstance(result, CreatorProfileResult):
         head_tags = creator_profile_head(result.creator)
-        return Titled(
+        page = Titled(
             creator_profile_page_title(result.creator),
             Container(
                 NavComponent(oauth, req, sess),
@@ -1838,6 +1863,7 @@ def creator_profile_by_handle(req, sess, handle: str):
             ),
             *head_tags,
         )
+        return _public_cached_response(sess, page, _CC_STD)
 
     return Titled(
         "Creator Profile - ViralVibes",
@@ -1912,7 +1938,7 @@ def creator_profile(req, sess, creator_id: str):
 
     if isinstance(result, CreatorProfileResult):
         head_tags = creator_profile_head(result.creator)
-        return Titled(
+        page = Titled(
             creator_profile_page_title(result.creator),
             Container(
                 NavComponent(oauth, req, sess),
@@ -1920,6 +1946,7 @@ def creator_profile(req, sess, creator_id: str):
             ),
             *head_tags,
         )
+        return _public_cached_response(sess, page, _CC_STD)
 
     return Titled(
         "Creator Profile - ViralVibes",
@@ -1984,13 +2011,14 @@ def creator_blueprint(req, sess, creator_id: str):
     auth = sess.get("auth") if sess else None
     channel_name = req.query_params.get("name", "Growth Blueprint")
     page_content = blueprint_route(req, creator_id, auth=auth)
-    return Titled(
+    page = Titled(
         f"{channel_name} — Growth Blueprint — ViralVibes",
         Container(
             NavComponent(oauth, req, sess),
             page_content,
         ),
     )
+    return _public_cached_response(sess, page, _CC_STD)
 
 
 @rt("/compare")
@@ -2411,7 +2439,7 @@ def blog(req, sess):
         title="ViralVibes Blog",
         href="/rss.xml",
     )
-    return Titled(
+    page = Titled(
         "Blog — ViralVibes",
         rss_link,
         Container(
@@ -2420,6 +2448,7 @@ def blog(req, sess):
             cls=ContainerT.xl,
         ),
     )
+    return _public_cached_response(sess, page, _CC_BLOG)
 
 
 @rt("/rss.xml")
@@ -2427,7 +2456,11 @@ def rss_feed(req):
     """RSS 2.0 feed for published blog posts (no auth required)."""
     posts = get_posts()
     xml = build_rss_feed(posts, SITE_BASE_URL)
-    return Response(xml, media_type="application/rss+xml; charset=utf-8")
+    return Response(
+        xml,
+        media_type="application/rss+xml; charset=utf-8",
+        headers={"Cache-Control": _CC_RSS},
+    )
 
 
 @rt("/blog/{slug}")
@@ -2461,7 +2494,7 @@ def blog_post_route(req, sess, slug: str):
                 cls=ContainerT.xl,
             ),
         )
-    return Titled(
+    page = Titled(
         f"{post.title} — ViralVibes Blog",
         Container(
             NavComponent(oauth, req, sess),
@@ -2469,6 +2502,7 @@ def blog_post_route(req, sess, slug: str):
             cls=ContainerT.xl,
         ),
     )
+    return _public_cached_response(sess, page, _CC_BLOG)
 
 
 @rt("/press")


### PR DESCRIPTION
- /creators/like/{handle}: replace str(page) with _render_page(page) so StarletteResponse includes the full <html><head> pipeline with CSS/JS. str() produces a bare fragment; _render_page() replicates FastHTML's internal assembly. Regression from the caching PR.
- /logout: add sess param and call clear_auth_session(sess) before redirecting, so sess["auth"] is cleared from the session cookie. Previously only the standalone "auth" cookie was deleted, leaving users authenticated until session expiry.

## Summary by Sourcery

Standardize CDN edge caching for public pages and ensure lookalike pages and logout behave correctly for sessions and assets.

New Features:
- Introduce shared helpers for generating CDN-cacheable HTML responses for logged-out visitors with consistent Cache-Control policies.
- Apply public edge caching to creators, top creators, creator profiles, blueprints, blog pages, and RSS feed responses.

Bug Fixes:
- Restore full HTML (including CSS/JS) on creators-like pages by using the page rendering pipeline instead of raw fragments.
- Ensure logout fully clears the authenticated session state before redirecting so users are immediately logged out.

Enhancements:
- Refactor multiple routes to use a common public caching helper, reducing duplication and centralizing cache behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved delivery of publicly accessible pages with CDN caching.
  * Added full-page rendering for anonymous visitors.
  * Applied optimized caching to creator, list, profile, blueprint, blog, and RSS pages.
  * Added dedicated cache durations for blog and RSS content.
  * Personalized pages now receive appropriate private or non-cached responses for signed-in visitors.

* **Bug Fixes**
  * Logout now reliably clears the active session and related administrative state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->