### PR TITLE
feat: thread compare context through creator list page

### DIFF
--- a/routes/creators.py
+++ b/routes/creators.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import threading
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from typing import Any
@@ -62,6 +63,21 @@ from views.blueprint import render_blueprint_page
 from utils.creator_metrics import get_country_flag, get_language_emoji, get_language_name
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_compare_id(raw: str | None) -> str:
+    """Return a normalised UUID string from the ?a= query param, or '' if invalid.
+
+    Validates the value is a well-formed UUID so arbitrary user input is never
+    propagated into rendered URLs or downstream DB calls.
+    """
+    if not raw:
+        return ""
+    try:
+        return str(uuid.UUID(raw.strip()))
+    except (ValueError, AttributeError):
+        return ""
+
 
 # Number of entries shown in the hero sidebar strips and filter dropdowns.
 # Defined once so both the handle_not_found path and the parallel fan-out
@@ -487,7 +503,7 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
         is_authenticated=is_authenticated,
         favourite_ids=favourite_ids,
         handle_not_found=handle_not_found,
-        compare_a_id=request.query_params.get("a", ""),
+        compare_a_id=_parse_compare_id(request.query_params.get("a")),
     )
 
 

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -487,6 +487,7 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
         is_authenticated=is_authenticated,
         favourite_ids=favourite_ids,
         handle_not_found=handle_not_found,
+        compare_a_id=request.query_params.get("a", ""),
     )
 
 

--- a/views/creators.py
+++ b/views/creators.py
@@ -2675,7 +2675,11 @@ def _render_creator_card(creator: dict, is_favourited: bool = False, compare_a_i
     creator_uuid = safe_get_value(creator, "id", "")
     if not creator_uuid:
         return card
-    _compare_qs = f"&a={compare_a_id}" if compare_a_id and compare_a_id != creator_uuid else ""
+    _compare_qs = (
+        f"&a={quote(compare_a_id, safe='')}"
+        if compare_a_id and compare_a_id != creator_uuid
+        else ""
+    )
     return A(
         card,
         href=f"{creator_profile_url(creator)}?name={quote(channel_name)}{_compare_qs}",

--- a/views/creators.py
+++ b/views/creators.py
@@ -803,6 +803,7 @@ def render_creators_page(
     is_authenticated: bool = False,
     favourite_ids: set[str] | None = None,
     handle_not_found: bool = False,
+    compare_a_id: str = "",
 ) -> Div:
     """
     Analytics-first creator discovery dashboard.
@@ -878,6 +879,28 @@ def render_creators_page(
             total_count=total_count,
             per_page=per_page,
         ),
+        # Compare-mode context banner — shown when the user arrived from the
+        # "Search all creators" fallback on the compare pick page (?a=<uuid>).
+        # Each creator card's link will carry ?a=<uuid> so the profile page can
+        # offer a direct "Compare with [Creator A]" button.
+        (
+            Div(
+                UkIcon("git-compare", cls="size-4 text-purple-500 shrink-0 mt-0.5"),
+                P(
+                    "Comparison mode — click any creator to compare them with your selected creator.",
+                    cls="text-sm text-foreground",
+                ),
+                A(
+                    "Cancel",
+                    href="/creators",
+                    cls="text-sm text-muted-foreground hover:text-foreground underline shrink-0",
+                ),
+                cls="flex items-start gap-2 px-4 py-3 mb-4 rounded-xl border border-purple-200 "
+                "bg-purple-50 dark:bg-purple-950/30 dark:border-purple-800",
+            )
+            if compare_a_id
+            else None
+        ),
         # "@handle not in DB" banner — only shown alongside a real results grid.
         # When creators is empty, _render_empty_state Flow 1 handles the CTA,
         # avoiding duplicate id="creator-add-result" in the same page.
@@ -889,7 +912,9 @@ def render_creators_page(
         # Creators grid or empty state
         (
             Div(
-                _render_creators_grid(creators, favourite_ids=favourite_ids),
+                _render_creators_grid(
+                    creators, favourite_ids=favourite_ids, compare_a_id=compare_a_id
+                ),
                 # Pagination controls
                 _render_pagination(
                     page=page,
@@ -1763,12 +1788,18 @@ def _render_filter_bar(
     )
 
 
-def _render_creators_grid(creators: list[dict], favourite_ids: set[str] | None = None) -> Div:
+def _render_creators_grid(
+    creators: list[dict], favourite_ids: set[str] | None = None, compare_a_id: str = ""
+) -> Div:
     """Grid of creator cards with strict row-based layout."""
     _favs = favourite_ids or set()
     return Div(
         *[
-            _render_creator_card(creator, is_favourited=safe_get_value(creator, "id", "") in _favs)
+            _render_creator_card(
+                creator,
+                is_favourited=safe_get_value(creator, "id", "") in _favs,
+                compare_a_id=compare_a_id,
+            )
             for creator in creators
         ],
         cls="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5",
@@ -2459,7 +2490,7 @@ def _build_recent_performance(
     )
 
 
-def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
+def _render_creator_card(creator: dict, is_favourited: bool = False, compare_a_id: str = "") -> Div:
     """
     Creator card - clean, data-driven design.
 
@@ -2644,9 +2675,10 @@ def _render_creator_card(creator: dict, is_favourited: bool = False) -> Div:
     creator_uuid = safe_get_value(creator, "id", "")
     if not creator_uuid:
         return card
+    _compare_qs = f"&a={compare_a_id}" if compare_a_id and compare_a_id != creator_uuid else ""
     return A(
         card,
-        href=f"{creator_profile_url(creator)}?name={quote(channel_name)}",
+        href=f"{creator_profile_url(creator)}?name={quote(channel_name)}{_compare_qs}",
         cls="block no-underline group min-w-0 w-full",
     )
 


### PR DESCRIPTION
When /creators is reached via ?a=<uuid> (the "Search all creators" fallback on the compare pick page), creator card links now carry ?a=<uuid> so the profile page Compare button resolves to /compare?a=<id_a>&b=<id_b> instead of starting a fresh comparison.

Also shows a purple "Comparison mode" banner above the results grid with a Cancel link to /creators.

Changed: routes/creators.py, views/creators.py

## Summary by Sourcery

Add comparison-mode context to the creators list and preserve the selected creator across navigation from the compare flow.

New Features:
- Show a comparison mode banner on the creators page when accessed with a selected creator ID via the `a` query parameter.
- Propagate the `a` compare context through creator card links so profile pages can directly offer comparison with the preselected creator.

Enhancements:
- Pass compare context from the creators route into the creators page rendering and grid/card components to support comparison-aware navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comparison-mode support to the creators listing.
  * Creator profile links now preserve the selected comparison context.
  * Added a comparison banner with an option to cancel comparison mode.

* **Bug Fixes**
  * Invalid or missing comparison values are safely ignored, preventing malformed links and unintended requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->