### PR TITLE
fix(db_lists): remove redundant topic_categories IS NOT NULL filter

### DIFF
--- a/db_lists.py
+++ b/db_lists.py
@@ -344,15 +344,24 @@ def resolve_category_slug(slug: str) -> str | None:
 
 
 def _apply_browseable_constraints(query):
-    """Apply the four predicates shared by every topic-category query.
+    """Apply the three predicates shared by every topic-category query.
 
     Centralised so that a change to BROWSEABLE_SYNC_STATUSES or the
     standard row-quality filters only needs to happen in one place.
+
+    Note: topic_categories IS NOT NULL is intentionally omitted.
+    Both query paths that call this function already filter on topic_categories
+    (ILIKE or containment), which implicitly excludes NULL rows — adding an
+    explicit IS NOT NULL generates a second topic_categories= query param in
+    the PostgREST URL.  PostgreSQL then treats the trgm index on topic_categories
+    as more attractive than idx_creators_listing_browseable, resulting in a
+    full bitmap heap scan of all matching rows instead of an early-stop index
+    scan sorted by current_subscribers.  For broad categories ("Society",
+    "Health") this scan exceeds the statement timeout (57014).
     """
     return (
         query.in_("sync_status", list(BROWSEABLE_SYNC_STATUSES))
         .not_.is_("channel_name", "null")
-        .not_.is_("topic_categories", "null")
         .gt("current_subscribers", 0)
     )
 


### PR DESCRIPTION
_apply_browseable_constraints added .not_.is_("topic_categories", "null") which generated a second topic_categories= query param in the PostgREST URL alongside the ILIKE filter. PostgreSQL treated two conditions on the same column as a signal to use the trgm index (bitmap heap scan of all matching rows + sort) instead of idx_creators_listing_browseable (index scan sorted by subscribers, early-stop at LIMIT).

For broad categories ("Society", "Health") the trgm bitmap scan visited 200k+ heap pages and exceeded the statement timeout (57014).

The IS NOT NULL condition was redundant: ILIKE already returns NULL/FALSE for NULL rows so the filter had no logical effect, only a planner effect.

After fix: idx_creators_listing_browseable used, 270 rows removed by
filter before finding 20 matches. Execution time: 39ms (was timeout).

## Summary by Sourcery

Remove a redundant topic_categories null-check from shared browseable query constraints to restore efficient index usage and avoid timeouts on broad category listings.

Bug Fixes:
- Avoid query planner regressions and statement timeouts on broad topic-category queries by no longer adding an unnecessary topic_categories IS NOT NULL predicate.

Enhancements:
- Clarify documentation in _apply_browseable_constraints about why topic_categories IS NOT NULL is intentionally omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated browseable content filtering to avoid excluding items based solely on missing topic categories.
  * Browseable results continue to require valid sync status, channel name, and positive subscriber counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->