### PR TITLE
feat(analysis-ux): faster feedback during playlist analysis submission

### DIFF
--- a/controllers/job_progress.py
+++ b/controllers/job_progress.py
@@ -231,7 +231,50 @@ def job_progress_controller(playlist_url: str):
         preview_info=preview_info,
         retry_count=retry_count,
         max_retries=MAX_RETRY_ATTEMPTS,
+        started_at=job_data.get("started_at"),
     )
+
+
+def _elapsed_timer_widgets(started_at: str | None) -> list:
+    """Return a live elapsed-time Span + a self-contained client-side timer Script.
+
+    The Script clears any previous interval (stored in window._vvElapsedTimer)
+    so repeated HTMX swaps don't accumulate stale setInterval calls.
+    Returns an empty list when started_at is unavailable.
+    """
+    if not started_at:
+        return []
+    try:
+        from datetime import datetime
+
+        dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        start_ts = int(dt.timestamp())
+    except (ValueError, AttributeError, OSError):
+        return []
+
+    timer_script = f"""
+(function() {{
+    if (window._vvElapsedTimer) clearInterval(window._vvElapsedTimer);
+    var startTs = {start_ts} * 1000;
+    function tick() {{
+        var el = document.getElementById('vv-elapsed-timer');
+        if (!el) {{ clearInterval(window._vvElapsedTimer); return; }}
+        var elapsed = Math.floor((Date.now() - startTs) / 1000);
+        var m = Math.floor(elapsed / 60), s = elapsed % 60;
+        el.textContent = m > 0 ? m + 'm ' + s + 's' : s + 's';
+    }}
+    tick();
+    window._vvElapsedTimer = setInterval(tick, 1000);
+}})();
+"""
+    return [
+        Div(
+            Span("⏱ Elapsed: ", cls="text-sm text-gray-500"),
+            Span("…", id="vv-elapsed-timer", cls="text-sm font-medium text-gray-700"),
+            cls="text-center mt-4 text-gray-600",
+        ),
+        Script(timer_script),
+    ]
 
 
 def render_job_progress_ui(
@@ -241,6 +284,7 @@ def render_job_progress_ui(
     preview_info: dict,
     retry_count: int = 0,
     max_retries: int = 3,
+    started_at: str | None = None,
 ):
     """
     Render the progress UI with preview data.
@@ -368,10 +412,12 @@ def render_job_progress_ui(
             ),
             cls="bg-gradient-to-br from-purple-50 to-blue-50 p-4 rounded-lg border",
         ),
+        # Live elapsed timer — ticks every second client-side between polls
+        *(_elapsed_timer_widgets(started_at)),
         cls="p-6 bg-white rounded-xl shadow-lg border max-w-3xl mx-auto",
         id="preview-box",
-        # 🔄 Continue polling
+        # 🔄 Continue polling every 3s (down from 10s)
         hx_get=f"/job-progress?playlist_url={quote_plus(playlist_url)}",
-        hx_trigger="every 10s",
+        hx_trigger="every 3s",
         hx_swap="outerHTML",
     )

--- a/controllers/job_progress.py
+++ b/controllers/job_progress.py
@@ -8,6 +8,10 @@ from urllib.parse import quote_plus
 from fasthtml.common import *
 from monsterui.all import *
 
+# How often the in-progress UI polls /job-progress for an update.
+# Tune here without touching view code.
+_PROGRESS_POLL_INTERVAL = "every 3s"
+
 from components.errors import get_user_friendly_error
 from components.processing_tips import get_tip_for_progress
 from constants import JobStatus, MAX_RETRY_ATTEMPTS
@@ -250,6 +254,7 @@ def _elapsed_timer_widgets(started_at: str | None) -> list:
         dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
         start_ts = int(dt.timestamp())
     except (ValueError, AttributeError, OSError):
+        logger.warning("_elapsed_timer_widgets: could not parse started_at %r", started_at)
         return []
 
     timer_script = f"""
@@ -259,7 +264,7 @@ def _elapsed_timer_widgets(started_at: str | None) -> list:
     function tick() {{
         var el = document.getElementById('vv-elapsed-timer');
         if (!el) {{ clearInterval(window._vvElapsedTimer); return; }}
-        var elapsed = Math.floor((Date.now() - startTs) / 1000);
+        var elapsed = Math.max(0, Math.floor((Date.now() - startTs) / 1000));
         var m = Math.floor(elapsed / 60), s = elapsed % 60;
         el.textContent = m > 0 ? m + 'm ' + s + 's' : s + 's';
     }}
@@ -416,8 +421,8 @@ def render_job_progress_ui(
         *(_elapsed_timer_widgets(started_at)),
         cls="p-6 bg-white rounded-xl shadow-lg border max-w-3xl mx-auto",
         id="preview-box",
-        # 🔄 Continue polling every 3s (down from 10s)
+        # 🔄 Continue polling (interval tunable via _PROGRESS_POLL_INTERVAL)
         hx_get=f"/job-progress?playlist_url={quote_plus(playlist_url)}",
-        hx_trigger="every 3s",
+        hx_trigger=_PROGRESS_POLL_INTERVAL,
         hx_swap="outerHTML",
     )

--- a/main.py
+++ b/main.py
@@ -796,10 +796,27 @@ def validate_url(playlist: YoutubePlaylist, req, sess):
         # Redirect to clean login page (avoids navbar duplication)
         return RedirectResponse("/login", status_code=303)
 
-    # Authenticated user - proceed to preview
-    return Script(
-        "htmx.ajax('POST', '/validate/preview', {target: '#preview-box', values: {playlist_url: '%s'}});"
-        % playlist.playlist_url
+    # Authenticated user - proceed to preview.
+    # Return two things at once via HTMX OOB:
+    #   1. A loading skeleton swapped into #preview-box immediately (OOB innerHTML)
+    #   2. A Script that fires the actual /validate/preview HTMX request
+    # This eliminates the blank gap between form submit and the preview card
+    # appearing.  json.dumps() safely escapes the URL for JS (XSS guard).
+    safe_url = json.dumps(playlist.playlist_url)
+    return (
+        Div(
+            Div(
+                Loading(cls=(LoadingT.ring, LoadingT.sm, "text-primary")),
+                Span("Loading playlist…", cls="text-sm text-muted-foreground ml-2"),
+                cls="flex items-center justify-center py-10",
+            ),
+            id="preview-box",
+            hx_swap_oob="innerHTML",
+        ),
+        Script(
+            f"htmx.ajax('POST', '/validate/preview', "
+            f"{{target: '#preview-box', values: {{playlist_url: {safe_url}}}}});"
+        ),
     )
 
 
@@ -1159,18 +1176,19 @@ def submit_job(playlist_url: str, req, sess):
     #     hx_trigger="every 3s",
     #     hx_swap="outerHTML",
     # )
-    # Instead of polling instruction, show the full engagement screen
+    # Fire the first /job-progress poll immediately on load.
+    # Subsequent polling is managed by the progress UI itself (every 3s),
+    # so we only need the initial "load" trigger here.
     return Div(
         hx_get=f"/job-progress?playlist_url={quote_plus(playlist_url)}",
-        hx_trigger="load, every 10s",
+        hx_trigger="load",
         hx_swap="outerHTML",
         id="preview-box",
         children=[
-            P("Analyzing playlist... This might take a moment."),
-            Span(
-                cls="loading loading-bars loading-large",
-                id="loading-bar",
-                style="margin-top:1rem; color:#393e6e;",
+            Div(
+                Loading(cls=(LoadingT.ring, LoadingT.sm, "text-primary")),
+                Span("Queuing analysis…", cls="text-sm text-muted-foreground ml-2"),
+                cls="flex items-center justify-center py-10",
             ),
         ],
     )


### PR DESCRIPTION
PR 1 — immediate skeleton between URL validation and preview card
- views/main.py validate_url: replace bare Script return with an HTMX OOB innerHTML swap that shows a spinner in #preview-box immediately, eliminating the 1–3 s blank gap while /validate/preview loads
- Fix XSS: playlist_url interpolated via json.dumps() instead of bare %s

PR 2 — faster progress polling + client-side live elapsed timer
- submit_job: simplify hx_trigger from "load, every 10s" to "load"; the progress view manages its own polling so the 10s fallback is dead code
- render_job_progress_ui: reduce poll interval from every 10s to every 3s
- Add _elapsed_timer_widgets(): renders an "⏱ Elapsed: Xs" counter that ticks every second via setInterval, keyed to job started_at timestamp; previous intervals cleared on each HTMX swap via window._vvElapsedTimer
- Pass started_at through job_progress_controller → render_job_progress_ui

## Summary by Sourcery

Improve playlist analysis feedback by showing loading states immediately and providing faster, more informative progress updates.

New Features:
- Show an immediate loading skeleton while playlist preview validation is in progress.
- Display a live elapsed-time counter during playlist analysis.

Bug Fixes:
- Safely escape playlist URLs before embedding them in client-side requests to prevent XSS.
- Avoid redundant progress polling initiated by the job submission view.

Enhancements:
- Increase analysis progress update frequency to provide faster feedback.