### PR TITLE
fix(creators): redirect after NL country extraction so filter pill ac…

### DIFF
--- a/routes/creators.py
+++ b/routes/creators.py
@@ -305,15 +305,31 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
     # Detects patterns like "MKBHD from Germany" or "gaming creators in Japan"
     # and splits them into a name search + a country_filter, but only when the
     # user has NOT already explicitly set a country filter via the pill UI.
+    #
+    # We redirect rather than mutating locals so the inferred country is
+    # explicit in the URL: the country pill activates, the URL is shareable,
+    # and pagination page numbers stay consistent.
     if search and country_filter == "all":
         parsed_search, inferred_country = _extract_country(search)
         if inferred_country != "all":
-            search = parsed_search
-            country_filter = inferred_country
             logger.debug(
-                "[CountryExtract] inferred country=%s from query",
-                country_filter,
+                "[CountryExtract] inferred country=%s from query %r; redirecting",
+                inferred_country,
+                search,
             )
+            redirect_params: dict[str, str] = {"sort": sort, "country": inferred_country}
+            if parsed_search:
+                redirect_params["search"] = parsed_search
+            for key, val in [
+                ("grade", grade_filter),
+                ("language", language_filter),
+                ("activity", activity_filter),
+                ("age", age_filter),
+                ("category", category_filter),
+            ]:
+                if val and val != "all":
+                    redirect_params[key] = val
+            return RedirectResponse(f"/creators?{urlencode(redirect_params)}", status_code=303)
 
     # Pagination parameters
     # NOTE: max(1, ...) clamps page to >= 1, so page < 1 is impossible.

--- a/routes/creators.py
+++ b/routes/creators.py
@@ -317,19 +317,19 @@ def creators_route(request, is_authenticated: bool = False, user_id: str | None 
                 inferred_country,
                 search,
             )
-            redirect_params: dict[str, str] = {"sort": sort, "country": inferred_country}
+            # Build redirect params from the live request so any future filter
+            # params are preserved automatically, then override the extracted
+            # values and drop the page number (results will change).
+            redirect_params = dict(request.query_params)
+            redirect_params["country"] = inferred_country
             if parsed_search:
                 redirect_params["search"] = parsed_search
-            for key, val in [
-                ("grade", grade_filter),
-                ("language", language_filter),
-                ("activity", activity_filter),
-                ("age", age_filter),
-                ("category", category_filter),
-            ]:
-                if val and val != "all":
-                    redirect_params[key] = val
-            return RedirectResponse(f"/creators?{urlencode(redirect_params)}", status_code=303)
+            else:
+                redirect_params.pop("search", None)
+            redirect_params.pop("page", None)
+            return RedirectResponse(
+                f"{request.url.path}?{urlencode(redirect_params)}", status_code=303
+            )
 
     # Pagination parameters
     # NOTE: max(1, ...) clamps page to >= 1, so page < 1 is impossible.


### PR DESCRIPTION
…tivates

Previously "gaming creators in Japan" mutated local variables (search, country_filter) but left the URL as ?search=gaming+creators+in+Japan. The country pill didn't reliably activate (JP must be in the top-8 pill list), the URL was not shareable, and pagination could re-trigger extraction on every page load.

Replace local mutation with a 303 redirect to
?search=gaming+creators&country=JP&sort=subscribers so the country filter is explicit in the URL. The pill activates naturally, the page renders with a canonical URL, and existing filter params are forwarded. Bare country-only phrases like "in Japan" redirect to ?country=JP (empty search, all JP creators).

## Summary by Sourcery

Canonicalize creator searches with inferred countries through redirects that expose the country filter in the URL.

Bug Fixes:
- Redirect inferred country searches to canonical URLs so country filters activate reliably, URLs are shareable, and pagination does not repeat extraction.
- Support country-only queries by redirecting them to an empty search with the inferred country filter.

Enhancements:
- Preserve existing query parameters during country-extraction redirects while removing the stale page number.