### PR TITLE
content(blog): add Social Blade alternative post + fix internal link …

### DIFF
--- a/posts/social-blade-alternative.md
+++ b/posts/social-blade-alternative.md
@@ -1,0 +1,133 @@
+---
+title: "Beyond Social Blade: 5 Signals That Actually Predict Campaign Performance"
+date: 2026-08-05
+excerpt: "Social Blade tells you how big a channel is. It doesn't tell you whether it will work for your brand. Here's what to look at instead."
+tags: ["strategy", "data", "discovery"]
+placeholder: false
+---
+
+Social Blade has been the default starting point for YouTube research for over a decade — and for good reason. Subscriber counts, view trajectories, estimated revenue ranges: free, fast, no login required.
+
+But there's a problem. A 1.2 million subscriber channel running at 0.4% engagement will lose on almost every brand metric to a 90,000 subscriber channel running at 6.1% engagement. Social Blade shows you the first number and hides the second entirely.
+
+If your shortlisting process starts and ends with subscriber count, you're optimising for the wrong thing.
+
+---
+
+## What Social Blade actually shows you
+
+To be fair: Social Blade does a specific job well. It shows you raw growth trajectory — subscriber gains and losses over time, estimated monthly views, a rough income range based on CPM estimates. It's a history of *how big a channel got*.
+
+What it does not show:
+
+- Whether the audience is engaged or passive
+- Whether growth is organic or from a bought subscriber spike
+- How the channel compares to others in its niche, at its size
+- Whether the creator has a business email you can actually reach
+- Which channels attract the same audience as a channel you already know works
+
+For pure brand safety checks or checking whether a channel has declined since your last campaign, Social Blade is fine. For the actual work of finding channels that will perform, it stops short.
+
+---
+
+## The 5 signals that predict campaign performance
+
+### 1. Engagement rate, not subscriber count
+
+Engagement rate — comments and likes as a percentage of views — is the clearest signal of an audience that shows up, watches, and responds. A channel with 200K subscribers and 5% engagement delivers more active impressions per post than a 2M channel at 0.4%.
+
+The benchmark varies by category and size. A Gaming channel at 200K subscribers is expected to run hotter than an Entertainment channel at 2M. Comparing raw rates across different tiers and niches misleads you.
+
+[ViralVibes filters creators by engagement rate](/creators) within category so comparisons are apples-to-apples. You can set a floor — say 3% — within a specific niche and instantly surface the channels that clear it.
+
+### 2. Quality grade: a composite of engagement, consistency, and momentum
+
+A single engagement rate number doesn't tell the full story either. A channel might have a good engagement rate from one viral video while most content gets ignored. Or it might have consistent 4% engagement across 200 uploads — a fundamentally different proposition for a brand.
+
+ViralVibes grades every creator on a scale of A+ through C, combining:
+
+- Engagement rate relative to category peers
+- Content consistency (upload frequency and view stability)
+- 30-day momentum (is the channel accelerating or coasting?)
+
+An A+ grade means the channel is firing on all three. A B grade might be a solid channel in a temporary dip. A C grade is a signal to investigate before committing budget.
+
+[Browse creators sorted by quality grade](/creators) to start a shortlist anchored to what actually matters.
+
+### 3. 30-day velocity: who is rising right now
+
+Subscriber count tells you where a channel has been. 30-day subscriber and view change tells you where it is going.
+
+A channel with 400K subscribers that added 28,000 in the last month is on a different trajectory than one that has been flat for a year. For brand deals timed to product launches, rising momentum matters: you want to be associated with a creator at their upswing, not their plateau.
+
+[Top creator lists](/creators/top) on ViralVibes rank by 30-day momentum rather than total subscribers — a completely different list than Social Blade's top channels by size.
+
+### 4. Lookalike matching: find more of what already worked
+
+If you ran a campaign with a creator that delivered — great click-through rate, clean audience overlap, content that fit your brand — the next question is: who else looks like this?
+
+Social Blade has no answer to this. You'd have to manually hunt through "similar channels" suggestions on YouTube and repeat the research process from scratch.
+
+ViralVibes builds embedding-based peer lists for every creator in the database. Find a creator that worked, then [open their profile](/creators) and follow the Similar Creators rail to the full lookalike list — 50 channels with the closest audience-profile match, ranked by similarity, each with a match-reason chip showing exactly why they appeared.
+
+### 5. Direct contact: from shortlist to outreach in one step
+
+Building a shortlist is only half the job. The other half is getting the email into the right inbox.
+
+Most creator research tools stop at the data. You export a CSV, paste names into Google, find a YouTube "About" page, sometimes find an email, often don't. A 20-creator shortlist can consume a half-day of outreach prep.
+
+ViralVibes extracts business contacts — email, website, Instagram, X — from creator profiles automatically. When a creator has an extractable email, it appears directly on their card. Your shortlist becomes a contact list with one export.
+
+---
+
+## A practical brand research workflow
+
+Here's how the process looks when you use ViralVibes instead of patching together Social Blade + manual research:
+
+**Step 1: Define your niche and minimum bar**
+Go to [creator search](/creators). Filter by category (Gaming, Howto & Style, Finance, etc.), set a country if you need a specific market, and set a minimum engagement rate. This is the filter that Social Blade doesn't have.
+
+**Step 2: Sort by quality grade or 30-day growth**
+Switch the sort from subscriber count to quality grade or momentum. The list you get looks nothing like a Social Blade top-20 — smaller channels surface that would never appear in a ranked-by-size view.
+
+**Step 3: Deep-dive a candidate with the Blueprint**
+Found a channel that looks interesting? [Open their profile from the creator search](/creators). The Growth Blueprint tab maps out category benchmarks, engagement position, growth trajectory, and how they compare to the top creators in their niche. Use this to make the case internally for why this channel is worth the spend.
+
+**Step 4: Run a comparison before committing**
+Shortlisted two creators and need to choose? The [side-by-side comparison tool](/compare) puts their subscriber trends, engagement rates, grades, and category context next to each other. No spreadsheet required.
+
+**Step 5: Expand with lookalikes**
+Once you've confirmed one creator is a fit, pull their lookalike list to build out the rest of the campaign. A campaign with 6 similar-audience creators in the same niche consistently outperforms 6 random picks from a Social Blade top-100.
+
+---
+
+## Country and category leaderboards
+
+Social Blade's country and category breakdowns exist but are ranked purely by subscriber count. That means the top spots are dominated by mega-channels that rarely take brand deals, and the rising mid-tier creators who are actively monetising through partnerships are buried or invisible.
+
+ViralVibes publishes [ranked lists by category and country](/lists) that weight momentum and engagement quality alongside size. The Gaming list for Germany looks very different here than on Social Blade — and it's the German Gaming list that actually reflects who is growing their audience in that market right now.
+
+---
+
+## The honest comparison
+
+| | Social Blade | ViralVibes |
+|---|---|---|
+| Subscriber history | ✅ | ✅ |
+| View count trends | ✅ | ✅ |
+| Engagement rate | ❌ | ✅ |
+| Quality grade | ❌ | ✅ |
+| 30-day momentum | ❌ | ✅ |
+| Category benchmarking | ❌ | ✅ |
+| Lookalike matching | ❌ | ✅ |
+| Business contact extraction | ❌ | ✅ |
+| Niche + country filtering | Limited | ✅ |
+| Free to use | ✅ | ✅ |
+
+Social Blade is a fine tool for checking whether a channel is growing or dying. It is not a campaign-planning tool.
+
+If you are selecting creators for a campaign — evaluating whether they will perform, comparing them against category peers, or building a contact list for outreach — you need engagement data, not subscriber history.
+
+---
+
+[Start your research in the creator search →](/creators)

