### PR TITLE
feat(compare): add inline search + add-creator form to pick page

### DIFF
--- a/routes/creators.py
+++ b/routes/creators.py
@@ -821,6 +821,7 @@ def compare_creators_route(request, user_id: str | None = None):
             creator_a,
             similar_creators=similar_creators_a,
             embedding_peers=embedding_peers_a or [],
+            is_authenticated=bool(user_id),
         )
 
     creator_a = get_creator_stats(id_a)

--- a/views/compare.py
+++ b/views/compare.py
@@ -20,6 +20,7 @@ from utils.creator_metrics import (
     get_language_name,
 )
 from views.creators import get_topic_category_emoji
+from components.add_creator import AddCreatorForm
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -180,6 +181,7 @@ def render_compare_pick_page(
     creator_a: dict,
     similar_creators: list[dict],
     embedding_peers: list[dict],
+    is_authenticated: bool = False,
 ) -> Div:
     """
     Step-2 page: user has chosen creator A and needs to pick creator B.
@@ -287,20 +289,47 @@ def render_compare_pick_page(
         cls="text-center mb-8",
     )
 
-    # ── Search fallback ──────────────────────────────────────────────────
+    # ── Search + add fallback ────────────────────────────────────────────
+    # Inline search navigates to /creators?a=<id> (compare-mode) so the
+    # selected creator's ID is threaded through to the profile link.
+    # AddCreatorForm lets the user queue a missing creator without leaving.
     search_fallback = Div(
-        P(
-            "Don't see who you're looking for?",
-            cls="text-xs text-muted-foreground mb-2",
-        ),
-        A(
-            UkIcon("search", cls="w-3.5 h-3.5 mr-1"),
-            "Search all creators",
-            href=f"/creators?a={id_a}",
-            cls=(
-                "inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-semibold "
-                "no-underline bg-accent hover:bg-accent/80 text-foreground transition-colors"
+        Div(
+            P(
+                "Don't see who you're looking for?",
+                cls="text-xs font-semibold text-foreground mb-2",
             ),
+            Form(
+                Div(
+                    UkIcon(
+                        "search",
+                        cls="absolute left-3 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none",
+                    ),
+                    Input(
+                        type="search",
+                        name="search",
+                        placeholder="Search creators…",
+                        autocomplete="off",
+                        cls="w-full pl-8 pr-3 py-1.5 text-sm rounded-lg border border-border "
+                        "bg-background focus:outline-none focus:ring-2 focus:ring-primary/25",
+                    ),
+                    Input(type="hidden", name="a", value=id_a),
+                    cls="relative",
+                ),
+                method="GET",
+                action="/creators",
+                cls="mb-3",
+            ),
+            P(
+                "Creator not in our database?",
+                cls="text-xs text-muted-foreground mb-1.5",
+            ),
+            AddCreatorForm(
+                is_authenticated,
+                return_url=f"/compare?a={id_a}",
+                size="sm",
+            ),
+            cls="p-4 rounded-xl border border-border bg-background",
         ),
         cls="pt-4 border-t border-border",
     )

--- a/views/compare.py
+++ b/views/compare.py
@@ -337,18 +337,10 @@ def render_compare_pick_page(
     body_content = (
         Div(
             P(
-                "No suggestions available. Search for a creator to compare.",
+                "No suggestions available yet.",
                 cls="text-sm text-muted-foreground mb-4",
             ),
-            A(
-                UkIcon("search", cls="w-4 h-4 mr-1.5"),
-                "Search all creators",
-                href=f"/creators?a={id_a}",
-                cls=(
-                    "inline-flex items-center px-4 py-2 rounded-lg text-sm font-semibold "
-                    "no-underline bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
-                ),
-            ),
+            search_fallback,
         )
         if no_suggestions
         else Div(


### PR DESCRIPTION
The step-2 "pick creator B" page previously only had a "Search all creators" link that bounced the user to /creators. Replace it with:

- Inline search input → GET /creators?a=<id>&search=<term> (compare-mode is preserved via the hidden ?a= param)
- AddCreatorForm below for submitting a missing creator directly, with return_url=/compare?a=<id> so the user lands back after login

Changes:
  views/compare.py  — import AddCreatorForm, add is_authenticated param, replace search_fallback Div routes/creators.py — pass is_authenticated=bool(user_id) to render_compare_pick_page

## Summary by Sourcery

Improve the creator selection step by enabling inline search and direct submission of missing creators.

New Features:
- Add inline creator search to the compare flow while preserving the selected creator and compare context.
- Allow users to submit missing creators directly from the compare pick page with authentication-aware return navigation.

Enhancements:
- Replace the previous search link fallback with a combined search and add-creator experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline creator search form to the comparison selection page.
  * Authenticated users can add creators directly while selecting a comparison.
  * Selected creators and comparison context are preserved when returning to the comparison page.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->