### PR TITLE
fix(auth): redirect to /analysis after login instead of /me/dashboards

### DIFF
--- a/auth/auth_service.py
+++ b/auth/auth_service.py
@@ -248,8 +248,8 @@ class ViralVibesAuth(OAuth):
         # 1. Check if user was trying to analyze a playlist
         intended_playlist_url = session.get("intended_playlist_url")
         if intended_playlist_url:
-            logger.info(f"User logged in to analyze playlist, redirecting to /me/dashboards")
-            return RedirectResponse("/me/dashboards", status_code=303)
+            logger.info(f"User logged in to analyze playlist, redirecting to /analysis")
+            return RedirectResponse("/analysis", status_code=303)
 
         # 2. Check if there's a stored intended destination
         intended_url = session.get("intended_url")

--- a/auth/auth_service.py
+++ b/auth/auth_service.py
@@ -247,7 +247,7 @@ class ViralVibesAuth(OAuth):
 
         # 1. Check if user was trying to analyze a playlist
         intended_playlist_url = session.get("intended_playlist_url")
-        if intended_playlist_url:
+        if intended_playlist_url and session.get("user_id"):
             logger.info(f"User logged in to analyze playlist, redirecting to /analysis")
             return RedirectResponse("/analysis", status_code=303)
 

--- a/main.py
+++ b/main.py
@@ -790,8 +790,7 @@ def validate_url(playlist: YoutubePlaylist, req, sess):
     if not (sess and sess.get("auth")):
         # Store the VALIDATED playlist URL they want to analyze
         sess["intended_playlist_url"] = playlist.playlist_url
-        # Store intended URL for post-login redirect
-        sess["intended_url"] = "/me/dashboards"
+        # After login, auth_service redirects to /analysis which picks this up
 
         # Redirect to clean login page (avoids navbar duplication)
         return RedirectResponse("/login", status_code=303)
@@ -1405,6 +1404,16 @@ def export_json(dashboard_id: str, req, sess):
 def analysis(req, sess):
     """Playlist analysis page — PUBLIC route"""
     user_id = sess.get("user_id") if sess else None
+
+    # Post-login: user submitted a playlist URL before authenticating.
+    # Submit the job now that we have a user_id and redirect straight to the result.
+    intended_playlist_url = sess.get("intended_playlist_url")
+    if intended_playlist_url and user_id:
+        sess.pop("intended_playlist_url", None)
+        logger.info(f"Submitting deferred job for {intended_playlist_url} after login")
+        submit_playlist_job(intended_playlist_url, user_id=user_id)
+        dashboard_id = compute_dashboard_id(intended_playlist_url)
+        return RedirectResponse(f"/d/{dashboard_id}", status_code=303)
     _analysis_title = "YouTube Playlist Analyzer — Instant Engagement & Viral Score | ViralVibes"
     _analysis_desc = (
         "Paste any YouTube playlist URL and instantly see engagement rate, viral score, "

--- a/main.py
+++ b/main.py
@@ -1409,11 +1409,16 @@ def analysis(req, sess):
     # Submit the job now that we have a user_id and redirect straight to the result.
     intended_playlist_url = sess.get("intended_playlist_url")
     if intended_playlist_url and user_id:
-        sess.pop("intended_playlist_url", None)
         logger.info(f"Submitting deferred job for {intended_playlist_url} after login")
-        submit_playlist_job(intended_playlist_url, user_id=user_id)
-        dashboard_id = compute_dashboard_id(intended_playlist_url)
-        return RedirectResponse(f"/d/{dashboard_id}", status_code=303)
+        if submit_playlist_job(intended_playlist_url, user_id=user_id):
+            sess.pop("intended_playlist_url", None)
+            dashboard_id = compute_dashboard_id(intended_playlist_url)
+            return RedirectResponse(f"/d/{dashboard_id}", status_code=303)
+        # Submission failed (DB unavailable or insert error) — keep the session
+        # value so the user can retry, and fall through to the analysis form.
+        logger.warning(
+            f"Deferred job submission failed for {intended_playlist_url}; showing analysis form"
+        )
     _analysis_title = "YouTube Playlist Analyzer — Instant Engagement & Viral Score | ViralVibes"
     _analysis_desc = (
         "Paste any YouTube playlist URL and instantly see engagement rate, viral score, "


### PR DESCRIPTION
When an unauthenticated user submitted a playlist URL, the post-login redirect went through /me/dashboards before landing on the result — a confusing flash of the wrong page.

Root causes:
- auth_service.py hardcoded /me/dashboards when intended_playlist_url was set, regardless of where the user actually came from
- validate_url set sess["intended_url"] = "/me/dashboards" which was dead code (auth_service checks intended_playlist_url first and returns early, never reaching the intended_url branch)

Fix:
- auth_service.py: redirect to /analysis when intended_playlist_url set
- main.py /analysis: handle intended_playlist_url on arrival — submit the deferred job and redirect straight to /d/{dashboard_id}
- main.py validate_url: remove the dead intended_url assignment

Before: login → /me/dashboards (flash) → /d/{dashboard_id}
After:  login → /analysis → /d/{dashboard_id}

## Summary by Sourcery

Ensure users who authenticate while submitting a playlist reach the analysis result directly without an intermediate dashboards-page redirect.

Bug Fixes:
- Redirect authenticated users who deferred playlist analysis to the analysis flow instead of briefly showing the dashboards page.
- Automatically submit the deferred playlist analysis after login and redirect users directly to its dashboard result.

Enhancements:
- Remove the unused post-login destination state for playlist validation while preserving retry behavior if deferred job submission fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * After signing in, users who submitted a playlist while unauthenticated are now redirected to the analysis flow.
  * Deferred playlist submissions are automatically resumed after login and routed to the resulting dashboard.
  * Removed the incorrect post-login redirect to the dashboards landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->