### PR TITLE
fix(ux): restore actionable recovery paths on job errors

### DIFF
--- a/controllers/job_progress.py
+++ b/controllers/job_progress.py
@@ -91,7 +91,7 @@ def job_progress_controller(playlist_url: str):
         return Div(
             Alert(
                 P("No analysis job found for this playlist."),
-                A("Try analyzing again", href="/", cls=ButtonT.primary),
+                A("Try analyzing again", href="/analysis", cls=ButtonT.primary),
                 cls=AlertT.warning,
             ),
             cls="p-6 max-w-2xl mx-auto",

--- a/main.py
+++ b/main.py
@@ -1067,7 +1067,13 @@ def validate_full(
 
         except Exception as e:
             logger.exception("Deep analysis failed")
-            yield str(Alert(P("Failed to fetch playlist data."), cls=AlertT.error))
+            yield str(
+                Alert(
+                    P("Failed to fetch playlist data."),
+                    A("Try again", href="/analysis", cls=ButtonT.primary),
+                    cls=AlertT.error,
+                )
+            )
 
     return StreamingResponse(stream(), media_type="text/html")
 


### PR DESCRIPTION
- controllers/job_progress.py: fix "Try analyzing again" href from "/" (marketing homepage) to "/analysis" (the URL input form)

- main.py: validate_full exception handler now renders an Alert with a "Try again → /analysis" link instead of a dead-end error message

## Summary by Sourcery

Bug Fixes:
- Restore actionable recovery links for missing jobs and playlist data fetch failures by directing users back to the analysis form.