### PR TITLE
fix(preview): skip preview card flash on auto-submit

### DIFF
--- a/controllers/preview.py
+++ b/controllers/preview.py
@@ -51,17 +51,14 @@ def preview_playlist_controller(playlist_url: str):
         logger.warning("Preview: job blocked")
         return render_blocked_preview()
 
-    # 3. Preview data (DB stub or API fallback)
-    preview_info = get_playlist_preview_info(playlist_url) or {}
-
-    # ✅ Auto-submit if no job exists or job failed
-    auto_submit = job_status is None or job_status == JobStatus.FAILED
-
-    if auto_submit:
+    # ✅ Auto-submit if no job exists or job failed — return before the
+    # preview-info DB query; that data is unused by the placeholder.
+    if job_status is None or job_status == JobStatus.FAILED:
         logger.info(f"Auto-submitting job for {playlist_url}")
-        # Skip rendering the full preview card — it would flash briefly then
-        # vanish when /submit-job fires.  Return a minimal spinner instead.
         return render_queuing_placeholder(playlist_url=playlist_url)
+
+    # 3. Preview data (DB stub or API fallback) — only needed for the card
+    preview_info = get_playlist_preview_info(playlist_url) or {}
 
     return render_preview_card(
         playlist_url=playlist_url,

--- a/controllers/preview.py
+++ b/controllers/preview.py
@@ -9,6 +9,7 @@ from db import (
 from views.preview import (
     render_blocked_preview,
     render_preview_card,
+    render_queuing_placeholder,
     render_redirect_to_full,
 )
 
@@ -58,10 +59,13 @@ def preview_playlist_controller(playlist_url: str):
 
     if auto_submit:
         logger.info(f"Auto-submitting job for {playlist_url}")
+        # Skip rendering the full preview card — it would flash briefly then
+        # vanish when /submit-job fires.  Return a minimal spinner instead.
+        return render_queuing_placeholder(playlist_url=playlist_url)
 
     return render_preview_card(
         playlist_url=playlist_url,
         job_status=job_status,
         preview_info=preview_info,
-        auto_submit=auto_submit,
+        auto_submit=False,
     )

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -305,7 +305,7 @@ class TestURLValidationAndPreview:
         Flow:
         1. No cache exists
         2. No active job found (job_status = None)
-        3. auto_submit=True passed to render_preview_card
+        3. Queuing placeholder returned (no preview card flash)
         4. HTMX trigger fires /submit-job on page load
         """
         monkeypatch.setattr(
@@ -316,19 +316,17 @@ class TestURLValidationAndPreview:
             "controllers.preview.get_playlist_job_status",
             lambda url: None,  # No job exists
         )
-        monkeypatch.setattr(
-            "controllers.preview.get_playlist_preview_info",
-            lambda url: make_test_preview_data(),
-        )
+        # get_playlist_preview_info is NOT called on the auto-submit path
 
         r = client.post("/validate/preview", data={"playlist_url": TEST_PLAYLIST_URL})
 
         assert r.status_code == 200
-        # Should show preview card
-        assert "Test Playlist" in r.text
-        # Should have auto-submit trigger (check for just "load", not "load once")
+        # Placeholder — no preview card content visible
+        assert "Test Playlist" not in r.text
+        assert "Queuing analysis" in r.text
+        # Auto-submit trigger must still be present
         assert 'hx-post="/submit-job"' in r.text
-        assert 'hx-trigger="load"' in r.text  # ✅ Fixed: removed "once"
+        assert 'hx-trigger="load"' in r.text
 
     def test_preview_auto_submit_when_job_failed(self, client, monkeypatch):
         """

--- a/views/preview.py
+++ b/views/preview.py
@@ -22,6 +22,34 @@ def render_redirect_to_full(playlist_url: str):
     )
 
 
+def render_queuing_placeholder(*, playlist_url: str, user_id: str | None = None):
+    """
+    Returned by preview_playlist_controller when auto_submit=True.
+    Avoids flashing the full preview card before the job is queued:
+    the spinner is already visible; we just keep it and fire /submit-job.
+    """
+    return Div(
+        # Hidden trigger — fires immediately on DOM insertion
+        Div(
+            hx_post="/submit-job",
+            hx_vals={
+                "playlist_url": playlist_url,
+                **(({"user_id": user_id}) if user_id else {}),
+            },
+            hx_trigger="load",
+            hx_target="#preview-box",
+            hx_swap="outerHTML",
+            style="display:none;",
+        ),
+        # Keep the same spinner that validate_url already rendered
+        Div(
+            Loading(cls=(LoadingT.ring, LoadingT.sm, "text-primary")),
+            Span("Queuing analysis\u2026", cls="text-sm text-muted-foreground ml-2"),
+            cls="flex items-center justify-center py-10",
+        ),
+    )
+
+
 def render_blocked_preview():
     return Div(
         UkIcon("ban", width=48, height=48, cls="text-red-500 mb-4"),


### PR DESCRIPTION
When a URL has no existing job, preview_playlist_controller previously returned the full render_preview_card (thumbnail, title, channel info) with auto_submit=True. The card would appear briefly before the hidden hx_trigger="load" fired /submit-job and replaced it — a one-frame flash the user never chose to see.

New render_queuing_placeholder (views/preview.py) returns only the hidden HTMX auto-submit trigger plus a "Queuing analysis…" spinner, continuing the loading state that validate_url already put in #preview-box.

The full preview card is unchanged and still rendered for jobs already in pending/processing state.

## Summary by Sourcery

Replace the auto-submit preview card with a queuing placeholder to avoid a brief flash before job submission.

Bug Fixes:
- Prevent the preview card from flashing when a URL is automatically submitted by showing a queuing placeholder instead.
- Preserve the existing preview card for jobs that are already pending or processing.

Enhancements:
- Skip unnecessary preview-data lookup on automatic submission paths.

Tests:
- Update endpoint coverage to verify the queuing placeholder is shown without preview-card content while retaining the HTMX auto-submit trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the preview experience when playlist analysis is queued or has failed.
  * Displays a loading placeholder while analysis is submitted instead of showing an incomplete preview.
  * Prevents automatic submission in paths where it is not appropriate.
  * Preserves optional account information during queued analysis submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->