### PR TITLE
feat(blog): add reading time, fix post header order

### DIFF
--- a/routes/blog.py
+++ b/routes/blog.py
@@ -12,10 +12,22 @@ Design adapted from https://github.com/jackhogan/personal-site:
 
 from __future__ import annotations
 
+import math
+
 from fasthtml.common import *
 from monsterui.all import *
 from urllib.parse import quote_plus
 from xml.sax.saxutils import escape
+
+
+def compute_reading_time_minutes(content: str) -> int:
+    """Return reading time in whole minutes, rounded up, minimum 1.
+
+    Uses 200 wpm — a conservative average that errs on the side of
+    slightly over-estimating, consistent with common blog UX practice.
+    ``ceil`` prevents underestimation: 250 words → 2 min, not 1.
+    """
+    return max(1, math.ceil(len(content.split()) / 200))
 
 
 # ---------------------------------------------------------------------------
@@ -219,8 +231,7 @@ def _post_row(post) -> A:
             )
         )
     else:
-        _wc = len(post.content.split())
-        _rm = max(1, round(_wc / 200))
+        _rm = compute_reading_time_minutes(post.content)
         meta_parts.append(Span(f"{_rm} min read", cls="text-xs text-muted-foreground"))
         meta_parts.extend([_tag_pill(t) for t in post.tags])
 
@@ -333,10 +344,8 @@ def blog_post_content(post) -> Div:
         cls="text-sm text-muted-foreground hover:text-foreground transition-colors no-underline",
     )
 
-    # Reading time: ~200 words per minute; minimum 1 min shown.
-    _word_count = len(post.content.split())
-    _read_min = max(1, round(_word_count / 200))
-    _read_label = f"{_read_min} min read"
+    # Reading time — ceil so 250 words → 2 min, not 1.
+    _read_label = f"{compute_reading_time_minutes(post.content)} min read"
 
     post_header = Div(
         # Eyebrow row: category tags + date + reading time

--- a/routes/blog.py
+++ b/routes/blog.py
@@ -219,6 +219,9 @@ def _post_row(post) -> A:
             )
         )
     else:
+        _wc = len(post.content.split())
+        _rm = max(1, round(_wc / 200))
+        meta_parts.append(Span(f"{_rm} min read", cls="text-xs text-muted-foreground"))
         meta_parts.extend([_tag_pill(t) for t in post.tags])
 
     meta_row = Div(*meta_parts, cls="flex flex-wrap items-center gap-2 mt-1")
@@ -330,20 +333,32 @@ def blog_post_content(post) -> Div:
         cls="text-sm text-muted-foreground hover:text-foreground transition-colors no-underline",
     )
 
+    # Reading time: ~200 words per minute; minimum 1 min shown.
+    _word_count = len(post.content.split())
+    _read_min = max(1, round(_word_count / 200))
+    _read_label = f"{_read_min} min read"
+
     post_header = Div(
-        (P(post.datestr, cls="text-sm text-muted-foreground mb-3") if post.datestr else None),
+        # Eyebrow row: category tags + date + reading time
+        Div(
+            *(
+                [Div(*[_tag_pill(t) for t in post.tags], cls="flex flex-wrap gap-2")]
+                if post.tags
+                else []
+            ),
+            Span("·", cls="text-muted-foreground text-xs") if post.tags and post.datestr else None,
+            Span(post.datestr, cls="text-xs text-muted-foreground") if post.datestr else None,
+            Span("·", cls="text-muted-foreground text-xs") if post.datestr else None,
+            Span(_read_label, cls="text-xs text-muted-foreground"),
+            cls="flex flex-wrap items-center gap-2 mb-4",
+        ),
         H1(
             post.title,
             cls="text-3xl md:text-4xl font-bold tracking-tight text-foreground mb-4 leading-tight",
         ),
         (
-            P(post.excerpt, cls="text-lg text-muted-foreground leading-relaxed mb-4")
+            P(post.excerpt, cls="text-lg text-muted-foreground leading-relaxed mb-6")
             if post.excerpt
-            else None
-        ),
-        (
-            Div(*[_tag_pill(t) for t in post.tags], cls="flex flex-wrap gap-2 mb-8")
-            if post.tags
             else None
         ),
         Div(cls="h-px bg-gradient-to-r from-border to-transparent mb-8"),


### PR DESCRIPTION
- Add reading time estimate (word_count / 200, min 1 min) to both the post header eyebrow and index listing rows — consistent with 2024+ tech blog conventions (Vercel, Resend, Stripe Engineering)

- Reorganise post header: tags · date · read time eyebrow row appears above the H1 so the title is the first substantial element after the back link, not after a decorative strip

- Remove hero illustration strip added in previous commit — the notebook SVG is a "coming soon / in progress" metaphor (dashed trailing line, "BLOG" cover text) that conflicts with a published article; the same generic image on every post also creates visual monotony. SVG kept in its original coming-soon context where the metaphor is semantically correct

## Summary by Sourcery

Add reading-time metadata to blog posts and reorganize the post header layout for improved readability.

New Features:
- Display an estimated reading time for each blog post in both the index listing and the post header.

Enhancements:
- Reorder the blog post header so tags, date, and reading time appear together in an eyebrow row above the title and remove the decorative hero strip to reduce visual clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published post listings and individual posts now display estimated reading times based on a 200-words-per-minute reading speed.
  * Estimates are rounded up and always show at least one minute.
  * Post headers now present tags, publication date, and reading time together in a single metadata row.

* **Style**
  * Increased spacing around excerpts for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->