### PR TITLE
feat(compare): show inline creator suggestions on compare step-2

### DIFF
--- a/routes/creators.py
+++ b/routes/creators.py
@@ -46,7 +46,7 @@ from db_lists import (
 
 # from services.youtube_backend_api import YouTubeBackendAPI
 from controllers.auth_routes import require_auth, safe_local_return_url
-from views.compare import render_compare_page
+from views.compare import render_compare_page, render_compare_pick_page
 from views.creators import (
     creator_profile_url,
     render_add_creator_result,
@@ -753,73 +753,33 @@ def compare_creators_route(request, user_id: str | None = None):
             cls="max-w-2xl mx-auto px-4 py-24 text-center",
         )
 
-    if id_a and not id_b:
+    if not id_b:
         # User clicked Compare on a profile but hasn't chosen the second creator yet.
-        # Show a guided step-2 state rather than a generic error.
+        # Fetch both suggestion sources in parallel so the page renders without
+        # the user having to navigate away to find creator B.
         creator_a = get_creator_stats(id_a)
         if not creator_a:
             return _not_found(id_a)
-        name_a = creator_a.get("channel_name", "this creator")
-        thumb_a = creator_a.get("channel_thumbnail_url", "")
-        return Div(
-            # Step indicator
-            Div(
-                Div(
-                    Span("1", cls="text-xs font-bold text-white"),
-                    cls="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center shrink-0",
-                ),
-                Span("Picked", cls="text-xs text-emerald-600 font-medium"),
-                Div(cls="h-px flex-1 bg-border mx-2"),
-                Div(
-                    Span("2", cls="text-xs font-bold text-muted-foreground"),
-                    cls="w-5 h-5 rounded-full bg-accent border-2 border-border flex items-center justify-center shrink-0",
-                ),
-                Span("Pick a second creator", cls="text-xs text-muted-foreground font-medium"),
-                cls="flex items-center gap-2 mb-8 max-w-xs mx-auto",
-            ),
-            # Creator A identity
-            Div(
-                (
-                    Img(
-                        src=thumb_a,
-                        alt=name_a,
-                        cls="w-14 h-14 rounded-xl object-cover ring-2 ring-blue-400 shrink-0",
-                    )
-                    if thumb_a
-                    else Div(
-                        Span(name_a[:1].upper(), cls="text-xl font-bold text-muted-foreground"),
-                        cls="w-14 h-14 rounded-xl bg-accent flex items-center justify-center shrink-0",
-                    )
-                ),
-                Div(
-                    P("Comparing from", cls="text-xs text-muted-foreground"),
-                    P(name_a, cls="font-bold text-foreground text-base leading-tight"),
-                    cls="text-left",
-                ),
-                cls="flex items-center gap-3 justify-center mb-8",
-            ),
-            H2("Now pick a second creator", cls="text-2xl font-bold text-foreground mb-2"),
-            P(
-                "Browse the creator index and click Compare on any profile — "
-                "or use the Similar Creators rail on the first creator's profile.",
-                cls="text-sm text-muted-foreground leading-relaxed max-w-sm mx-auto mb-8",
-            ),
-            Div(
-                A(
-                    UkIcon("search", cls="w-4 h-4 mr-1.5"),
-                    "Search all creators",
-                    href=f"/creators?a={id_a}",
-                    cls="inline-flex items-center px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold no-underline hover:opacity-90 transition-opacity",
-                ),
-                A(
-                    UkIcon("users", cls="w-4 h-4 mr-1.5"),
-                    f"See creators similar to {name_a}",
-                    href=f"/creator/{id_a}?a={id_a}",
-                    cls="inline-flex items-center px-4 py-2 rounded-lg bg-accent hover:bg-accent/80 text-foreground text-sm font-semibold no-underline transition-colors",
-                ),
-                cls="flex flex-wrap items-center justify-center gap-3",
-            ),
-            cls="max-w-2xl mx-auto px-4 py-20 text-center",
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            fut_similar = pool.submit(_get_similar_creators, creator_a)
+            fut_peers = pool.submit(
+                get_embedding_peers,
+                id_a,
+                # peer_type defaults to "embedding_v1"; pass limit + hydrate_limit
+                # as kwargs because hydrate_limit is keyword-only (after *).
+                limit=_PROFILE_PEER_RAIL_LIMIT,
+                hydrate_limit=_PROFILE_PEER_RAIL_LIMIT,
+            )
+            similar_creators_a = fut_similar.result()
+            peers_result_a = fut_peers.result()
+
+        embedding_peers_a = peers_result_a[0] if peers_result_a else []
+
+        return render_compare_pick_page(
+            creator_a,
+            similar_creators=similar_creators_a,
+            embedding_peers=embedding_peers_a or [],
         )
 
     creator_a = get_creator_stats(id_a)

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -771,8 +771,16 @@ def compare_creators_route(request, user_id: str | None = None):
                 limit=_PROFILE_PEER_RAIL_LIMIT,
                 hydrate_limit=_PROFILE_PEER_RAIL_LIMIT,
             )
-            similar_creators_a = fut_similar.result()
-            peers_result_a = fut_peers.result()
+            try:
+                similar_creators_a = fut_similar.result()
+            except Exception:
+                logger.exception("[Compare] _get_similar_creators failed in step-2")
+                similar_creators_a = []
+            try:
+                peers_result_a = fut_peers.result()
+            except Exception:
+                logger.exception("[Compare] get_embedding_peers failed in step-2")
+                peers_result_a = None
 
         embedding_peers_a = peers_result_a[0] if peers_result_a else []
 

--- a/views/compare.py
+++ b/views/compare.py
@@ -93,6 +93,255 @@ def _insight_callout(*text_parts: str) -> Div:
     )
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Compare pick page — step-2 state shown when only ?a= is provided
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _compare_pick_card(c: dict, compare_href: str) -> Div:
+    """
+    Vertical "player card" for the pick-your-second-creator grid.
+
+    Vertical layout (avatar centred above name) carries equal visual weight
+    across all cards in a 2–4-column grid and signals "choose your opponent"
+    better than a horizontal identity row would.
+    """
+    from views.creators import creator_profile_url  # local to avoid circular
+
+    name = c.get("channel_name") or "Creator"
+    thumb = c.get("channel_thumbnail_url") or ""
+    subs = int(c.get("current_subscribers") or 0)
+    grade = c.get("quality_grade") or ""
+
+    _grade_cls = {
+        "A+": "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+        "A": "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+        "B+": "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+        "B": "bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300",
+        "C": "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300",
+    }.get(grade, "bg-accent text-muted-foreground")
+
+    avatar = (
+        Img(
+            src=thumb,
+            alt=name,
+            cls="w-16 h-16 rounded-xl object-cover mx-auto",
+            loading="lazy",
+        )
+        if thumb
+        else Div(
+            Span(name[:1].upper(), cls="text-xl font-bold text-muted-foreground"),
+            cls="w-16 h-16 rounded-xl bg-accent flex items-center justify-center mx-auto",
+        )
+    )
+
+    return Div(
+        # ── Avatar ────────────────────────────────────────────────────────
+        avatar,
+        # ── Identity ──────────────────────────────────────────────────────
+        P(
+            name,
+            cls="text-xs font-semibold text-foreground text-center leading-tight line-clamp-2 mt-2",
+        ),
+        Div(
+            Span(format_number(subs), cls="text-[11px] text-muted-foreground"),
+            *(
+                [Span(grade, cls=f"text-[10px] font-bold px-1.5 py-0.5 rounded-full {_grade_cls}")]
+                if grade
+                else []
+            ),
+            cls="flex items-center justify-center gap-1.5 mt-0.5 mb-3",
+        ),
+        # ── Primary CTA ──────────────────────────────────────────────────
+        A(
+            UkIcon("git-compare", cls="w-3.5 h-3.5 mr-1 shrink-0"),
+            "Compare →",
+            href=compare_href,
+            cls=(
+                "w-full inline-flex items-center justify-center "
+                "px-3 py-1.5 rounded-lg text-xs font-semibold no-underline "
+                "bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+            ),
+        ),
+        # ── Escape hatch ─────────────────────────────────────────────────
+        A(
+            "view profile",
+            href=creator_profile_url(c),
+            cls="block text-center text-[11px] text-muted-foreground hover:text-foreground no-underline mt-1.5 transition-colors",
+        ),
+        cls=(
+            "p-3 rounded-xl border border-border bg-background "
+            "hover:border-primary/40 hover:shadow-sm transition-all"
+        ),
+    )
+
+
+def render_compare_pick_page(
+    creator_a: dict,
+    similar_creators: list[dict],
+    embedding_peers: list[dict],
+) -> Div:
+    """
+    Step-2 page: user has chosen creator A and needs to pick creator B.
+
+    Shows two suggestion grids (embedding-based peers first, then category
+    leaders) so the user can complete the comparison without leaving the page.
+    Both lists are pre-fetched in the route handler to avoid latency.
+    """
+    id_a = creator_a.get("id", "")
+    name_a = creator_a.get("channel_name") or "this creator"
+    thumb_a = creator_a.get("channel_thumbnail_url") or ""
+    category_a = creator_a.get("primary_category") or ""
+
+    def _compare_href(b_id: str) -> str:
+        return f"/compare?a={id_a}&b={b_id}"
+
+    def _section(title: str, subtitle: str, creators: list[dict]) -> Div | None:
+        if not creators:
+            return None
+        cards = [
+            _compare_pick_card(c, _compare_href(c.get("id", "")))
+            for c in creators
+            if c.get("id") and c.get("id") != id_a
+        ]
+        if not cards:
+            return None
+        return Div(
+            Div(
+                P(title, cls="text-sm font-semibold text-foreground"),
+                P(subtitle, cls="text-xs text-muted-foreground"),
+                cls="mb-3",
+            ),
+            Div(
+                *cards,
+                cls=("grid gap-3 " "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4"),
+            ),
+            cls="mb-6",
+        )
+
+    embedding_section = _section(
+        title=f"Similar to {name_a}",
+        subtitle="Matched by content type, audience size and engagement",
+        creators=embedding_peers or [],
+    )
+    category_section = _section(
+        title=f"Top {category_a} Creators" if category_a else "Popular Creators",
+        subtitle="Popular in the same category — useful for benchmark comparisons",
+        creators=similar_creators or [],
+    )
+
+    # If no suggestions at all, fall back to a simple "search" prompt
+    no_suggestions = embedding_section is None and category_section is None
+
+    # ── Header — centred, prominent; same visual language as the old step-2 ──
+    # The header and the grid are sequential, not competing. A prominent header
+    # followed by a grid is better than a cramped header followed by a grid.
+    header = Div(
+        # Step tracker — centred, max-w-xs (matches original design)
+        Div(
+            Div(
+                Span("1", cls="text-xs font-bold text-white"),
+                cls="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center shrink-0",
+            ),
+            Span("Picked", cls="text-xs text-emerald-600 font-medium"),
+            Div(cls="h-px flex-1 bg-border mx-2"),
+            Div(
+                Span("2", cls="text-xs font-bold text-muted-foreground"),
+                cls=(
+                    "w-5 h-5 rounded-full bg-accent border-2 border-border "
+                    "flex items-center justify-center shrink-0"
+                ),
+            ),
+            Span("Pick a second creator", cls="text-xs text-muted-foreground font-medium"),
+            cls="flex items-center gap-2 max-w-xs mx-auto mb-8",
+        ),
+        # Creator A identity — large avatar, centred (restores original visual weight)
+        Div(
+            (
+                Img(
+                    src=thumb_a,
+                    alt=name_a,
+                    cls="w-14 h-14 rounded-xl object-cover ring-2 ring-blue-400 shrink-0",
+                )
+                if thumb_a
+                else Div(
+                    Span(name_a[:1].upper(), cls="text-xl font-bold text-muted-foreground"),
+                    cls="w-14 h-14 rounded-xl bg-accent flex items-center justify-center shrink-0",
+                )
+            ),
+            Div(
+                P("Comparing from", cls="text-xs text-muted-foreground"),
+                P(name_a, cls="font-bold text-foreground text-base leading-tight"),
+                cls="text-left",
+            ),
+            cls="flex items-center gap-3 justify-center mb-6",
+        ),
+        H2(
+            "Now pick a second creator",
+            cls="text-2xl font-bold text-foreground mb-2",
+        ),
+        P(
+            "Click any card below to start the comparison, or search for someone specific.",
+            cls="text-sm text-muted-foreground",
+        ),
+        cls="text-center mb-8",
+    )
+
+    # ── Search fallback ──────────────────────────────────────────────────
+    search_fallback = Div(
+        P(
+            "Don't see who you're looking for?",
+            cls="text-xs text-muted-foreground mb-2",
+        ),
+        A(
+            UkIcon("search", cls="w-3.5 h-3.5 mr-1"),
+            "Search all creators",
+            href=f"/creators?a={id_a}",
+            cls=(
+                "inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-semibold "
+                "no-underline bg-accent hover:bg-accent/80 text-foreground transition-colors"
+            ),
+        ),
+        cls="pt-4 border-t border-border",
+    )
+
+    body_content = (
+        Div(
+            P(
+                "No suggestions available. Search for a creator to compare.",
+                cls="text-sm text-muted-foreground mb-4",
+            ),
+            A(
+                UkIcon("search", cls="w-4 h-4 mr-1.5"),
+                "Search all creators",
+                href=f"/creators?a={id_a}",
+                cls=(
+                    "inline-flex items-center px-4 py-2 rounded-lg text-sm font-semibold "
+                    "no-underline bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
+                ),
+            ),
+        )
+        if no_suggestions
+        else Div(
+            embedding_section,
+            category_section,
+            search_fallback,
+        )
+    )
+
+    return Div(
+        A(
+            UkIcon("arrow-left", cls="w-4 h-4 mr-1"),
+            "Back",
+            href=f"/creator/{id_a}",
+            cls="inline-flex items-center text-sm font-medium text-muted-foreground hover:text-foreground no-underline transition-colors mb-6",
+        ),
+        header,
+        body_content,
+        cls="max-w-3xl mx-auto px-4 pb-16 pt-6",
+    )
+
+
 def _how_to_read_card() -> Div:
     """Compact explainer shown above the first metric section.
 


### PR DESCRIPTION
When a user clicks Compare on a profile (/compare?a=<id>), instead of a dead-end page with two navigation CTAs, show pre-fetched candidates so the comparison can be completed without leaving the page.

Route (routes/creators.py):
- Replace inline step-2 Div with a call to render_compare_pick_page
- Fetch _get_similar_creators (category-based) and get_embedding_peers (embedding-based) in parallel via ThreadPoolExecutor before rendering
- Fix: get_embedding_peers was called with positional args — _PROFILE_PEER_RAIL_LIMIT was landing in peer_type (str) instead of limit (int); hydrate_limit is keyword-only and was unreachable positionally. Switched to kwargs.
- Simplify redundant `if id_a and not id_b:` guard to `if not id_b:`

View (views/compare.py):
- Add render_compare_pick_page(creator_a, similar_creators, embedding_peers) Embedding peers first ("Similar to [name]"), category leaders second; both render as a responsive 2→4-column grid with a search fallback at bottom
- Add _compare_pick_card: vertical "player card" layout (avatar centred above name/stats) suited to grid picking rather than horizontal-rail browsing; primary CTA "Compare →" full-width, secondary "view profile" escape hatch
- Header preserves the original centred design: max-w-xs step tracker, w-14 avatar with blue ring, text-2xl heading — same visual language as the previous step-2 state the design was built around

## Summary by Sourcery

Show an inline step-2 comparison pick page with suggested creators when only creator A is selected, replacing the previous dead-end state.

New Features:
- Add a compare pick page that surfaces embedding-based peers and category-based similar creators so users can choose a second creator without leaving the compare flow.

Bug Fixes:
- Fix get_embedding_peers call to pass limit and hydrate_limit as keyword arguments so the peer rail uses the intended limits and peer type.

Enhancements:
- Fetch similar creators and embedding peers in parallel in the compare route to reduce latency when loading suggestions.
- Introduce a grid-based creator pick card layout with prominent compare and secondary profile CTAs and preserve the original step-2 header visual language.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated creator selection page when starting a comparison with one creator.
  * Displays suggested creators with thumbnails, subscriber counts, grades, comparison links, and profile links.
  * Separates closely related creators from category-based recommendations.
  * Provides search options when recommendations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->