### PR TITLE
fix: add connection pool timeout error handling in database operations

### DIFF
--- a/db.py
+++ b/db.py
@@ -3230,6 +3230,17 @@ def _is_statement_timeout_error(exc: Exception) -> bool:
     return "57014" in text or "statement timeout" in text
 
 
+def _is_connection_pool_timeout(exc: Exception) -> bool:
+    """Return True for PostgREST PGRST003 connection-pool exhaustion errors.
+
+    Occurs when all PgBouncer / PostgREST connections are in use and the
+    request waits longer than the pool timeout.  Transient under load;
+    the same graceful-empty degradation applied to 57014 timeouts applies.
+    """
+    text = str(exc)
+    return "PGRST003" in text or "Timed out acquiring connection from connection pool" in text
+
+
 def _is_handle_like_search(search: str) -> bool:
     """Return True for single-token searches that look like YouTube handles."""
     return bool(_HANDLE_RE.match(f"@{_normalize_creator_handle(search)}"))
@@ -3547,7 +3558,9 @@ def get_creators(
                         return CreatorsResult([], 0)
                     return []
 
-            if not no_extra_filters and _is_statement_timeout_error(e):
+            if not no_extra_filters and (
+                _is_statement_timeout_error(e) or _is_connection_pool_timeout(e)
+            ):
                 # A filter+sort combination hit a statement timeout — most likely
                 # a multi-filter query whose index coverage was insufficient.
                 # Apply migration 048 (grade_sort_composite_indexes) to fix the root

--- a/db.py
+++ b/db.py
@@ -3237,8 +3237,8 @@ def _is_connection_pool_timeout(exc: Exception) -> bool:
     request waits longer than the pool timeout.  Transient under load;
     the same graceful-empty degradation applied to 57014 timeouts applies.
     """
-    text = str(exc)
-    return "PGRST003" in text or "Timed out acquiring connection from connection pool" in text
+    text = str(exc).lower()
+    return "pgrst003" in text or "timed out acquiring connection from connection pool" in text
 
 
 def _is_handle_like_search(search: str) -> bool:
@@ -3561,32 +3561,45 @@ def get_creators(
             if not no_extra_filters and (
                 _is_statement_timeout_error(e) or _is_connection_pool_timeout(e)
             ):
-                # A filter+sort combination hit a statement timeout — most likely
-                # a multi-filter query whose index coverage was insufficient.
-                # Apply migration 048 (grade_sort_composite_indexes) to fix the root
-                # cause. Return empty gracefully so the UI shows "no results" rather
-                # than a 500 error.
-                #
-                # Guard: only degrade gracefully when at least one non-default filter
-                # is active (no_extra_filters=False). A timeout on a plain unfiltered
-                # browse is a genuine outage and should propagate as an error, not
-                # silently return empty results.
-                logger.warning(
-                    "get_creators timed out (57014) — returning empty. "
-                    "Sort: %s, Limit: %s, Offset: %s, Search: %r, "
-                    "Filters: [grade=%s, lang=%s, activity=%s, age=%s, "
-                    "country=%s, category=%s]. Apply migration 048 to fix.",
-                    sort,
-                    limit,
-                    offset,
-                    search[:256] if isinstance(search, str) else search,
-                    grade_filter,
-                    language_filter,
-                    activity_filter,
-                    age_filter,
-                    country_filter,
-                    category_filter,
-                )
+                # Transient DB resource error on a filtered query — return empty
+                # gracefully so the UI shows "no results" rather than a 500.
+                # Guard: only degrade when at least one non-default filter is
+                # active (no_extra_filters=False). A timeout on a plain unfiltered
+                # browse is a genuine outage and should propagate, not be masked.
+                if _is_connection_pool_timeout(e):
+                    logger.warning(
+                        "get_creators — connection pool exhausted (PGRST003), returning empty. "
+                        "Sort: %s, Limit: %s, Offset: %s, Search: %r, "
+                        "Filters: [grade=%s, lang=%s, activity=%s, age=%s, "
+                        "country=%s, category=%s]. Reduce concurrent load or increase pool size.",
+                        sort,
+                        limit,
+                        offset,
+                        search[:256] if isinstance(search, str) else search,
+                        grade_filter,
+                        language_filter,
+                        activity_filter,
+                        age_filter,
+                        country_filter,
+                        category_filter,
+                    )
+                else:
+                    logger.warning(
+                        "get_creators timed out (57014) — returning empty. "
+                        "Sort: %s, Limit: %s, Offset: %s, Search: %r, "
+                        "Filters: [grade=%s, lang=%s, activity=%s, age=%s, "
+                        "country=%s, category=%s]. Apply migration 048 to fix.",
+                        sort,
+                        limit,
+                        offset,
+                        search[:256] if isinstance(search, str) else search,
+                        grade_filter,
+                        language_filter,
+                        activity_filter,
+                        age_filter,
+                        country_filter,
+                        category_filter,
+                    )
                 if return_count:
                     return CreatorsResult([], 0)
                 return []


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Treat PostgREST PGRST003 connection-pool exhaustion errors as transient timeouts to avoid failing creator queries under load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Creator listings with active filters now gracefully return no results when database statement or connection-pool timeouts occur.
  * Improved handling of temporary database capacity issues to prevent request failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->