### PR TITLE
fix(creators): show one-click add CTA for plain handle-like searches

### DIFF
--- a/views/creators.py
+++ b/views/creators.py
@@ -98,6 +98,7 @@ def _login_href(return_url: str = "/creators") -> str:
 # Matches a bare YouTube handle token — same alphabet as the @handle format
 # but without the leading @.  Used to detect searches like "mrbeast" or
 # "ai.engineer" that are clearly handle-intent even without the @ prefix.
+# Character class must stay in sync with db._HANDLE_RE = r"^@[a-zA-Z0-9._-]{1,100}$".
 _HANDLE_LIKE_RE = _re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
 
 
@@ -2865,11 +2866,11 @@ def _render_empty_state(
     # Triggers on "@mrbeast" AND bare "mrbeast" (same user intent, different
     # typing habit).  prefill always includes @ so the submit form is correct.
     # ────────────────────────────────────────────────────────────────────────
-    _is_handle_intent = search and (
-        search.startswith("@") or bool(_HANDLE_LIKE_RE.match(search.strip()))
-    )
+    # Strip once so "  @mrbeast" and "  mrbeast" both hit the handle path.
+    _s = search.strip()
+    _is_handle_intent = _s and (_s.startswith("@") or bool(_HANDLE_LIKE_RE.match(_s)))
     if _is_handle_intent:
-        prefill = search if search.startswith("@") else f"@{search.strip()}"
+        prefill = _s if _s.startswith("@") else f"@{_s}"
         add_cta = AddCreatorForm(
             is_authenticated,
             prefill=prefill,

--- a/views/creators.py
+++ b/views/creators.py
@@ -95,6 +95,12 @@ def _login_href(return_url: str = "/creators") -> str:
     return f"/login?{urlencode({'return_url': return_url})}"
 
 
+# Matches a bare YouTube handle token — same alphabet as the @handle format
+# but without the leading @.  Used to detect searches like "mrbeast" or
+# "ai.engineer" that are clearly handle-intent even without the @ prefix.
+_HANDLE_LIKE_RE = _re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
+
+
 def creator_profile_url(creator: dict) -> str:
     """Return the canonical profile URL for a creator.
 
@@ -2841,13 +2847,11 @@ def _render_empty_state(
     """Empty state when no creators found.
 
     Three progressive-disclosure flows:
-    1. @handle typed → one-click "Add to ViralVibes" CTA (handle pre-filled)
+    1. @handle typed OR bare handle-like term (e.g. "mrbeast") with no match
+       → one-click pre-filled "Add to ViralVibes" CTA
     2. Name search / filters, no results → inline handle submit form
     3. Truly empty DB → encourage playlist analysis
     """
-
-    # ── shared submit result target (HTMX drops response here) ──────────────
-    result_slot = Div(id="creator-add-result", cls="mt-3")
 
     # ── shared "back to all" link ────────────────────────────────────────────
     back_link = A(
@@ -2857,15 +2861,20 @@ def _render_empty_state(
     )
 
     # ────────────────────────────────────────────────────────────────────────
-    # FLOW 1 — @handle typed, no match in DB
-    # Known handle → pre-fill the form so user needs only one click
+    # FLOW 1 — handle-intent search, no match in DB
+    # Triggers on "@mrbeast" AND bare "mrbeast" (same user intent, different
+    # typing habit).  prefill always includes @ so the submit form is correct.
     # ────────────────────────────────────────────────────────────────────────
-    if search and search.startswith("@"):
+    _is_handle_intent = search and (
+        search.startswith("@") or bool(_HANDLE_LIKE_RE.match(search.strip()))
+    )
+    if _is_handle_intent:
+        prefill = search if search.startswith("@") else f"@{search.strip()}"
         add_cta = AddCreatorForm(
             is_authenticated,
-            prefill=search,
+            prefill=prefill,
             return_url=f"/creators?search={quote_plus(search)}",
-            button_label=f"Add {search} to ViralVibes",
+            button_label=f"Add {prefill} to ViralVibes",
             size="md",
             align="center",
         )
@@ -2874,7 +2883,7 @@ def _render_empty_state(
             Div(
                 Span("👀", cls="text-5xl block text-center mb-3"),
                 H2(
-                    f"{search} isn't in our database yet",
+                    f"{prefill} isn't in our database yet",
                     cls="text-center text-xl font-bold mb-1",
                 ),
                 P(


### PR DESCRIPTION
Previously typing "mrbeast" (no @) with no results landed on the generic Flow 2 empty state (blank input form). Only "@mrbeast" triggered the pre-filled one-click Flow 1 card.

- Add _HANDLE_LIKE_RE = r"^[a-zA-Z0-9._-]{1,100}$" in views/creators.py
- Flow 1 now fires when search starts with "@" OR matches the handle alphabet (single token, no spaces)
- prefill is always normalised to "@handle" format so the submit form receives the correct input regardless of how the user typed it
- Remove dead result_slot variable (leftover from pre-component refactor)

## Summary by Sourcery

Recognize bare handle-like searches as creator-add intent and present the normalized one-click add flow.

New Features:
- Show the one-click add-creator CTA for no-result searches that look like bare creator handles, such as “mrbeast”.
- Normalize bare handle searches to the canonical “@handle” format in the prefilled add form and empty state.

Bug Fixes:
- Ensure handle-intent searches without an @ prefix no longer fall through to the generic empty state.

Chores:
- Remove the unused empty-state result target.