### PR TITLE
fix(bots): reduce /login invocations from non-human crawlers

### DIFF
--- a/components/navigation.py
+++ b/components/navigation.py
@@ -166,6 +166,7 @@ def NavComponent(oauth, req=None, sess=None):
             A(
                 "Sign in with Google",
                 href=login_href,
+                rel="nofollow",
                 cls="btn-cta-primary text-sm",
             ),
         )

--- a/main.py
+++ b/main.py
@@ -575,6 +575,32 @@ def index(req, sess):
     )
 
 
+_BOT_UA_KEYWORDS = (
+    "bot",
+    "crawl",
+    "spider",
+    "scrape",
+    "slurp",
+    "ia_archiver",
+    "python-requests",
+    "python-urllib",
+    "go-http-client",
+    "curl/",
+    "wget/",
+    "libwww",
+    "java/",
+    "ruby/",
+    "perl/",
+    "scrapy",
+)
+
+
+def _is_bot_request(req) -> bool:
+    """Return True for non-human User-Agents that have no business hitting /login."""
+    ua = req.headers.get("user-agent", "").lower()
+    return any(kw in ua for kw in _BOT_UA_KEYWORDS)
+
+
 @rt("/login")
 def login(req, sess):
     """
@@ -588,6 +614,12 @@ def login(req, sess):
     Default: Modern One-Tap Material Design UI
     Fallback: Simple button (set USE_NEW_LOGIN_UI=false)
     """
+    # Reject non-human UAs immediately — before any session work or rendering.
+    # Bots that reach this route despite robots.txt + rel=nofollow get a 410
+    # (Gone) so they de-prioritise future requests rather than retrying (403).
+    if _is_bot_request(req):
+        return Response(status_code=410)
+
     # Normalize session: if user manually visited /login (no intended_url),
     # clear any stale URLs so they get redirected to homepage after login
     normalize_intended_url(sess)

--- a/vercel.json
+++ b/vercel.json
@@ -90,6 +90,34 @@
         { "key": "Cache-Control", "value": "no-store" },
         { "key": "X-Robots-Tag", "value": "noindex" }
       ]
+    },
+    {
+      "source": "/login(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
+      ]
+    },
+    {
+      "source": "/logout",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
+      ]
+    },
+    {
+      "source": "/me/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
+      ]
+    },
+    {
+      "source": "/billing/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
+      ]
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -106,6 +106,13 @@
       ]
     },
     {
+      "source": "/me",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" },
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow" }
+      ]
+    },
+    {
       "source": "/me/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "no-store" },


### PR DESCRIPTION
Three layered defences — each catches bots that slip through the previous:

1. components/navigation.py: add rel="nofollow" to the navbar "Sign in" link. Every public page was advertising /login to every crawler. Combined with the existing robots.txt Disallow: /login this covers Googlebot, Bingbot and all major SEO crawlers.

2. vercel.json: add X-Robots-Tag: noindex, nofollow to /login(.*), /logout, /me/(.*) and /billing/(.*). Matches the pattern already used for /admin(.*) and /job-progress but missing for auth routes.

3. main.py: _is_bot_request() early-exits with 410 Gone before any session work or HTML rendering for UAs matching known non-human clients (curl, python-requests, scrapy, *bot, *crawl, etc.). 410 chosen over 403 so bots treat the endpoint as permanently gone and stop retrying.

Does not protect against bots spoofing browser UAs — a Vercel WAF rule is the right tool for credential stuffers.

## Summary by Sourcery

Reduce crawler access to private routes by adding search-engine directives and returning Gone for known non-human requests to /login.

Bug Fixes:
- Reduce unnecessary crawler traffic to authentication and other private routes by discouraging indexing and rejecting recognized non-human user agents before login processing.

Enhancements:
- Mark the public sign-in link as nofollow and add noindex/nofollow response headers for authentication, account, billing, and logout routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Improved handling of automated requests to the sign-in page.
  * Added safeguards to prevent private account and billing pages from being indexed or cached.
  * Updated the logged-out Google sign-in link to discourage search engine following.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->