--- a/utils/blog.py
+++ b/utils/blog.py
@@ -142,7 +142,7 @@ def _make_renderer():
         import mistletoe
 
         # Known in-app route prefixes — only these get same-tab link behaviour.
-        _INTERNAL_PREFIXES = ("/blog", "/creators", "/dashboard", "/compare")
+        _INTERNAL_PREFIXES = ("/blog", "/creators", "/creator", "/dashboard", "/compare", "/lists")
 
         class _SiteRenderer(FrankenRenderer):
             """Extends FrankenRenderer: internal site links open in the same tab;


### PR DESCRIPTION
…renderer

New post at posts/social-blade-alternative.md → /blog/social-blade-alternative "Beyond Social Blade: 5 Signals That Actually Predict Campaign Performance"
- Covers engagement rate, quality grade, 30-day velocity, lookalike matching, and contact extraction as the five campaign-relevant signals
- Links to /creators, /creators/top, /compare, /lists throughout
- Comparison table: Social Blade vs ViralVibes feature parity

Fix utils/blog.py — _SiteRenderer._INTERNAL_PREFIXES was missing /lists and /creator; those links were silently rendering with target="_blank" instead of same-tab navigation. Added both prefixes.

Fix post copy: two link anchor phrases implied direct URLs that don't exist as generic paths (blueprint at /creator/{id}/blueprint, lookalike at /creators/like/{handle}); rewritten to describe the actual navigation path.

## Summary by Sourcery

Add a new blog post comparing Social Blade with ViralVibes and update internal link handling for new in-app routes.

New Features:
- Publish a new blog article outlining five data signals that better predict campaign performance than Social Blade metrics, including a comparison table between Social Blade and ViralVibes.

Bug Fixes:
- Treat /creator and /lists routes as internal links so they open in the same tab instead of as external links.

Enhancements:
- Refine blog post copy to describe accurate navigation paths instead of implying non-existent generic URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an article comparing Social Blade with ViralVibes for creator campaign research.
  - Covers engagement rate, quality grading, growth velocity, lookalike matching, contact extraction, research workflows, leaderboards, and feature comparisons.
  - Includes a call to action for finding creators.

- **Bug Fixes**
  - Updated creator and list links to open within the same tab, matching other internal navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->