### PR TITLE
refactor(creators): extract AddCreatorForm component, fix poll timing

### DIFF
--- a/components/add_creator.py
+++ b/components/add_creator.py
@@ -1,0 +1,142 @@
+"""
+AddCreatorForm — reusable HTMX form for submitting a missing YouTube creator.
+
+Used in three contexts across the product:
+  - "handle not found" banner above search results       (compact, pre-filled)
+  - empty-state card when @handle returns no results     (card, pre-filled)
+  - empty-state card when a name/filter search misses    (card, open input)
+
+The form always posts to POST /creators/request and renders its response into
+a #creator-add-result slot injected below the submit button.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from fasthtml.common import *
+from monsterui.all import *
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_RESULT_SLOT_ID = "creator-add-result"
+
+_BTN_BASE = (
+    "flex items-center gap-1.5 font-semibold rounded-lg "
+    "bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shrink-0"
+)
+_BTN_SM = _BTN_BASE + " px-4 py-1.5 text-sm"
+_BTN_MD = _BTN_BASE + " px-5 py-2.5 text-sm"
+
+_LOGIN_BTN_BASE = (
+    "inline-flex items-center gap-1.5 font-semibold rounded-lg "
+    "border border-border hover:bg-accent transition-colors shrink-0 no-underline"
+)
+_LOGIN_BTN_SM = _LOGIN_BTN_BASE + " px-4 py-1.5 text-sm"
+_LOGIN_BTN_MD = _LOGIN_BTN_BASE + " px-5 py-2.5 text-sm"
+
+_INPUT_CLS = (
+    "flex-1 px-3 py-2 text-sm rounded-lg border border-border "
+    "bg-background focus:outline-none focus:ring-2 focus:ring-primary/40"
+)
+
+
+def _login_href(return_url: str) -> str:
+    return f"/login?{urlencode({'return_url': return_url})}"
+
+
+# ---------------------------------------------------------------------------
+# Public component
+# ---------------------------------------------------------------------------
+
+
+def AddCreatorForm(
+    is_authenticated: bool,
+    *,
+    prefill: str = "",
+    return_url: str = "/creators",
+    button_label: str = "",
+    size: str = "sm",
+    align: str = "start",
+) -> FT:
+    """
+    HTMX add-creator form / sign-in CTA.
+
+    Args:
+        is_authenticated: Whether the current user is logged in.
+        prefill:          Pre-fill and hide the input (one-click submit).
+                          When empty an open text ``<input>`` is shown instead.
+        return_url:       Login redirect target for unauthenticated users.
+        button_label:     Submit button text.  Defaults to ``"Add {prefill}"``
+                          when *prefill* is set, otherwise ``"Submit"``.
+        size:             ``"sm"`` (py-1.5) or ``"md"`` (py-2.5).
+        align:            Form flex alignment — ``"start"`` or ``"center"``.
+    """
+    btn_cls = _BTN_MD if size == "md" else _BTN_SM
+    login_btn_cls = _LOGIN_BTN_MD if size == "md" else _LOGIN_BTN_SM
+    form_cls = f"flex flex-col items-{'center' if align == 'center' else 'start'} gap-0"
+    result_slot = Div(id=_RESULT_SLOT_ID, cls="mt-2")
+
+    # Resolve default button label
+    label = button_label or (f"Add {prefill}" if prefill else "Submit")
+
+    if not is_authenticated:
+        # Unauthenticated — render a sign-in link (no form, no DB write)
+        if prefill:
+            return A(
+                UkIcon("log-in", cls="size-4"),
+                "Sign in with Google to add",
+                href=_login_href(return_url),
+                cls=login_btn_cls,
+            )
+        # Open-input variant: inline sentence link
+        return P(
+            A(
+                "Sign in with Google",
+                href=_login_href(return_url),
+                cls="text-primary hover:underline font-medium",
+            ),
+            " to submit a creator by @handle.",
+            cls="text-sm text-muted-foreground",
+        )
+
+    # Authenticated — render the HTMX form
+    if prefill:
+        # One-click: hidden input, single button
+        return Form(
+            Input(type="hidden", name="q", value=prefill),
+            Button(
+                UkIcon("plus-circle", cls="size-4"),
+                label,
+                type="submit",
+                cls=btn_cls,
+            ),
+            result_slot,
+            hx_post="/creators/request",
+            hx_target=f"#{_RESULT_SLOT_ID}",
+            cls=form_cls,
+        )
+
+    # Open input: text field + submit button side by side
+    return Form(
+        Div(
+            Input(
+                type="text",
+                name="q",
+                placeholder="@handle or channel ID…",
+                autocomplete="off",
+                cls=_INPUT_CLS,
+            ),
+            Button(
+                label,
+                type="submit",
+                cls=btn_cls,
+            ),
+            cls="flex gap-2",
+        ),
+        result_slot,
+        hx_post="/creators/request",
+        hx_target=f"#{_RESULT_SLOT_ID}",
+    )

--- a/components/add_creator.py
+++ b/components/add_creator.py
@@ -12,6 +12,7 @@ a #creator-add-result slot injected below the submit button.
 
 from __future__ import annotations
 
+from typing import Literal
 from urllib.parse import urlencode
 
 from fasthtml.common import *
@@ -22,6 +23,9 @@ from monsterui.all import *
 # ---------------------------------------------------------------------------
 
 _RESULT_SLOT_ID = "creator-add-result"
+
+# Icon size used inside flex-gap containers (no margin-right needed).
+_ICON_CLS = "size-4"
 
 _BTN_BASE = (
     "flex items-center gap-1.5 font-semibold rounded-lg "
@@ -58,8 +62,8 @@ def AddCreatorForm(
     prefill: str = "",
     return_url: str = "/creators",
     button_label: str = "",
-    size: str = "sm",
-    align: str = "start",
+    size: Literal["sm", "md"] = "sm",
+    align: Literal["start", "center"] = "start",
 ) -> FT:
     """
     HTMX add-creator form / sign-in CTA.
@@ -86,7 +90,7 @@ def AddCreatorForm(
         # Unauthenticated — render a sign-in link (no form, no DB write)
         if prefill:
             return A(
-                UkIcon("log-in", cls="size-4"),
+                UkIcon("log-in", cls=_ICON_CLS),
                 "Sign in with Google to add",
                 href=_login_href(return_url),
                 cls=login_btn_cls,
@@ -108,7 +112,7 @@ def AddCreatorForm(
         return Form(
             Input(type="hidden", name="q", value=prefill),
             Button(
-                UkIcon("plus-circle", cls="size-4"),
+                UkIcon("plus-circle", cls=_ICON_CLS),
                 label,
                 type="submit",
                 cls=btn_cls,

--- a/views/creators.py
+++ b/views/creators.py
@@ -54,6 +54,7 @@ from utils.creator_metrics import (
 )
 from db import calculate_creator_stats, get_creator_hero_stats
 from services.contact_extractor import extract_social_links
+from components.add_creator import AddCreatorForm
 from components.category_stats import render_category_box_plots
 from views.mentions import render_mentions_placeholder
 from components.seo import (
@@ -327,60 +328,6 @@ def _build_filter_url(
 # ============================================================================
 
 
-def render_add_creator_section() -> Div:
-    """
-    HTMX form that lets authenticated users submit a creator by @handle or
-    channel ID.  No YouTube API is called on the Vercel frontend — the input
-    is passed directly to the backend worker queue via ``POST /creators/request``.
-    """
-    return Div(
-        Div(
-            Div(
-                UkIcon("plus-circle", cls="size-5 text-primary shrink-0 mt-0.5"),
-                Div(
-                    H3("Submit a Creator", cls="text-base font-semibold text-foreground"),
-                    P(
-                        "Know a channel that's not listed? Submit their @handle or "
-                        "channel ID and our system will add them automatically.",
-                        cls="text-sm text-muted-foreground mt-0.5",
-                    ),
-                    cls="flex-1 min-w-0",
-                ),
-                cls="flex items-start gap-3",
-            ),
-            # Input + submit (HTMX inline form)
-            Form(
-                Div(
-                    Input(
-                        type="text",
-                        name="q",
-                        id="creator-add-input",
-                        placeholder="@MrBeast or UCX6OQ3DkcsbYNE6H8uQQuVA",
-                        autocomplete="off",
-                        cls="flex-1 px-3 py-2 text-sm rounded-lg border border-border "
-                        "bg-background focus:outline-none focus:ring-2 focus:ring-primary/40",
-                    ),
-                    Button(
-                        UkIcon("send", cls=_CLS_ICON_SM),
-                        "Submit",
-                        type="submit",
-                        cls="flex items-center px-4 py-2 text-sm font-medium rounded-lg "
-                        "bg-primary text-primary-foreground hover:bg-primary/90 "
-                        "transition-colors shrink-0",
-                    ),
-                    cls="flex gap-2 mt-3",
-                ),
-                # Response target injected below the form
-                Div(id="creator-add-result", cls="mt-3"),
-                hx_post="/creators/request",
-                hx_target="#creator-add-result",
-            ),
-            cls="p-4 rounded-xl border border-border bg-background",
-        ),
-        cls="mt-6 mb-2",
-    )
-
-
 def render_add_creator_result(
     success: bool,
     message: str,
@@ -503,11 +450,11 @@ def render_add_creator_status_result(
             "border border-red-200 dark:border-red-800",
         )
 
-    # Still processing — continue polling
+    # Still processing — continue polling (load fires immediately, then every 15s)
     status_url = f"/creators/add-status?{urlencode({'q': input_query})}"
     poll_attrs = dict(
         hx_get=status_url,
-        hx_trigger="every 15s",
+        hx_trigger="load, every 15s",
         hx_target="this",
         hx_swap="outerHTML",
     )
@@ -2852,31 +2799,13 @@ def _render_handle_not_found_banner(search: str, is_authenticated: bool) -> Div:
     returned no exact DB match — even if related creators are shown below.
     Reuses the same HTMX endpoint as the empty-state Flow 1.
     """
-    result_slot = Div(id="creator-add-result", cls="mt-2")
-
-    if is_authenticated:
-        action = Form(
-            Input(type="hidden", name="q", value=search),
-            Button(
-                UkIcon("plus-circle", cls=_CLS_ICON_SM),
-                f"Add {search}",
-                type="submit",
-                cls="flex items-center px-4 py-1.5 text-sm font-semibold rounded-lg "
-                "bg-primary text-primary-foreground hover:bg-primary/90 transition-colors shrink-0",
-            ),
-            result_slot,
-            hx_post="/creators/request",
-            hx_target="#creator-add-result",
-            cls="flex flex-col items-start gap-0",
-        )
-    else:
-        action = A(
-            UkIcon("log-in", cls=_CLS_ICON_SM),
-            "Sign in with Google to add",
-            href=_login_href(f"/creators?search={quote_plus(search)}" if search else "/creators"),
-            cls="inline-flex items-center px-4 py-1.5 text-sm font-semibold rounded-lg "
-            "border border-border hover:bg-accent transition-colors shrink-0",
-        )
+    action = AddCreatorForm(
+        is_authenticated,
+        prefill=search,
+        return_url=f"/creators?search={quote_plus(search)}" if search else "/creators",
+        size="sm",
+        align="start",
+    )
 
     return Div(
         Div(
@@ -2930,29 +2859,14 @@ def _render_empty_state(
     # Known handle → pre-fill the form so user needs only one click
     # ────────────────────────────────────────────────────────────────────────
     if search and search.startswith("@"):
-        if is_authenticated:
-            add_cta = Form(
-                Input(type="hidden", name="q", value=search),
-                Button(
-                    UkIcon("plus-circle", cls=_CLS_ICON_SM),
-                    f"Add {search} to ViralVibes",
-                    type="submit",
-                    cls="flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg "
-                    "bg-primary text-primary-foreground hover:bg-primary/90 transition-colors",
-                ),
-                result_slot,
-                hx_post="/creators/request",
-                hx_target="#creator-add-result",
-                cls="flex flex-col items-center gap-0",
-            )
-        else:
-            add_cta = A(
-                UkIcon("log-in", cls=_CLS_ICON_SM),
-                "Sign in with Google to add this creator",
-                href=_login_href(f"/creators?search={quote_plus(search)}"),
-                cls="inline-flex items-center px-5 py-2.5 text-sm font-semibold rounded-lg "
-                "border border-border hover:bg-accent transition-colors",
-            )
+        add_cta = AddCreatorForm(
+            is_authenticated,
+            prefill=search,
+            return_url=f"/creators?search={quote_plus(search)}",
+            button_label=f"Add {search} to ViralVibes",
+            size="md",
+            align="center",
+        )
 
         return Card(
             Div(
@@ -2978,42 +2892,12 @@ def _render_empty_state(
     # ────────────────────────────────────────────────────────────────────────
     if has_active_filters:
         label = f'No creators match "{search}"' if search else "No creators match these filters"
-        if is_authenticated:
-            submit_area = Form(
-                Div(
-                    Input(
-                        type="text",
-                        name="q",
-                        placeholder="@handle or channel ID…",
-                        autocomplete="off",
-                        cls="flex-1 px-3 py-2 text-sm rounded-lg border border-border "
-                        "bg-background focus:outline-none focus:ring-2 focus:ring-primary/40",
-                    ),
-                    Button(
-                        "Submit",
-                        type="submit",
-                        cls="px-4 py-2 text-sm font-semibold rounded-lg "
-                        "bg-primary text-primary-foreground hover:bg-primary/90 "
-                        "transition-colors shrink-0",
-                    ),
-                    cls="flex gap-2",
-                ),
-                result_slot,
-                hx_post="/creators/request",
-                hx_target="#creator-add-result",
-            )
-        else:
-            submit_area = P(
-                A(
-                    "Sign in with Google",
-                    href=_login_href(
-                        f"/creators?search={quote_plus(search)}" if search else "/creators"
-                    ),
-                    cls="text-primary hover:underline font-medium",
-                ),
-                " to submit a creator by @handle.",
-                cls=_CLS_MUTED_SM,
-            )
+        submit_area = AddCreatorForm(
+            is_authenticated,
+            prefill="",
+            return_url=f"/creators?search={quote_plus(search)}" if search else "/creators",
+            size="sm",
+        )
 
         return Card(
             Div(

--- a/views/creators.py
+++ b/views/creators.py
@@ -450,11 +450,13 @@ def render_add_creator_status_result(
             "border border-red-200 dark:border-red-800",
         )
 
-    # Still processing — continue polling (load fires immediately, then every 15s)
+    # Still processing — wait 15s before the next check.
+    # No 'load' trigger here: this card was just fetched (via the 15s poll on
+    # the queued card), so firing immediately would create a rapid re-poll loop.
     status_url = f"/creators/add-status?{urlencode({'q': input_query})}"
     poll_attrs = dict(
         hx_get=status_url,
-        hx_trigger="load, every 15s",
+        hx_trigger="every 15s",
         hx_target="this",
         hx_swap="outerHTML",
     )


### PR DESCRIPTION
- Delete dead render_add_creator_section() (exported but never called)
- Add components/add_creator.py: AddCreatorForm(is_authenticated, prefill, return_url, button_label, size, align) replaces three separate inline form copies in views/creators.py
- _render_handle_not_found_banner, _render_empty_state Flow 1 and Flow 2 now delegate to the shared component (~60 lines removed)
- Fix processing-card poll: hx_trigger="every 15s" → "load, every 15s" so a fast worker completes without waiting for the first 15s tick

## Summary by Sourcery

Consolidate creator submission interfaces and make processing status updates respond immediately.

Bug Fixes:
- Start creator-status polling immediately when the status card loads while preserving the 15-second polling interval for subsequent checks.

Enhancements:
- Centralize authenticated add-creator forms and unauthenticated sign-in prompts in a reusable component.
- Remove the unused add-creator rendering function and consolidate duplicated creator submission UI across search empty states and banners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable creator-submission forms with configurable labels, sizing, alignment, and prefilled handles.
  * Unauthenticated visitors now see sign-in links when attempting to add creators.
  * Creator-submission prompts are available in handle-not-found and empty-state views.

* **Bug Fixes**
  * Processing-status updates now appear immediately and refresh every 15 seconds for more timely feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->